### PR TITLE
[feat] title step 컴포넌트 구현

### DIFF
--- a/src/shared/components/titleStep/TitleStep.css.ts
+++ b/src/shared/components/titleStep/TitleStep.css.ts
@@ -1,0 +1,34 @@
+import { style } from '@vanilla-extract/css';
+import { colorVars } from '@/shared/styles/tokens/color.css';
+import { fontStyle } from '@/shared/styles/fontStyle';
+
+export const wrapper = style({
+  display: 'flex',
+  flexDirection: 'column',
+  width: '33.5rem',
+  gap: '1.2rem',
+  alignItems: 'flex-start',
+});
+
+export const stepLabelBox = style({
+  display: 'flex',
+  width: '5.6rem',
+  height: '2.8rem',
+  padding: '1rem 1.6rem',
+  justifyContent: 'center',
+  alignItems: 'center',
+  borderRadius: '0.4rem',
+  backgroundColor: colorVars.color.primary_light2,
+});
+
+export const stepLabel = style({
+  ...fontStyle('caption_m_12'),
+  color: colorVars.color.primary,
+  whiteSpace: 'nowrap',
+});
+
+export const title = style({
+  ...fontStyle('heading_sb_18'),
+  color: colorVars.color.gray900,
+  alignSelf: 'stretch',
+});

--- a/src/shared/components/titleStep/TitleStep.tsx
+++ b/src/shared/components/titleStep/TitleStep.tsx
@@ -1,0 +1,19 @@
+import * as styles from './TitleStep.css.ts';
+
+interface TitleStepProps {
+  stepLabel: string;
+  title: string;
+}
+
+const TitleStep = ({ stepLabel, title }: TitleStepProps) => {
+  return (
+    <div className={styles.wrapper}>
+      <div className={styles.stepLabelBox}>
+        <span className={styles.stepLabel}>{stepLabel}</span>
+      </div>
+      <h2 className={styles.title}>{title}</h2>
+    </div>
+  );
+};
+
+export default TitleStep;

--- a/src/stories/TitleStep.stories.tsx
+++ b/src/stories/TitleStep.stories.tsx
@@ -1,0 +1,35 @@
+import TitleStep from '@shared/components/titleStep/TitleStep';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta = {
+  title: 'Components/TitleStep',
+  component: TitleStep,
+  parameters: {
+    docs: {
+      description: {
+        component: '제목과 단계 정보를 함께 표시하는 TitleStep 컴포넌트입니다.',
+      },
+    },
+  },
+  argTypes: {
+    stepLabel: {
+      description: '단계 텍스트 (예: "STEP 1")',
+      control: { type: 'text' },
+    },
+    title: {
+      description: '제목 텍스트 (예: "내용 입력")',
+      control: { type: 'text' },
+    },
+  },
+} satisfies Meta<typeof TitleStep>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    stepLabel: 'STEP 1',
+    title: '제목',
+  },
+};


### PR DESCRIPTION
## 📌 Summary

- close #43 

- 랜딩페이지에 위치한 title step 공통 컴포넌트를 구현합니다.

## 📄 Tasks

![image](https://github.com/user-attachments/assets/d0e52d70-615f-4dff-83c9-28cbef90e16f)
스토리북 실행 결과 화면 첨부합니다.

## 🔍 To Reviewer

- 컴포넌트 사용법
```tsx
<TitleStep stepLabel="STEP 1" title="제목" />
```

## 📸 Screenshot

![image](https://github.com/user-attachments/assets/089348c7-0bcc-4c70-917d-8aba37c9de3a)

