### PR TITLE
[chore] 모바일 우선 반응형 레이아웃 최소/최대 너비 제한 추가

### DIFF
--- a/src/shared/styles/global.css.ts
+++ b/src/shared/styles/global.css.ts
@@ -1,15 +1,56 @@
-import { globalStyle } from '@vanilla-extract/css';
+import { globalStyle, createGlobalTheme } from '@vanilla-extract/css';
 import { colorVars } from '@styles/tokens/color.css';
 import { fontVars } from '@styles/tokens/font.css';
 import '@styles/reset.css.ts';
 import '@styles/fontFace.css';
 
-globalStyle('html, body', {
+// 레이아웃 관련 CSS 변수
+export const layoutVars = createGlobalTheme(':root', {
+  minWidth: '375px',
+  maxWidth: '430px',
+  height: '100dvh',
+});
+
+// Root 요소 스타일
+globalStyle('#root', {
+  height: '100%',
+  display: 'flex',
+  flexDirection: 'column',
+});
+
+// HTML 요소 스타일
+globalStyle('html', {
+  fontSize: '62.5%', // 이미 reset.css.ts에 있지만 중요하므로 명시
+  scrollbarWidth: 'none', // Firefox
+  height: '100%',
+});
+
+// Webkit 기반 브라우저의 스크롤바 숨김
+globalStyle('html::-webkit-scrollbar', {
+  display: 'none',
+});
+
+// Body 요소 스타일
+globalStyle('body', {
   fontFamily: fontVars.family.pretendard,
   backgroundColor: colorVars.color.gray050,
   color: colorVars.color.gray999,
   WebkitFontSmoothing: 'antialiased',
   MozOsxFontSmoothing: 'grayscale',
   overflowWrap: 'break-word',
-  minHeight: '100%',
+  height: '100%',
+  minWidth: layoutVars.minWidth,
+  maxWidth: layoutVars.maxWidth,
+  marginLeft: 'auto',
+  marginRight: 'auto',
+  display: 'flex',
+  flexDirection: 'column',
+  scrollBehavior: 'smooth',
+  boxShadow: '0px 0px 30px 0px rgba(0, 0, 0, 0.25)',
+  scrollbarWidth: 'none', // Firefox
+});
+
+// Body의 스크롤바 숨김
+globalStyle('body::-webkit-scrollbar', {
+  display: 'none',
 });

--- a/src/shared/styles/global.css.ts
+++ b/src/shared/styles/global.css.ts
@@ -4,52 +4,109 @@ import { fontVars } from '@styles/tokens/font.css';
 import '@styles/reset.css.ts';
 import '@styles/fontFace.css';
 
-// 레이아웃 관련 CSS 변수
+/**
+ * 프로젝트 글로벌 스타일 설정
+ * reset.css.ts의 기본 초기화 위에 프로젝트 특화 스타일을 정의합니다.
+ *
+ * 주요 기능:
+ * - 반응형 레이아웃 설정 (모바일 중심)
+ * - 스크롤바 커스터마이징
+ * - 앱 컨테이너 스타일링
+ */
+
+/* ===== 레이아웃 CSS 변수 정의 ===== */
+/**
+ * 반응형 레이아웃을 위한 전역 CSS 변수
+ * 모바일 앱과 같은 고정 너비 레이아웃 구현
+ *
+ * @property minWidth - 최소 너비 (iPhone SE 기준)
+ * @property maxWidth - 최대 너비 (대형 모바일 기준)
+ * @property height - 뷰포트 높이 (동적 뷰포트 단위 사용)
+ */
 export const layoutVars = createGlobalTheme(':root', {
   minWidth: '375px',
   maxWidth: '430px',
   height: '100dvh',
 });
 
-// Root 요소 스타일
+/* ===== 앱 루트 컨테이너 ===== */
+/**
+ * React 앱의 최상위 컨테이너 설정
+ * 전체 높이를 차지하며 수직 플렉스 레이아웃 적용
+ * 하위 컴포넌트들이 플렉스 아이템으로 배치됨
+ */
 globalStyle('#root', {
   height: '100%',
   display: 'flex',
   flexDirection: 'column',
 });
 
-// HTML 요소 스타일
+/* ===== HTML 루트 설정 ===== */
+/**
+ * HTML 요소의 추가 설정
+ * - 전체 높이 사용으로 body까지 높이 상속
+ * - 스크롤바 숨김으로 모바일 앱 같은 UI 구현
+ */
 globalStyle('html', {
-  scrollbarWidth: 'none', // Firefox
   height: '100%',
+  scrollbarWidth: 'none', // Firefox 스크롤바 숨김
 });
 
-// Webkit 기반 브라우저의 스크롤바 숨김
+/**
+ * Webkit 기반 브라우저 스크롤바 숨김
+ * Chrome, Safari, Edge 등에서 적용
+ */
 globalStyle('html::-webkit-scrollbar', {
   display: 'none',
 });
 
-// Body 요소 스타일
+/* ===== Body 프로젝트 스타일 ===== */
+/**
+ * 앱의 메인 컨테이너 역할을 하는 body 스타일
+ *
+ * 타이포그래피:
+ * - Pretendard 폰트 적용
+ * - 폰트 스무딩으로 선명한 텍스트 렌더링
+ * - 긴 단어 자동 줄바꿈
+ *
+ * 레이아웃:
+ * - 모바일 중심 고정 너비 (375px ~ 430px)
+ * - 가운데 정렬로 데스크톱에서도 모바일 뷰 유지
+ * - 플렉스 컨테이너로 하위 요소 배치 관리
+ *
+ * 시각적 효과:
+ * - 배경색과 텍스트 색상 설정
+ * - 그림자 효과로 앱 영역 구분 (데스크톱에서 효과적)
+ * - 부드러운 스크롤 애니메이션
+ */
 globalStyle('body', {
+  // 타이포그래피
   fontFamily: fontVars.family.pretendard,
-  backgroundColor: colorVars.color.gray050,
   color: colorVars.color.gray999,
-  WebkitFontSmoothing: 'antialiased',
-  MozOsxFontSmoothing: 'grayscale',
-  overflowWrap: 'break-word',
+  WebkitFontSmoothing: 'antialiased', // macOS/iOS 폰트 렌더링 최적화
+  MozOsxFontSmoothing: 'grayscale', // Firefox 폰트 렌더링 최적화
+  overflowWrap: 'break-word', // 긴 단어 자동 줄바꿈
+
+  // 레이아웃
   height: '100%',
-  minWidth: layoutVars.minWidth,
-  maxWidth: layoutVars.maxWidth,
-  marginLeft: 'auto',
+  minWidth: layoutVars.minWidth, // 최소 너비 제한
+  maxWidth: layoutVars.maxWidth, // 최대 너비 제한
+  marginLeft: 'auto', // 가로 중앙 정렬
   marginRight: 'auto',
   display: 'flex',
   flexDirection: 'column',
-  scrollBehavior: 'smooth',
-  boxShadow: '0px 0px 30px 0px rgba(0, 0, 0, 0.25)',
-  scrollbarWidth: 'none', // Firefox
+
+  // 시각적 효과
+  backgroundColor: colorVars.color.gray050,
+  boxShadow: '0px 0px 30px 0px rgba(0, 0, 0, 0.25)', // 앱 영역 그림자
+  scrollBehavior: 'smooth', // 부드러운 스크롤
+  scrollbarWidth: 'none', // Firefox 스크롤바 숨김
 });
 
-// Body의 스크롤바 숨김
+/**
+ * Body의 Webkit 스크롤바 숨김
+ * 모바일 앱 같은 깔끔한 UI 구현
+ */
 globalStyle('body::-webkit-scrollbar', {
   display: 'none',
 });

--- a/src/shared/styles/global.css.ts
+++ b/src/shared/styles/global.css.ts
@@ -20,7 +20,6 @@ globalStyle('#root', {
 
 // HTML 요소 스타일
 globalStyle('html', {
-  fontSize: '62.5%', // 이미 reset.css.ts에 있지만 중요하므로 명시
   scrollbarWidth: 'none', // Firefox
   height: '100%',
 });

--- a/src/shared/styles/reset.css.ts
+++ b/src/shared/styles/reset.css.ts
@@ -4,8 +4,14 @@ import { globalStyle } from '@vanilla-extract/css';
  * CSS Reset - vanilla-extract 버전
  * 브라우저 기본 스타일을 초기화하여 일관된 스타일링 기반을 제공합니다.
  *
- * 참고: Modern CSS Reset 기반으로 구성
- * https://piccalil.li/blog/a-modern-css-reset/
+ * Modern CSS Reset을 프로젝트 요구사항에 맞게 확장했습니다.
+ * 참고: https://piccalil.li/blog/a-modern-css-reset/
+ *
+ * 주요 변경점:
+ * - 추가적인 리셋 (모든 요소의 padding 제거)
+ * - rem 계산 편의를 위한 62.5% 폰트 크기
+ * - 모바일 최적화 속성 추가 (tap highlight, touch-action 등)
+ * - 폼 요소에 대한 더 완전한 리셋 (all: unset 사용)
  */
 
 /* ===== Box Model Reset ===== */

--- a/src/shared/styles/reset.css.ts
+++ b/src/shared/styles/reset.css.ts
@@ -1,43 +1,163 @@
 import { globalStyle } from '@vanilla-extract/css';
 
-globalStyle('*', {
+/**
+ * CSS Reset - vanilla-extract 버전
+ * 브라우저 기본 스타일을 초기화하여 일관된 스타일링 기반을 제공합니다.
+ *
+ * 참고: Modern CSS Reset 기반으로 구성
+ * https://piccalil.li/blog/a-modern-css-reset/
+ */
+
+/* ===== Box Model Reset ===== */
+/**
+ * 1. 모든 요소에 border-box 적용 (패딩과 보더가 너비에 포함)
+ * 2. 기본 마진과 패딩 제거
+ */
+globalStyle('*, *::before, *::after', {
   margin: 0,
   padding: 0,
   boxSizing: 'border-box',
 });
 
+/* ===== 루트 요소 설정 ===== */
+/**
+ * rem 단위 계산을 쉽게 하기 위해 10px 기준으로 설정
+ * 1rem = 10px (62.5% of 16px)
+ */
 globalStyle('html', {
   fontSize: '62.5%',
+  // 텍스트 크기 조정 방지 (모바일)
+  WebkitTextSizeAdjust: '100%',
 });
 
-// 텍스트 요소 초기화
-globalStyle('h1, h2, h3, h4, h5, h6, p', {
+/* ===== Body 기본값 ===== */
+/**
+ * line-height 기본값 설정으로 가독성 향상
+ */
+globalStyle('body', {
+  lineHeight: 1.5,
+  // 텍스트 렌더링 최적화
+  textRendering: 'optimizeSpeed',
+});
+
+/* ===== 제목 요소 초기화 ===== */
+/**
+ * 제목 태그들의 기본 스타일 제거
+ * 프로젝트에서 정의한 스타일만 적용되도록 함
+ */
+globalStyle('h1, h2, h3, h4, h5, h6', {
   margin: 0,
   fontWeight: 'inherit',
   fontSize: 'inherit',
+  lineHeight: 'inherit',
 });
 
-// 리스트 초기화
+/* ===== 텍스트 요소 초기화 ===== */
+/**
+ * 문단 태그의 기본 마진 제거
+ */
+globalStyle('p', {
+  margin: 0,
+});
+
+/* ===== 리스트 초기화 ===== */
+/**
+ * 리스트의 기본 스타일 제거
+ * 마커/번호 제거 및 들여쓰기 제거
+ */
 globalStyle('ul, ol', {
   margin: 0,
   padding: 0,
   listStyle: 'none',
 });
 
-// a 태그 초기화
+/* ===== 링크 초기화 ===== */
+/**
+ * 링크의 기본 색상과 밑줄 제거
+ * 부모 요소의 색상 상속
+ */
 globalStyle('a', {
   color: 'inherit',
   textDecoration: 'none',
 });
 
-// form 요소 초기화
+/* ===== 미디어 요소 ===== */
+/**
+ * 이미지와 비디오가 컨테이너를 넘지 않도록 제한
+ * 이미지 하단 여백 제거 (inline-block 특성)
+ */
+globalStyle('img, picture, video, canvas, svg', {
+  display: 'block',
+  maxWidth: '100%',
+  height: 'auto',
+});
+
+/* ===== 폼 요소 초기화 ===== */
+/**
+ * 버튼의 모든 기본 스타일 제거
+ * 커서는 포인터로 유지하여 클릭 가능함을 표시
+ */
 globalStyle('button', {
   all: 'unset',
   cursor: 'pointer',
   boxSizing: 'border-box',
+  // 텍스트 선택 방지
+  userSelect: 'none',
+  // 모바일 탭 하이라이트 제거
+  WebkitTapHighlightColor: 'transparent',
 });
 
-globalStyle('input, textarea', {
+/**
+ * 입력 요소들의 기본 스타일 제거
+ * 폰트는 부모 요소에서 상속
+ */
+globalStyle('input, textarea, select', {
   all: 'unset',
   fontFamily: 'inherit',
+  fontSize: 'inherit',
+  color: 'inherit',
+  // 모바일에서 확대 방지
+  touchAction: 'manipulation',
+});
+
+/**
+ * textarea 리사이즈 세로만 허용
+ */
+globalStyle('textarea', {
+  resize: 'vertical',
+});
+
+/* ===== 테이블 초기화 ===== */
+/**
+ * 테이블 셀 간격 제거
+ */
+globalStyle('table', {
+  borderCollapse: 'collapse',
+  borderSpacing: 0,
+});
+
+/* ===== 기타 요소 ===== */
+/**
+ * hr 요소 스타일 초기화
+ */
+globalStyle('hr', {
+  border: 0,
+  borderTop: '1px solid',
+  margin: 0,
+});
+
+/**
+ * 숨김 속성이 있는 요소는 확실히 숨김
+ */
+globalStyle('[hidden]', {
+  display: 'none !important',
+});
+
+/**
+ * 포커스 아웃라인 접근성을 위해 유지
+ * (필요시 프로젝트에서 커스터마이징)
+ */
+globalStyle(':focus-visible', {
+  outline: '2px solid',
+  outlineOffset: '2px',
 });


### PR DESCRIPTION
## 📌 Summary

- close #85 

글로벌 스타일 시스템을 vanilla-extract best practice에 맞춰 개선하고, 모바일 중심의 반응형 레이아웃을 구현했습니다.

## 📄 Tasks

- 반응형 레이아웃 고정
  - CSS 변수를 활용한 최소/최대 너비 설정 (375px ~ 430px)
  - 모바일 앱 스타일의 고정 너비 레이아웃 적용
  - 데스크톱에서도 일관된 모바일 뷰 유지되도록
- CSS Reset 수정
  - Modern CSS Reset 기반 확장
  - 추가적인 브라우저 기본 스타일 초기화
  - 모바일 최적화 속성 추가 (tap highlight, touch-action 등)
- 스타일 파일 역할 명확화
  - reset.css.ts: 브라우저 기본 스타일 초기화
  - global.css.ts: 프로젝트 특화 스타일 (레이아웃, 테마 등)
  - 중복 속성 제거 (fontSize 등)

- 모든 스타일 규칙에 상세한 한국어 주석 추가
- vanilla-extract best practice 적용

## 🔍 To Reviewer

- 반응형 너비 설정값(375px ~ 430px)이 요구사항에 맞는지 확인 부탁드립니다.
- 스크롤바를 완전히 숨긴 것이 UX 측면에서 적절한지 검토 부탁드립니다.
- Modern CSS Reset의 추가 기능들(text-wrap: balance, :target scroll-margin 등) 중 필요한 것이 있다면 의견 부탁드립니다.

## 📸 Screenshot

-
