### PR TITLE
[style] TitleNavBar 디자인 변경사항 반영

### DIFF
--- a/src/shared/components/navBar/TitleNavBar.css.ts
+++ b/src/shared/components/navBar/TitleNavBar.css.ts
@@ -11,7 +11,6 @@ export const container = style({
   alignItems: 'center',
   textAlign: 'center',
   position: 'relative',
-  ...fontStyle('title_m_16'),
   background: colorVars.color.gray000,
   color: colorVars.color.gray900,
 });
@@ -38,6 +37,7 @@ export const title = style({
   zIndex: zIndex.base,
   width: 'max-content',
   pointerEvents: 'none',
+  ...fontStyle('title_m_16'),
 });
 
 export const rightdiv = style({
@@ -47,4 +47,5 @@ export const rightdiv = style({
   width: '8rem',
   height: '4.8rem',
   padding: '1.2rem 1.6rem',
+  ...fontStyle('body_r_14'),
 });

--- a/src/shared/components/navBar/TitleNavBar.css.ts
+++ b/src/shared/components/navBar/TitleNavBar.css.ts
@@ -6,10 +6,10 @@ export const container = style({
   display: 'flex',
   width: '100%',
   height: '4.8rem',
-  paddingRight: '1.6rem',
   justifyContent: 'space-between',
   alignItems: 'center',
   textAlign: 'center',
+  position: 'relative',
   ...fontStyle('title_m_16'),
   background: colorVars.color.gray000,
   color: colorVars.color.gray900,
@@ -28,11 +28,22 @@ export const backicon = style({
   cursor: 'pointer',
 });
 
+export const title = style({
+  position: 'absolute',
+  left: '50%',
+  top: '50%',
+  transform: 'translate(-50%, -50%)',
+  margin: 0,
+  zIndex: 1,
+  width: 'max-content',
+  pointerEvents: 'none',
+});
+
 export const rightdiv = style({
   display: 'flex',
   justifyContent: 'center',
   alignItems: 'center',
-  width: '4.8rem',
+  width: '8rem',
   height: '4.8rem',
-  padding: '1.2rem 0',
+  padding: '1.2rem 1.6rem',
 });

--- a/src/shared/components/navBar/TitleNavBar.css.ts
+++ b/src/shared/components/navBar/TitleNavBar.css.ts
@@ -1,6 +1,7 @@
 import { style } from '@vanilla-extract/css';
 import { fontStyle } from '@/shared/styles/fontStyle';
 import { colorVars } from '@/shared/styles/tokens/color.css';
+import { zIndex } from '@/shared/styles/tokens/zIndex';
 
 export const container = style({
   display: 'flex',
@@ -34,7 +35,7 @@ export const title = style({
   top: '50%',
   transform: 'translate(-50%, -50%)',
   margin: 0,
-  zIndex: 1,
+  zIndex: zIndex.base,
   width: 'max-content',
   pointerEvents: 'none',
 });

--- a/src/shared/components/navBar/TitleNavBar.tsx
+++ b/src/shared/components/navBar/TitleNavBar.tsx
@@ -29,7 +29,7 @@ const TitleNavBar = ({
           />
         )}
       </div>
-      <h1>{title}</h1>
+      <h1 className={styles.title}>{title}</h1>
       <div className={styles.rightdiv}>
         {isLoginBtn && (
           <button


### PR DESCRIPTION
## 📌 Summary

- close #175 


## 📄 Tasks

- TitleNavBar 컴포넌트 padding-right 값 변경
- 내부 요소 중앙정렬 확인


## 🔍 To Reviewer

1. TitleNavBar의 title(h1) 중앙 정렬 개선

양쪽 div(아이콘/버튼) 유무와 상관없이 title 문자열이 항상 container(100% width) 기준으로 정확히 가운데에 오도록 
구조 및 스타일을 수정했습니다.
- 전체 container  : `position: 'relative'` 속성 적용
- title :  `position: 'absolute'`, `left: '50%', top: '50%'`, `transform: 'translate(-50%, -50%)'` 등으로 완전 중앙 정렬

2. 로그인 버튼 rightdiv : padding 값 변경사항 반영

## 📸 Screenshot

<img width="470" height="208" alt="스크린샷 2025-07-15 오전 3 55 24" src="https://github.com/user-attachments/assets/6888ad9c-57db-4c98-be77-c39e8c93ed52" />
