### PR TITLE
[chore] z-index 디자인 토큰 추가 및 적용

### DIFF
--- a/src/shared/components/overlay/modal/Modal.css.ts
+++ b/src/shared/components/overlay/modal/Modal.css.ts
@@ -3,10 +3,18 @@ import { fontStyle } from '@/shared/styles/fontStyle';
 import { colorVars } from '@/shared/styles/tokens/color.css';
 import { zIndex } from '@/shared/styles/tokens/zIndex';
 
-export const container = style({
+export const backdrop = style({
   position: 'fixed',
   inset: 0,
-  margin: 'auto',
+  background: 'rgba(0, 0, 0, 0.08)',
+  zIndex: zIndex.backdrop,
+});
+
+export const container = style({
+  position: 'fixed',
+  top: '50%',
+  left: '50%',
+  transform: 'translate(-50%, -50%)',
   zIndex: zIndex.modal,
   display: 'flex',
   flexDirection: 'column',
@@ -17,6 +25,7 @@ export const container = style({
   alignItems: 'center',
   gap: '3.2rem',
   borderRadius: '2rem',
+  border: 0,
 });
 
 export const info = style({

--- a/src/shared/components/overlay/popup/Popup.css.ts
+++ b/src/shared/components/overlay/popup/Popup.css.ts
@@ -1,0 +1,67 @@
+import { style } from '@vanilla-extract/css';
+import { fontStyle } from '@/shared/styles/fontStyle';
+import { colorVars } from '@/shared/styles/tokens/color.css';
+import { zIndex } from '@/shared/styles/tokens/zIndex';
+
+export const backdrop = style({
+  position: 'fixed',
+  inset: 0,
+  background: 'rgba(0, 0, 0, 0.08)',
+  zIndex: zIndex.backdrop,
+});
+
+export const container = style({
+  position: 'fixed',
+  top: '50%',
+  left: '50%',
+  transform: 'translate(-50%, -50%)',
+  zIndex: zIndex.popup,
+  display: 'flex',
+  flexDirection: 'column',
+  width: '30rem',
+  borderRadius: '20px',
+  background: colorVars.color.gray000,
+  border: 0,
+});
+
+export const info = style({
+  display: 'flex',
+  flexDirection: 'column',
+  padding: '3.2rem 1.4rem',
+  justifyContent: 'center',
+  alignItems: 'center',
+  gap: '1.2rem',
+  whiteSpace: 'pre-line',
+  textAlign: 'center',
+});
+
+export const title = style({
+  ...fontStyle('heading_sb_18'),
+  color: colorVars.color.gray900,
+});
+
+export const detail = style({
+  ...fontStyle('body_r_14'),
+  color: colorVars.color.gray700,
+});
+
+export const buttonBox = style({
+  display: 'flex',
+  borderTop: `1px solid ${colorVars.color.gray200}`,
+  textAlign: 'center',
+});
+
+export const exit = style({
+  flex: 1,
+  padding: '10px 0',
+  ...fontStyle('body_r_14'),
+  color: colorVars.color.gray700,
+  borderRight: `1px solid ${colorVars.color.gray200}`,
+});
+
+export const cancel = style({
+  flex: 1,
+  padding: '10px 0',
+  ...fontStyle('title_sb_16'),
+  color: colorVars.color.primary,
+});

--- a/src/shared/styles/tokens/zIndex.ts
+++ b/src/shared/styles/tokens/zIndex.ts
@@ -1,5 +1,5 @@
 export const zIndex = {
-  default: 1,
+  base: 1,
   navigation: 200,
   backdrop: 250,
   modal: 300,

--- a/src/shared/styles/tokens/zIndex.ts
+++ b/src/shared/styles/tokens/zIndex.ts
@@ -1,0 +1,8 @@
+export const zIndex = {
+  default: '1',
+  navigation: '200',
+  backdrop: '250',
+  toast: '300',
+  modal: '300',
+  popup: '300',
+} as const;

--- a/src/shared/styles/tokens/zIndex.ts
+++ b/src/shared/styles/tokens/zIndex.ts
@@ -1,8 +1,8 @@
 export const zIndex = {
-  default: '1',
-  navigation: '200',
-  backdrop: '250',
-  toast: '300',
-  modal: '300',
-  popup: '300',
+  default: 1,
+  navigation: 200,
+  backdrop: 250,
+  modal: 300,
+  popup: 350,
+  toast: 400,
 } as const;


### PR DESCRIPTION
## 📌 Summary

- close #76 

> 관련 있는 Issue를 태그해주세요. (e.g. > - #1)

- z-index 값을 디자인 토큰으로 관리하여 컴포넌트 간 레이어 순서를 체계적으로 관리할 수 있도록 개선했습니다.

_해당 PR에 대한 작업 내용을 요약하여 작성해주세요._

## 📄 Tasks

- 디자인 토큰에 zIndex 관리 토큰을 추가
- z-index값 50 단위 증가
- 컴포넌트 역할에 따른 네이밍

_해당 PR에 수행한 작업을 작성해주세요._

## 🔍 To Reviewer

- z-index 디자인 토큰 관리에 대한 표준은 존재하지 않는 듯합니다.
- Tailwind CSS, Storybook, Panda CSS 등 주요 디자인 시스템에서 공통적으로 컴포넌트별로 적절한 z-index 값을 key-value 형태로 제공하는 패턴을 사용하고 있습니다. 각 시스템마다 z-index 증가 단위는 다양하게 적용되고 있으며(1, 5, 10, 50, 100, 1000 등), 하우미 z-index 디자인 토큰에는 50 단위로 index값을 올렸습니다.
```typescript
export const zIndex = {
  default: 1,
  navigation: 200,
  backdrop: 250,
  modal: 300,
  popup: 350,
  toast: 400,
} as const;
```

_리뷰어에게 요청하는 내용을 작성해주세요._

## 📸 Screenshot

- 

_작업한 내용에 대한 스크린샷을 첨부해주세요._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 팝업 및 모달 오버레이에 대한 새로운 스타일이 추가되었습니다.
  * 다양한 UI 요소(타이틀, 버튼, 정보 영역 등)에 맞춘 세부 스타일이 적용되었습니다.
  * z-index 디자인 토큰이 도입되어 UI 레이어링이 일관성 있게 관리됩니다.

* **Style**
  * 모달 및 팝업 컴포넌트의 스타일이 개선되어 디자인이 더욱 통일되고 세련되어졌습니다.
  * z-index 값이 하드코딩에서 토큰 참조 방식으로 변경되어 유지보수가 용이해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->