### PR TITLE
[deploy] @storybook/addon-vitest 옵션 주석 처리

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -6,7 +6,7 @@ const config: StorybookConfig = {
     '@chromatic-com/storybook',
     '@storybook/addon-docs',
     '@storybook/addon-a11y',
-    '@storybook/addon-vitest',
+    // '@storybook/addon-vitest',
   ],
   framework: {
     name: '@storybook/react-vite',


### PR DESCRIPTION
## 📌 Summary

- close #160 

배포 과정에서 @storybook/addon-vitest 옵션 설정으로 인해 생기는 빌드 오류를 해결하기 위해, 옵션을 주석 처리했습니다.

## 📄 Tasks

- @storybook/addon-vitest 옵션 주석 처리


## 🔍 To Reviewer

### 1. Vite/Vitest 플러그인과의 충돌
@storybook/addon-vitest는 내부적으로 vitest, vite-plugin-vitest, 또는 vite-plugin-test 등 런타임에 필요한 플러그인들을 요구할 수 있는데, Vercel은 일반적으로 NODE_ENV=production 환경에서 vitest를 설치하지 않기 때문에 @storybook/addon-vitest가 내부에서 vitest를 로딩하려고 할 때 오류가 발생할 수 있다고 합니다.

### 2. Vite config 확장 시 충돌
이 addon이 Storybook 내부에서 viteFinal을 통해 Vite 설정을 확장하려 할 때, vitest 관련 설정이 포함되면 Vercel 빌드 시 Vite가 해당 설정을 파싱하려고 시도하고,  그 설정이 vitest 모듈을 참조하면 모듈을 찾을 수 없어 빌드에 실패합니다.

### 3. Vercel이 .storybook 경로 스캔

Vercel은 때때로 프로젝트 전체에서 사용된 설정 파일이나 모듈을 스캔해서 불필요한 파일도 번들에 포함시킬 수 있는데,
이 경우에도 .storybook/main.ts 안의 @storybook/addon-vitest도 참조되며, vitest가 실제로 설치되어 있지 않으면 에러가 발생할 수 있습니다.

**현재 정확한 빌드 에러의 로직상 원인은 찾지 못한 상황이나, 해당 옵션을 주석 처리하거나 삭제하면 빌드가 가능함을 확인하여 반영해두었습니다. 관련 에러를 경험한 적이 있거나 해결 방법을 아신다면 공유해주세요!!**

## 📸 Screenshot

-