### PR TITLE
Feat/bottom sheet/#80

### DIFF
--- a/src/pages/home/HomePage.tsx
+++ b/src/pages/home/HomePage.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
-import FlipSheet from '@/shared/components/bottomSheet/flipSheet/FlipSheet';
 import CtaButton from '@/shared/components/button/ctaButton/CtaButton';
+import NoMatchSheet from '@/shared/components/bottomSheet/noMatchSheet/NoMatchSheet';
 
 const HomePage = () => {
   const [isSheetOpen, setIsSheetOpen] = useState(false);
@@ -20,11 +20,12 @@ const HomePage = () => {
   return (
     <div>
       <CtaButton onClick={handleOpen}>시트 열기</CtaButton>
-      <FlipSheet
+      <NoMatchSheet
         onFlipClick={handleFlip}
         onChooseClick={handleChoose}
         isOpen={isSheetOpen}
         onClose={handleClose}
+        user="박소이"
       />
     </div>
   );

--- a/src/pages/home/HomePage.tsx
+++ b/src/pages/home/HomePage.tsx
@@ -25,7 +25,7 @@ const HomePage = () => {
         onChooseClick={handleChoose}
         isOpen={isSheetOpen}
         onClose={handleClose}
-        user="박소이"
+        user="김하우미"
       />
     </div>
   );

--- a/src/pages/home/HomePage.tsx
+++ b/src/pages/home/HomePage.tsx
@@ -1,19 +1,31 @@
-import TextField from '@/shared/components/textField/TextField';
+import { useState } from 'react';
+import FlipSheet from '@/shared/components/bottomSheet/flipSheet/FlipSheet';
+import CtaButton from '@/shared/components/button/ctaButton/CtaButton';
 
 const HomePage = () => {
+  const [isSheetOpen, setIsSheetOpen] = useState(false);
+
+  const handleOpen = () => setIsSheetOpen(true);
+  const handleClose = () => setIsSheetOpen(false);
+
+  const handleFlip = () => {
+    console.log('Flip clicked!');
+  };
+
+  const handleChoose = () => {
+    console.log('Choose clicked!');
+    setIsSheetOpen(false);
+  };
+
   return (
-    <div
-      style={{
-        padding: '2rem',
-        display: 'flex',
-        flexDirection: 'column',
-        gap: '2rem',
-        backgroundColor: '#BDBDBD',
-      }}
-    >
-      <TextField fieldSize="small" placeholder="YYYY" maxLength={4} />
-      <TextField fieldSize="large" placeholder="이름을 입력해주세요." />
-      <TextField fieldSize="thin" placeholder="ex) 솝트특별자치시 앱잼구" />
+    <div>
+      <CtaButton onClick={handleOpen}>시트 열기</CtaButton>
+      <FlipSheet
+        onFlipClick={handleFlip}
+        onChooseClick={handleChoose}
+        isOpen={isSheetOpen}
+        onClose={handleClose}
+      />
     </div>
   );
 };

--- a/src/pages/home/HomePage.tsx
+++ b/src/pages/home/HomePage.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
+import FlipSheet from '@/shared/components/bottomSheet/flipSheet/FlipSheet';
 import CtaButton from '@/shared/components/button/ctaButton/CtaButton';
-import NoMatchSheet from '@/shared/components/bottomSheet/noMatchSheet/NoMatchSheet';
 
 const HomePage = () => {
   const [isSheetOpen, setIsSheetOpen] = useState(false);
@@ -20,12 +20,11 @@ const HomePage = () => {
   return (
     <div>
       <CtaButton onClick={handleOpen}>시트 열기</CtaButton>
-      <NoMatchSheet
+      <FlipSheet
         onFlipClick={handleFlip}
         onChooseClick={handleChoose}
         isOpen={isSheetOpen}
         onClose={handleClose}
-        user="김하우미"
       />
     </div>
   );

--- a/src/shared/assets/icons/defaultCard.svg
+++ b/src/shared/assets/icons/defaultCard.svg
@@ -1,0 +1,3 @@
+<svg width="221" height="330" viewBox="0 0 221 330" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="0.5" width="220" height="330" rx="16" fill="#F3F4F7"/>
+</svg>

--- a/src/shared/components/bottomSheet/flipSheet/FlipSheet.css.ts
+++ b/src/shared/components/bottomSheet/flipSheet/FlipSheet.css.ts
@@ -1,0 +1,70 @@
+import { style } from '@vanilla-extract/css';
+import { colorVars } from '@styles/tokens/color.css';
+import { fontStyle } from '@/shared/styles/fontStyle';
+
+export const backdrop = style({
+  position: 'fixed',
+  top: 0,
+  left: 0,
+  right: 0,
+  bottom: 0,
+  backgroundColor: 'rgba(0, 0, 0, 0.5)',
+  zIndex: 0,
+  opacity: 0,
+  visibility: 'hidden',
+});
+
+export const backdropVisible = style({
+  opacity: 1,
+  visibility: 'visible',
+});
+
+export const sheetWrapper = style({
+  position: 'fixed',
+  bottom: 0,
+  left: '50%',
+  transform: 'translate(-50%, 100%)',
+  width: '100%',
+  maxWidth: '37.5rem',
+  padding: '0rem 2.4rem 2rem 2.4rem',
+  backgroundColor: colorVars.color.gray000,
+  borderRadius: '30px 30px 0 0',
+  willChange: 'transform',
+  transition: 'transform 0.6s ease-in-out ',
+  zIndex: 1,
+  overflow: 'hidden',
+});
+
+export const sheetWrapperExpanded = style({
+  transform: 'translate(-50%, 0)',
+});
+
+export const sheetWrapperCollapsed = style({
+  transform: 'translate(-50%, 100%)',
+});
+
+export const imageArea = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '2rem',
+  alignItems: 'center',
+  justifyContent: 'center',
+});
+
+export const dragHandleContainer = style({
+  display: 'flex',
+  height: '2.8rem',
+  alignItems: 'center',
+  justifyContent: 'center',
+});
+
+export const infoText = style({
+  ...fontStyle('heading_sb_18'),
+  color: colorVars.color.gray900,
+});
+
+export const buttonGroup = style({
+  display: 'flex',
+  gap: '1.2rem',
+  marginTop: '3.2rem',
+});

--- a/src/shared/components/bottomSheet/flipSheet/FlipSheet.tsx
+++ b/src/shared/components/bottomSheet/flipSheet/FlipSheet.tsx
@@ -1,0 +1,51 @@
+import clsx from 'clsx';
+import DefaultCardIcon from '@assets/icons/defaultCard.svg?react';
+import DragHandle from '@components/dragHandle/DragHandle';
+import FilpButton from '@components/button/filpButton/FlipButton';
+import CtaButton from '@components/button/ctaButton/CtaButton';
+import * as styles from './FlipSheet.css';
+
+interface FlipSheetProps {
+  onFlipClick: () => void;
+  onChooseClick: () => void;
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+const FlipSheet = ({
+  onFlipClick,
+  onChooseClick,
+  isOpen,
+  onClose,
+}: FlipSheetProps) => {
+  return (
+    <>
+      <div
+        className={clsx(styles.backdrop, isOpen && styles.backdropVisible)}
+        onClick={onClose}
+      />
+      <div
+        className={clsx(
+          styles.sheetWrapper,
+          isOpen ? styles.sheetWrapperExpanded : styles.sheetWrapperCollapsed
+        )}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className={styles.imageArea}>
+          <div className={styles.dragHandleContainer}>
+            <DragHandle />
+          </div>
+          <p className={styles.infoText}>이미지를 좌우반전 할 수 있어요</p>
+          <DefaultCardIcon />
+        </div>
+
+        <div className={styles.buttonGroup}>
+          <FilpButton onClick={onFlipClick} />
+          <CtaButton onClick={onChooseClick}>선택하기</CtaButton>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default FlipSheet;

--- a/src/shared/components/bottomSheet/noMatchSheet/NoMatchSheet.css.ts
+++ b/src/shared/components/bottomSheet/noMatchSheet/NoMatchSheet.css.ts
@@ -1,0 +1,94 @@
+import { style } from '@vanilla-extract/css';
+import { colorVars } from '@styles/tokens/color.css';
+import { fontStyle } from '@/shared/styles/fontStyle';
+
+export const backdrop = style({
+  position: 'fixed',
+  top: 0,
+  left: 0,
+  right: 0,
+  bottom: 0,
+  backgroundColor: 'rgba(0, 0, 0, 0.5)',
+  zIndex: 0,
+  opacity: 0,
+  visibility: 'hidden',
+});
+
+export const backdropVisible = style({
+  opacity: 1,
+  visibility: 'visible',
+});
+
+export const sheetWrapper = style({
+  position: 'fixed',
+  bottom: 0,
+  left: '50%',
+  transform: 'translate(-50%, 100%)',
+  width: '100%',
+  maxWidth: '37.5rem',
+  padding: '0rem 2.4rem 2rem 2.4rem',
+  backgroundColor: colorVars.color.gray000,
+  borderRadius: '30px 30px 0 0',
+  willChange: 'transform',
+  transition: 'transform 0.6s ease-in-out ',
+  zIndex: 1,
+  overflow: 'hidden',
+});
+
+export const sheetWrapperExpanded = style({
+  transform: 'translate(-50%, 0)',
+});
+
+export const sheetWrapperCollapsed = style({
+  transform: 'translate(-50%, 100%)',
+});
+
+export const contentWapper = style({
+  display: 'flex',
+  flexDirection: 'column',
+});
+
+export const dragHandleContainer = style({
+  display: 'flex',
+  height: '2.8rem',
+  width: '100%',
+  justifyContent: 'center',
+  alignItems: 'center',
+  marginBottom: '2rem',
+});
+
+export const infoTextContainer = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '1.2rem',
+  marginBottom: '3.2rem',
+});
+
+export const infoText = style({
+  ...fontStyle('heading_sb_18'),
+  color: colorVars.color.gray900,
+});
+
+export const descriptionText = style({
+  ...fontStyle('body_r_14'),
+  color: colorVars.color.gray600,
+});
+
+export const fieldWrapper = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '1.2rem',
+  marginBottom: '4.8rem',
+});
+
+export const fieldContainer = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '1.2rem',
+});
+
+export const title = style({
+  ...fontStyle('title_sb_15'),
+  color: colorVars.color.gray800,
+  width: '5.6rem',
+});

