### PR TITLE
[feat] card review 컴포넌트 구현

### DIFF
--- a/src/shared/components/cardReview/CardReview.css.ts
+++ b/src/shared/components/cardReview/CardReview.css.ts
@@ -1,0 +1,36 @@
+import { style } from '@vanilla-extract/css';
+import { colorVars } from '@/shared/styles/tokens/color.css';
+import { fontStyle } from '@/shared/styles/fontStyle';
+
+export const cardReview = style({
+  display: 'flex',
+  flexDirection: 'column',
+  justifyContent: 'flex-start',
+  alignItems: 'flex-start',
+  width: '31.5rem',
+  padding: '3.2rem',
+  gap: '1.6rem',
+  borderRadius: '1.6rem',
+  background: colorVars.color.gray000,
+});
+
+//제목 텍스트
+export const title = style({
+  ...fontStyle('title_sb_15'),
+  color: colorVars.color.primary,
+});
+
+// 본문 내용 텍스트
+export const body = style({
+  ...fontStyle('body_r_14'),
+  color: colorVars.color.gray700,
+  alignSelf: 'stretch',
+});
+
+// 사용자 이름 텍스트
+export const username = style({
+  ...fontStyle('body_r_14'),
+  color: colorVars.color.gray500,
+  textAlign: 'right',
+  alignSelf: 'stretch',
+});

--- a/src/shared/components/cardReview/CardReview.tsx
+++ b/src/shared/components/cardReview/CardReview.tsx
@@ -1,0 +1,17 @@
+import * as styles from '@shared/components/cardReview/CardReview.css.ts';
+
+interface CardReviewProps {
+  title: string;
+  body: string;
+  username: string;
+}
+
+export const CardReview = ({ title, body, username }: CardReviewProps) => {
+  return (
+    <div className={styles.cardReview}>
+      <div className={styles.title}>{title}</div>
+      <div className={styles.body}>{body}</div>
+      <div className={styles.username}>{username}</div>
+    </div>
+  );
+};

--- a/src/stories/CardReview.stories.tsx
+++ b/src/stories/CardReview.stories.tsx
@@ -1,0 +1,24 @@
+import { CardReview } from '@shared/components/cardReview/CardReview';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta: Meta<typeof CardReview> = {
+  title: 'Components/CardReview',
+  component: CardReview,
+  tags: ['autodocs'],
+  argTypes: {
+    title: { control: 'text' },
+    body: { control: 'text' },
+    username: { control: 'text' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof CardReview>;
+
+export const Default: Story = {
+  args: {
+    title: '제목',
+    body: '내용내용내용',
+    username: '유저이름',
+  },
+};


### PR DESCRIPTION
## 📌 Summary

- close #75 

- 랜딩 페이지의 review 카드 컴포넌트 구현합니다.

## 📄 Tasks

![image](https://github.com/user-attachments/assets/ba998d3a-06b7-472d-bbf4-cbb7dd21ceb4)

- 스토리북 실행 결과 화면 첨부합니다.

## 🔍 To Reviewer

- 사용 방법
```tsx
import { CardReview } from '@/stories/CardReview'; // 실제 경로에 맞게 조정

export default function HomePage() {
  return (
    <section>
      <h2>사용자 리뷰</h2>
      <CardReview
        title="가성비 좋아요"
        body="배송도 빠르고 제품 상태도 아주 만족스러웠어요."
        username="리뷰작성자123"
      />
    </section>
  );
}
```

## 📸 Screenshot

![image](https://github.com/user-attachments/assets/3d8231e5-407b-4dcb-bf05-ba94c4087e74)

- 피그마 화면 첨부합니다.