### PR TITLE
[chore] 이미지 드래그 방지 기능 추가

### DIFF
--- a/src/shared/styles/global.css.ts
+++ b/src/shared/styles/global.css.ts
@@ -110,3 +110,26 @@ globalStyle('body', {
 globalStyle('body::-webkit-scrollbar', {
   display: 'none',
 });
+
+/* ===== 이미지 보호 설정 ===== */
+/**
+ * 모든 이미지 요소에 대한 사용자 상호작용 제한
+ *
+ * Best Practice:
+ * - CSS만으로는 완전한 드래그 방지가 불가능
+ * - 중요한 이미지는 개별적으로 draggable="false" HTML 속성 추가 권장
+ * - 모바일 환경에서의 길게 누르기 메뉴도 방지
+ */
+globalStyle('img', {
+  // 텍스트/이미지 선택 방지
+  userSelect: 'none',
+  WebkitUserSelect: 'none',
+  MozUserSelect: 'none',
+  msUserSelect: 'none',
+
+  // 모바일 터치 콜아웃(길게 누르기 메뉴) 방지
+  WebkitTouchCallout: 'none',
+
+  // 이미지 하이라이트 방지
+  WebkitTapHighlightColor: 'transparent',
+});


### PR DESCRIPTION
## 📌 Summary

- close #143

프로젝트 내 모든 이미지 요소에 대해 드래그 및 선택을 방지하는 글로벌 CSS 스타일을 적용했습니다.

## 📄 Tasks

- src/shared/styles/global.css.ts에 이미지 보호 설정 추가
  - userSelect: 'none' - 이미지 선택 방지
  - WebkitTouchCallout: 'none' - 모바일 길게 누르기 메뉴 방지
  - WebkitTapHighlightColor: 'transparent' - 터치 하이라이트 제거

## 🔍 To Reviewer

- HTML draggable="false" 속성은 CSS로 적용할 수 없어, TypeScript와 호환되는 표준 CSS 속성들을 사용했습니다
- 완전한 드래그 방지가 필요한 중요 이미지는 개별적으로 draggable="false" HTML 속성 추가를 권장합니다.
- 빌드 테스트 완료

## 📸 Screenshot

- 
