### PR TITLE
[fix] Storybook main.js ESM 형식 전환

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -23,4 +23,4 @@ const config = {
   },
 };
 
-module.exports = config;
+export default config;


### PR DESCRIPTION
## 📌 Summary

- close #179 

.storybook/main.js에서 CommonJS (module.exports) → ESM (export default) 형식으로 변경

Storybook v9에서 ESM 지원이 강화되며, module is not defined 오류 해결을 위해 변경 적용

## 📄 Tasks

 .storybook/main.js를 ESM 방식으로 변경

```tsx
module.exports = { ... } → export default { ... }
```
 Storybook 실행 시 `MainFileEvaluationError: module is not defined` 오류 해결

## 🔍 To Reviewer
Node 23+ 환경에서는 .storybook/main.js에 CommonJS 사용 시 `module is not defined` 오류가 발생합니다.
Storybook이 ESM 기반으로 작동하므로, 해당 파일을 ESM 형식으로 변경한 점 참고 부탁드립니다.



## 📸 Screenshot

.
