### PR TITLE
[feat] Step3MainActivity 페이지 UI 마무리

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,14 @@
-import { RouterProvider } from 'react-router-dom';
+import { BrowserRouter, RouterProvider } from 'react-router-dom';
+import { ImageGenerationFunnel } from './pages/onboarding/ImageGenerationFunnel';
 import { router } from '@/routes/router';
 
 function App() {
-  return <RouterProvider router={router} />;
+  // return <RouterProvider router={router} />;
+  return (
+    <BrowserRouter>
+      <ImageGenerationFunnel />
+    </BrowserRouter>
+  );
 }
 
 export default App;

--- a/src/pages/onboarding/components/steps/step3/MoodBoard.css.ts
+++ b/src/pages/onboarding/components/steps/step3/MoodBoard.css.ts
@@ -6,7 +6,7 @@ export const container = style({
   display: 'flex',
   justifyContent: 'center',
   alignItems: 'center',
-  padding: '0 2rem',
+  padding: '2rem',
 });
 
 export const gridbox = style({

--- a/src/pages/onboarding/components/steps/step3/Step3InteriorTaste.css.ts
+++ b/src/pages/onboarding/components/steps/step3/Step3InteriorTaste.css.ts
@@ -1,0 +1,20 @@
+import { style } from '@vanilla-extract/css';
+import { zIndex } from '@/shared/styles/tokens/zIndex';
+
+export const container = style({
+  display: 'flex',
+  position: 'relative',
+  flexDirection: 'column',
+  alignItems: 'center',
+  width: '100%',
+  marginBottom: '96px',
+});
+
+export const buttonWrapper = style({
+  position: 'fixed',
+  bottom: '2rem',
+  width: '100%',
+  display: 'flex',
+  justifyContent: 'center',
+  zIndex: zIndex.button,
+});

--- a/src/pages/onboarding/components/steps/step3/Step3InteriorTaste.tsx
+++ b/src/pages/onboarding/components/steps/step3/Step3InteriorTaste.tsx
@@ -1,8 +1,12 @@
 // Step 3
+import MoodBoard from './MoodBoard';
+import * as styles from './Step3InteriorTaste.css';
+import FunnelHeader from '../../header/FunnelHeader';
 import type {
   CompletedInteriorTaste,
   ImageGenerateSteps,
 } from '../../../types/funnel';
+import CtaButton from '@/shared/components/button/ctaButton/CtaButton';
 
 interface Step3InteriorTasteProps {
   context: ImageGenerateSteps['InteriorTaste'];
@@ -11,23 +15,31 @@ interface Step3InteriorTasteProps {
 
 const Step3InteriorTaste = ({ context, onNext }: Step3InteriorTasteProps) => {
   return (
-    <div>
+    <div className={styles.container}>
       {/* 테스트 코드 */}
       <span>{context.houseType}</span>
-      <button
-        type="button"
-        onClick={() =>
-          onNext({
-            houseType: 'office',
-            roomType: 'openOne',
-            roomSize: 'sixToTen',
-            selectedHouseStructure: [1, 2, 3],
-            selectedInteriorTaste: [1, 2, 3, 4],
-          })
-        }
-      >
-        다음 단계
-      </button>
+      <FunnelHeader
+        title={`인테리어 취향을 알려주세요`}
+        detail={`인테리어 취향에 맞는 이미지를\n최대 5개까지 선택해주세요.`}
+        currentStep={3}
+      />
+      <MoodBoard />
+      <div className={styles.buttonWrapper}>
+        <CtaButton
+          isActive={true}
+          onClick={() =>
+            onNext({
+              houseType: 'office',
+              roomType: 'openOne',
+              roomSize: 'sixToTen',
+              selectedHouseStructure: [1, 2, 3],
+              selectedInteriorTaste: [1, 2, 3, 4],
+            })
+          }
+        >
+          집구조 선택하기
+        </CtaButton>
+      </div>
     </div>
   );
 };

--- a/src/shared/styles/tokens/zIndex.ts
+++ b/src/shared/styles/tokens/zIndex.ts
@@ -1,5 +1,6 @@
 export const zIndex = {
   base: 1,
+  button: 50,
   navigation: 200,
   backdrop: 250,
   modal: 300,


### PR DESCRIPTION
## 📌 Summary

- close #166 

- `Step3MainActivity.tsx` 페이지의 UI를 마무리했습니다.

_해당 PR에 대한 작업 내용을 요약하여 작성해주세요._

## 📄 Tasks

- 기존 개발된 컴포넌트인 `MoodBoard` 컴포넌트와 `Step3MainActivity.tsx`를 통합해 `MoodBoard` 컴포넌트를 퍼널 스텝에 적용했습니다.

_해당 PR에 수행한 작업을 작성해주세요._

## 🔍 To Reviewer

- 현재 `MoodBoard` 내에서 이미지 선택 상태를 관리하고 있습니다.
- 무드모드 이미지 선택 데이터를 퍼널 플로우에서 관리하기 위해서는 `Step3MainActivity.tsx`에서 `MoodBoard.tsx`로 상태값을 props로 전달해야 합니다. `MoodBoard` 컴포넌트 담당자가 구현할 예정입니다!

_리뷰어에게 요청하는 내용을 작성해주세요._

## 📸 Screenshot

https://github.com/user-attachments/assets/9b1c26e4-d464-4101-891a-45f3d19f0e81

_작업한 내용에 대한 스크린샷을 첨부해주세요._