--- a/src/shared/components/bottomSheet/noMatchSheet/NoMatchSheet.tsx
+++ b/src/shared/components/bottomSheet/noMatchSheet/NoMatchSheet.tsx
@@ -1,0 +1,61 @@
+import clsx from 'clsx';
+import DragHandle from '@components/dragHandle/DragHandle';
+import TextField from '@components/textField/TextField';
+import CtaButton from '@components/button/ctaButton/CtaButton';
+import * as styles from './NoMatchSheet.css';
+
+interface NoMatchSheetProps {
+  isOpen: boolean;
+  onClose: () => void;
+  user?: string;
+}
+
+const NoMatchSheet = ({ isOpen, onClose, user }: NoMatchSheetProps) => {
+  return (
+    <>
+      <div
+        className={clsx(styles.backdrop, isOpen && styles.backdropVisible)}
+        onClick={onClose}
+      />
+      <div
+        className={clsx(
+          styles.sheetWrapper,
+          isOpen ? styles.sheetWrapperExpanded : styles.sheetWrapperCollapsed
+        )}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className={styles.contentWapper}>
+          <div className={styles.dragHandleContainer}>
+            <DragHandle />
+          </div>
+          <div className={styles.infoTextContainer}>
+            <span className={styles.infoText}>
+              하우미는 점차 집 구조 템플릿을 <br />
+              확대해 나갈 예정이에요!
+            </span>
+            <span className={styles.descriptionText}>
+              아래 버튼을 통해 주소를 공유해주시면, <br />
+              {user}님의 스타일링을 위해 빠르게 반영해드릴게요!
+            </span>
+          </div>
+          <div className={styles.fieldWrapper}>
+            <div className={styles.fieldContainer}>
+              <p className={styles.title}>시/군/구</p>
+              <TextField
+                fieldSize="thin"
+                placeholder="ex) 솝트특별자치시 앱잼구"
+              />
+            </div>
+            <div className={styles.fieldContainer}>
+              <p className={styles.title}>상세 주소</p>
+              <TextField fieldSize="thin" placeholder="ex) 하우미로 123" />
+            </div>
+          </div>
+          <CtaButton isActive={false}>제출하기</CtaButton>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default NoMatchSheet;

--- a/src/shared/components/button/ctaButton/CtaButton.css.ts
+++ b/src/shared/components/button/ctaButton/CtaButton.css.ts
@@ -7,6 +7,8 @@ export const CtaButton = recipe({
     display: 'flex',
     justifyContent: 'center',
     width: '100%',
+    minWidth: '23.5rem',
+    maxWidth: '33.5rem',
     height: '5.9rem',
     padding: '1.7rem 0',
     textAlign: 'center',

--- a/src/shared/components/button/ctaButton/CtaButton.css.ts
+++ b/src/shared/components/button/ctaButton/CtaButton.css.ts
@@ -6,7 +6,7 @@ export const CtaButton = recipe({
   base: {
     display: 'flex',
     justifyContent: 'center',
-    width: '28rem',
+    width: '100%',
     height: '5.9rem',
     padding: '1.7rem 0',
     textAlign: 'center',

--- a/src/stories/FlipSheet.stories.tsx
+++ b/src/stories/FlipSheet.stories.tsx
@@ -1,0 +1,64 @@
+import { useState } from 'react';
+import FlipSheet from '@components/bottomSheet/flipSheet/FlipSheet';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta: Meta<typeof FlipSheet> = {
+  title: 'Sheet/FlipSheet',
+  component: FlipSheet,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component: '이미지를 좌우반전할 수 있는 시트 컴포넌트입니다.',
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof FlipSheet>;
+
+export const Default: Story = {
+  render: () => {
+    const [isOpen, setIsOpen] = useState(false);
+
+    const handleFlipClick = () => {
+      alert('이미지를 좌우 반전했습니다!');
+    };
+
+    const handleChooseClick = () => {
+      alert('이미지를 선택했습니다!');
+    };
+
+    return (
+      <div
+        style={{
+          position: 'relative',
+          height: '100vh',
+          overflow: 'hidden',
+        }}
+      >
+        <button
+          onClick={() => setIsOpen(true)}
+          style={{
+            padding: '1rem 2rem',
+            borderRadius: '8px',
+            backgroundColor: '#eee',
+            cursor: 'pointer',
+          }}
+        >
+          시트 열기
+        </button>
+        <FlipSheet
+          isOpen={isOpen}
+          onClose={() => setIsOpen(false)}
+          onFlipClick={handleFlipClick}
+          onChooseClick={handleChooseClick}
+        />
+      </div>
+    );
+  },
+  parameters: {
+    layout: 'fullscreen',
+  },
+};

--- a/src/stories/NoMatchSheet.stories.tsx
+++ b/src/stories/NoMatchSheet.stories.tsx
@@ -1,0 +1,56 @@
+import { useState } from 'react';
+import NoMatchSheet from '@components/bottomSheet/noMatchSheet/NoMatchSheet';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta: Meta<typeof NoMatchSheet> = {
+  title: 'Sheet/NoMatchSheet',
+  component: NoMatchSheet,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          '집 구조 템플릿이 없을 때 유저가 주소를 공유할 수 있는 시트 컴포넌트입니다.',
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof NoMatchSheet>;
+
+export const Default: Story = {
+  render: () => {
+    const [isOpen, setIsOpen] = useState(false);
+
+    return (
+      <div
+        style={{
+          position: 'relative',
+          height: '100vh',
+          overflow: 'hidden',
+        }}
+      >
+        <button
+          onClick={() => setIsOpen(true)}
+          style={{
+            padding: '1rem 2rem',
+            borderRadius: '8px',
+            backgroundColor: '#eee',
+            cursor: 'pointer',
+          }}
+        >
+          시트 열기
+        </button>
+        <NoMatchSheet
+          isOpen={isOpen}
+          onClose={() => setIsOpen(false)}
+          user="김하우미"
+        />
+      </div>
+    );
+  },
+  parameters: {
+    layout: 'fullscreen',
+  },
+};


### PR DESCRIPTION
## 📌 Summary

- close #80 


FlipSheet와 NoMatchSheet 두 가지 시트 컴포넌트를 구현했습니다.
공통된 시트 레이아웃 및 애니메이션 로직을 적용하며, 각각의 기능과 입력 폼 목적에 맞게 분리하였습니다.


## 📄 Tasks
- onFlipClick, onChooseClick, onClose, isOpen props를 공통적으로 지원합니다.
- No Match sheet에선 user를 선언했는데 추후 api 연동 때 타입에 맞게 수정하셔도 됩니다! 그리고 피그마 디자인에 따라 disabled 상태의 버튼을 렌더링했습니다.
- sheetWrapper, backdrop, transition 등 공통 스타일을 적용해 애니메이션을 구현했습니다.

> 홈 화면에 버튼 누르면 콘솔 찍히도록 예시 구현했으니 사용하실 때 잘 모르겠으면 `HomePage.tsx` 참고하시면 될 것 같아요.
```tsx
  <NoMatchSheet
    isOpen={isSheetOpen}
    onClose={handleClose}
    user="김하우미"
  />

  <FlipSheet
    onFlipClick={handleFlip}
    onChooseClick={handleChoose}
    isOpen={isSheetOpen}
    onClose={handleClose}
  />
```


## 🔍 To Reviewer

- 버튼의 경우 고정 넓이로 구현했었는데, CTA 버튼의 경우 여러 페이지에서 width값이 달라져서 부모의 100%가 되게 설정하고, 피그마에 따라 min, max 설정했습니다.
```ts
  width: '100%',
  minWidth: '23.5rem',
  maxWidth: '33.5rem',
```




## 📸 Screenshot

<img width="242" alt="image" src="https://github.com/user-attachments/assets/fb1074c0-c030-4dea-adc1-a65247b0c113" />


<img width="253" alt="image" src="https://github.com/user-attachments/assets/6046193a-1bdd-40ba-a09a-b7109886f739" />


