### PR TITLE
[chore] React Router v7로 마이그레이션

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "overlay-kit": "^1.8.4",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "react-router-dom": "^7.6.3",
+    "react-router": "^7.6.3",
     "react-toastify": "^11.0.5"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,7 +34,7 @@ importers:
       react-dom:
         specifier: ^19.1.0
         version: 19.1.0(react@19.1.0)
-      react-router-dom:
+      react-router:
         specifier: ^7.6.3
         version: 7.6.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react-toastify:
@@ -4316,16 +4316,6 @@ packages:
       }
     engines: { node: '>=0.10.0' }
 
-  react-router-dom@7.6.3:
-    resolution:
-      {
-        integrity: sha512-DiWJm9qdUAmiJrVWaeJdu4TKu13+iB/8IEi0EW/XgaHCjW/vWGrwzup0GVvaMteuZjKnh5bEvJP/K0MDnzawHw==,
-      }
-    engines: { node: '>=20.0.0' }
-    peerDependencies:
-      react: '>=18'
-      react-dom: '>=18'
-
   react-router@7.6.3:
     resolution:
       {
@@ -7913,12 +7903,6 @@ snapshots:
   react-is@17.0.2: {}
 
   react-refresh@0.17.0: {}
-
-  react-router-dom@7.6.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
-    dependencies:
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-      react-router: 7.6.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
 
   react-router@7.6.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { RouterProvider } from 'react-router-dom';
+import { RouterProvider } from 'react-router';
 import { router } from '@/routes/router';
 
 function App() {

--- a/src/layout/RootLayout.tsx
+++ b/src/layout/RootLayout.tsx
@@ -1,4 +1,4 @@
-import { Outlet } from 'react-router-dom';
+import { Outlet } from 'react-router';
 
 function RootLayout() {
   return (

--- a/src/routes/ProtectedRoute.tsx
+++ b/src/routes/ProtectedRoute.tsx
@@ -4,7 +4,7 @@
 //
 // createBrowserRouter 객체 트리에서 중간 노드로 사용해
 // 하위(children) 라우트를 한 번에 보호할 수 있습니다.
-import { Navigate, Outlet } from 'react-router-dom';
+import { Navigate, Outlet } from 'react-router';
 import { ROUTES } from '@/routes/paths';
 
 interface ProtectedRouteProps {

--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -9,7 +9,7 @@
 //
 // isAuthenticated 는 임시 하드코딩 값이며, 추후 useAuth 훅 등의 실제 인증 상태로 교체될 예정입니다.
 // ------------------------------
-import { createBrowserRouter } from 'react-router-dom';
+import { createBrowserRouter } from 'react-router';
 import { ROUTES } from '@/routes/paths';
 import RootLayout from '@/layout/RootLayout';
 import ProtectedRoute from '@/routes/ProtectedRoute';

--- a/src/shared/components/navBar/LogoNavBar.tsx
+++ b/src/shared/components/navBar/LogoNavBar.tsx
@@ -1,4 +1,4 @@
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import LogoIcon from '@shared/assets/icons/logoIcon.svg?react';
 import ProfileIcon from '@shared/assets/icons/profileIcon.svg?react';
 import * as styles from './LogoNavBar.css';

--- a/src/shared/components/navBar/TitleNavBar.tsx
+++ b/src/shared/components/navBar/TitleNavBar.tsx
@@ -1,4 +1,4 @@
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import BackIcon from '@shared/assets/icons/backIcon.svg?react';
 import * as styles from './TitleNavBar.css';
 import * as btnStyles from './LoginNavBtn.css';

--- a/src/stories/LogoNavBar.stories.tsx
+++ b/src/stories/LogoNavBar.stories.tsx
@@ -1,4 +1,4 @@
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import LogoNavBar from '@shared/components/navBar/LogoNavBar';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 

--- a/src/stories/TitleNavBar.stories.tsx
+++ b/src/stories/TitleNavBar.stories.tsx
@@ -1,4 +1,4 @@
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import TitleNavBar from '@/shared/components/navBar/TitleNavBar';
 


### PR DESCRIPTION
## 📌 Summary

- close #53

React Router v7의 공식 권장사항에 따라 모든 import 경로를 `react-router-dom`에서 `react-router`로 변경했습니다. 이젠 하나의 패키지에서 모든 라우팅 기능을 제공합니다.

React Router v7에서는 웹 환경에서도 `react-router` 사용이 표준으로 자리잡았다고 합니다.

## 📄 Tasks

- 기능적 변경사항은 없으며 순수 import 경로 변경만 수행했습니다.

## 🔍 To Reviewer

- 모든 라우팅 기능 정상 동작 확인

## 📸 Screenshot

- 
