### PR TITLE
[fix] Reset css 빌드 오류 해결

### DIFF
--- a/src/shared/styles/reset.css.ts
+++ b/src/shared/styles/reset.css.ts
@@ -34,7 +34,7 @@ globalStyle('html', {
   fontSize: '62.5%',
   // 텍스트 크기 조정 방지 (모바일)
   WebkitTextSizeAdjust: '100%',
-});
+} as any);
 
 /* ===== Body 기본값 ===== */
 /**
@@ -111,7 +111,7 @@ globalStyle('img', {
   WebkitTapHighlightColor: 'transparent', // 탭 하이라이트 제거
   // 접근성을 위한 설정
   pointerEvents: 'auto', // 클릭/탭 이벤트는 허용
-});
+} as any);
 
 /* ===== 폼 요소 초기화 ===== */
 /**
@@ -126,7 +126,7 @@ globalStyle('button', {
   userSelect: 'none',
   // 모바일 탭 하이라이트 제거
   WebkitTapHighlightColor: 'transparent',
-});
+} as any);
 
 /**
  * 입력 요소들의 기본 스타일 제거

--- a/src/shared/styles/reset.css.ts
+++ b/src/shared/styles/reset.css.ts
@@ -32,9 +32,9 @@ globalStyle('*, *::before, *::after', {
  */
 globalStyle('html', {
   fontSize: '62.5%',
-  // 텍스트 크기 조정 방지 (모바일)
-  WebkitTextSizeAdjust: '100%',
-} as any);
+  // 텍스트 크기 조정 방지 (모바일) - 표준 CSS 사용
+  textSizeAdjust: '100%',
+});
 
 /* ===== Body 기본값 ===== */
 /**
@@ -100,18 +100,16 @@ globalStyle('img, picture, video, canvas, svg', {
 });
 
 /**
- * 이미지 드래그 및 선택 방지
- * 모바일 앱과 같은 UX 제공을 위해 드래그 동작 비활성화
+ * 이미지 사용자 상호작용 제어
+ * 모던 방식으로 이미지 선택 및 드래그 비활성화
  */
 globalStyle('img', {
-  WebkitUserDrag: 'none', // Webkit 브라우저 드래그 방지
   userSelect: 'none', // 텍스트 선택 방지
-  // 추가적인 터치 동작 제어
-  WebkitTouchCallout: 'none', // iOS Safari 롱프레스 메뉴 방지
-  WebkitTapHighlightColor: 'transparent', // 탭 하이라이트 제거
   // 접근성을 위한 설정
   pointerEvents: 'auto', // 클릭/탭 이벤트는 허용
-} as any);
+  // 드래그 비활성화는 CSS 대신 JavaScript로 처리 권장
+  // draggable="false" 속성을 HTML에서 사용하세요
+});
 
 /* ===== 폼 요소 초기화 ===== */
 /**
@@ -124,9 +122,9 @@ globalStyle('button', {
   boxSizing: 'border-box',
   // 텍스트 선택 방지
   userSelect: 'none',
-  // 모바일 탭 하이라이트 제거
-  WebkitTapHighlightColor: 'transparent',
-} as any);
+  // 모바일 터치 하이라이트는 outline: none으로 대체 가능
+  outline: 'none',
+});
 
 /**
  * 입력 요소들의 기본 스타일 제거


### PR DESCRIPTION
## 📌 Summary

- close #102 

CSS reset 파일에서 발생하는 TypeScript 빌드 오류를 해결했습니다.

## 📄 Tasks

- TypeScript 빌드 오류 해결: Webkit CSS 속성으로 인한 GlobalStyleRule 타입 오류 수정
- WebkitTextSizeAdjust → 표준 textSizeAdjust 사용
- WebkitTapHighlightColor → 표준 outline: none 사용
- WebkitUserDrag, WebkitTouchCallout 제거 (HTML draggable="false" 권장)

변경된 CSS 속성 :
  - ✅ textSizeAdjust: '100%' (표준)
  - ✅ outline: 'none' (표준)
  - ✅ userSelect: 'none' (표준)
  - ❌ WebkitTextSizeAdjust (제거)
  - ❌ WebkitTapHighlightColor (제거)
  - ❌ WebkitUserDrag (제거)
  
최근에는 Webkit 벤더 프리픽스는 권장되지 않는다고 합니다. 
대부분의 Webkit 전용 기능이 표준 CSS로 이미 통합되었으며, 모던 브라우저(Chrome, Firefox, Safari, Edge)는 표준 속성만으로도 충분한 호환성을 제공하고 벤더 프리픽스는 코드 복잡성을 증가시키는 경향이 있어서 제거하였습니다.

## 🔍 To Reviewer

- 

## 📸 Screenshot

- 
