### PR TITLE
[fix] Storybook 빌드 에러 해결

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lint:staged": "lint-staged",
     "prepare": "husky",
     "storybook": "storybook dev -p 6006",
-    "build-storybook": "storybook build —stats-json",
+    "build-storybook": "storybook build --stats-json",
     "chromatic": "chromatic --exit-zero-on-changes",
     "chromatic:ci": "chromatic --only-changed --exit-zero-on-changes"
   },

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lint:staged": "lint-staged",
     "prepare": "husky",
     "storybook": "storybook dev -p 6006",
-    "build-storybook": "storybook build",
+    "build-storybook": "storybook build —stats-json",
     "chromatic": "chromatic --exit-zero-on-changes",
     "chromatic:ci": "chromatic --only-changed --exit-zero-on-changes"
   },


### PR DESCRIPTION
## 📌 Summary

- close #61 

## 📄 Tasks
> 에러 발생 및 해결 과정
1. Chromatic 빌드 과정에서 `preview-stats.json` 파일 누락으로 인한 오류가 발생했습니다. 
- Chromatic TurboSnap 활성화 관련 [공식문서](https://www.chromatic.com/docs/turbosnap/setup/)

2. 공식문서의 안내에 따라 `package.json`을 수정했습니다.
```json
"build-storybook": "build-storybook --stats-json",
```
3. 그 후 스크립트를 실행했을 때 `sh: build-storybook: command not found` 에러가 발생했습니다.
- Storybook 공식 문서의 "build-storybook"은 storybook build를 호출하는 별칭(alias)인데, `npm/yarn` 환경에선 이 별칭이 $PATH에 자동 추가되어 실행 가능한 구조입니다. 
하지만 `pnpm`의 고유한 `node_modules` 관리 방식 (심볼릭 링크 기반 중첩 구조) 때문에, 이 alias가 쉘에 의해 직접 인식되지 않아 해당 오류가 발생했습니다.

5. 최종 해결
```json 
"build-storybook": "storybook build --stats-json",
```
- `pnpm run`은 `node_modules/.bin` 경로를 $PATH에 임시 추가합니다. 따라서 storybook build는 `node_modules/.bin/storybook`이라는 실제 실행 파일을 명확히 호출하는 방식입니다. 
따라서 pnpm 환경에서도 안정적으로 작동하며, Chromatic에 필요한 `--stats-json` 플래그를 통해 `preview-stats.json` 파일도 정상적으로 생성됩니다.


## 🔍 To Reviewer

-가 2개임에 주의하세요 제발.

## 📸 Screenshot

-

_작업한 내용에 대한 스크린샷을 첨부해주세요._
