### PR TITLE
[style] error 상태 border 색상 변경

### DIFF
--- a/src/shared/components/button/largeFilledButton/LargeFilledButton.css.ts
+++ b/src/shared/components/button/largeFilledButton/LargeFilledButton.css.ts
@@ -32,6 +32,7 @@ export const largeFilled = recipe({
         backgroundColor: colorVars.color.error_light,
         color: colorVars.color.error,
         ...fontStyle('body_m_14'),
+        border: `1px solid ${colorVars.color.error}`,
       },
     },
     buttonSize: {

--- a/src/shared/components/button/largeFilledButton/LargeFilledButton.tsx
+++ b/src/shared/components/button/largeFilledButton/LargeFilledButton.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import * as styles from './LargeFilledButton.css';
 
 interface LargeFilledProps extends React.ComponentProps<'button'> {
@@ -6,28 +5,25 @@ interface LargeFilledProps extends React.ComponentProps<'button'> {
   isActive?: boolean;
   isError?: boolean;
   buttonSize?: 'medium' | 'large';
+  isSelected?: boolean;
 }
 
 const LargeFilled = ({
   children,
   isActive = true,
-  isError,
+  isError = true,
   buttonSize = 'large',
+  isSelected = false,
+  onClick,
   ...props
 }: LargeFilledProps) => {
-  const [isSelected, setIsSelected] = useState(false);
-
-  const handleClick = () => {
-    setIsSelected((prev) => !prev);
-  };
-
   return (
     <button
       type="button"
-      onClick={handleClick}
+      onClick={onClick}
       className={styles.largeFilled({
         state: isError ? 'error' : isActive ? 'active' : 'disabled',
-        selected: isSelected ? true : false,
+        selected: isSelected,
         buttonSize,
       })}
       {...props}

--- a/src/shared/components/button/largeFilledButton/LargeFilledButton.tsx
+++ b/src/shared/components/button/largeFilledButton/LargeFilledButton.tsx
@@ -11,7 +11,7 @@ interface LargeFilledProps extends React.ComponentProps<'button'> {
 const LargeFilled = ({
   children,
   isActive = true,
-  isError = true,
+  isError = false,
   buttonSize = 'large',
   isSelected = false,
   onClick,

--- a/src/shared/components/textField/TextField.css.ts
+++ b/src/shared/components/textField/TextField.css.ts
@@ -34,6 +34,7 @@ export const textField = recipe({
       error: {
         backgroundColor: colorVars.color.error_light,
         color: colorVars.color.error,
+        border: `1px solid ${colorVars.color.error}`,
       },
     },
     fieldSize: {


### PR DESCRIPTION
## 📌 Summary

- close #112

error 상태일 때 border 컬러를 수정했습니다. 

## 📄 Tasks

- error 상태일 때 border 컬러 수정 
largeFilled, textField

## 🔍 To Reviewer

-


## 📸 Screenshot

<img width="298" height="136" alt="image" src="https://github.com/user-attachments/assets/c004e879-86da-4cea-b942-4a2741ff46c2" />

<img width="308" height="141" alt="image" src="https://github.com/user-attachments/assets/3fdf2d79-6291-4024-8881-bd2fb5b3d7ae" />
