### PR TITLE
[style] cta 버튼 높이 값 수정

### DIFF
--- a/src/pages/home/HomePage.tsx
+++ b/src/pages/home/HomePage.tsx
@@ -1,7 +1,6 @@
 import { useState } from 'react';
 import FlipSheet from '@/shared/components/bottomSheet/flipSheet/FlipSheet';
 import CtaButton from '@/shared/components/button/ctaButton/CtaButton';
-import LargeFilled from '@/shared/components/button/largeFilledButton/LargeFilledButton';
 
 const HomePage = () => {
   const [isSheetOpen, setIsSheetOpen] = useState(false);
@@ -27,7 +26,6 @@ const HomePage = () => {
         isOpen={isSheetOpen}
         onClose={handleClose}
       />
-      <LargeFilled buttonSize={'medium'}>여성</LargeFilled>
     </div>
   );
 };

--- a/src/shared/components/button/ctaButton/CtaButton.css.ts
+++ b/src/shared/components/button/ctaButton/CtaButton.css.ts
@@ -7,7 +7,7 @@ export const CtaButton = recipe({
     display: 'flex',
     justifyContent: 'center',
     width: '100%',
-    minWidth: '23.5rem',
+    minWidth: '12.1rem',
     maxWidth: '33.5rem',
     height: '5.9rem',
     padding: '1.7rem 0',
@@ -47,6 +47,12 @@ export const CtaButton = recipe({
           backgroundColor: '#FEE500',
         },
       },
+    },
+    buttonSize: {
+      small: {
+        height: '4rem',
+      },
+      large: {},
     },
   },
   defaultVariants: {

--- a/src/shared/components/button/ctaButton/CtaButton.tsx
+++ b/src/shared/components/button/ctaButton/CtaButton.tsx
@@ -5,12 +5,14 @@ interface CtaButtonProps extends React.ComponentProps<'button'> {
   children: React.ReactNode;
   isActive?: boolean;
   typeVariant?: 'default' | 'kakao';
+  buttonSize?: 'small' | 'large';
 }
 
 const CtaButton = ({
   children,
   isActive = true,
   typeVariant = 'default',
+  buttonSize = 'large',
   ...props
 }: CtaButtonProps) => {
   return (
@@ -21,6 +23,7 @@ const CtaButton = ({
       className={styles.CtaButton({
         state: isActive ? 'active' : 'disabled',
         type: typeVariant,
+        buttonSize: buttonSize,
       })}
       {...props}
     >


### PR DESCRIPTION
## 📌 Summary

- close #142

cta 버튼에 대한 높이가 달라 props로 관리하도록 했습니다.

## 📄 Tasks
`buttonSize`
- 기존 높이(5.9rem)은 large (default 값)
- 이미지 생성 완료 뷰에서 쓰인 높이(4rem)은 small

_해당 PR에 수행한 작업을 작성해주세요._

## 🔍 To Reviewer

- 이미지 생성 완료 뷰에서 넓이도 달라서 minWidth 값을 변경하였습니다. 

_리뷰어에게 요청하는 내용을 작성해주세요._

## 📸 Screenshot

-

_작업한 내용에 대한 스크린샷을 첨부해주세요._
