### PR TITLE
[fix] 캡션 공통 컴포넌트 높이 차이 수정

### DIFF
--- a/src/shared/components/text/Caption.css.ts
+++ b/src/shared/components/text/Caption.css.ts
@@ -9,7 +9,8 @@ export const captionBox = style({
   padding: '0.8rem 1.2rem',
   borderRadius: '6px',
   backgroundColor: colorVars.color.gray000,
-  border: `1px solid ${colorVars.color.gray300}`,
+  outline: `1px solid ${colorVars.color.gray300}`,
+  outlineOffset: '-1px',
   boxSizing: 'border-box',
   width: '33.5rem',
 });


### PR DESCRIPTION
## 📌 Summary

- close #124

테두리 선을 inside 방식으로 변경하여 내부로 들어가도록 수정하였습니다.
따라서 테두리 두께 만큼 높이가 커지지 않고, 34px를 유지하도록 하였습니다.

## 📄 Tasks

- border에서 outline으로 변경 이후, outlineOffset -1px 속성을 추가

## 🔍 To Reviewer

- 

## 📸 Screenshot

<img width="1206" height="362" alt="20250712002713" src="https://github.com/user-attachments/assets/c5bced52-ae32-48bd-b25f-763af2bf0342" />
<img width="1010" height="618" alt="20250712002815" src="https://github.com/user-attachments/assets/f15e644b-2ea4-412f-8423-25df91de1993" />

