### PR TITLE
[feat] 자체 회원가입 API 연동

### DIFF
--- a/src/pages/login/LoginPage.tsx
+++ b/src/pages/login/LoginPage.tsx
@@ -1,8 +1,14 @@
 import * as styles from './loginPage.css';
+import { KAKAO_AUTH_URL } from './constants/kakaoLoginPath';
 import CtaButton from '@/shared/components/button/ctaButton/CtaButton';
 import TitleNavBar from '@/shared/components/navBar/TitleNavBar';
 
 const LoginPage = () => {
+  const handleKakaoLogin = () => {
+    // 외부 URL로 리다이렉트하기 위해 window.location.href 사용
+    window.location.href = KAKAO_AUTH_URL;
+  };
+
   return (
     <div className={styles.container}>
       <TitleNavBar
@@ -19,7 +25,9 @@ const LoginPage = () => {
       </div>
       <div className={styles.imgbox}></div>
       <div className={styles.btnarea}>
-        <CtaButton typeVariant="kakao">카카오 로그인</CtaButton>
+        <CtaButton typeVariant="kakao" onClick={handleKakaoLogin}>
+          카카오 로그인
+        </CtaButton>
         <aside className={styles.aside}>
           가입 시{' '}
           <a

--- a/src/pages/login/hooks/useKakaoLogin.ts
+++ b/src/pages/login/hooks/useKakaoLogin.ts
@@ -30,7 +30,7 @@ export const useKakaoLogin = () => {
     mutationFn: getKakaoLogin, // 카카오 로그인 API 호출 함수
     // 로그인 성공 시 실행되는 함수
     onSuccess: (response) => {
-      // console.log('[useKakaoLogin] 로그인 성공:', response.data);
+      console.log('[useKakaoLogin] 로그인 성공:', response.data);
 
       // 액세스 토큰을 로컬 스토리지에 저장
       localStorage.setItem('accessToken', response.accessToken);

--- a/src/pages/signup/SignupPage.tsx
+++ b/src/pages/signup/SignupPage.tsx
@@ -1,5 +1,6 @@
 import * as styles from './SignupPage.css';
 import useSignupForm from './hooks/useSignupForm';
+import { usePatchSignup } from './hooks/usePatchSignup';
 import TitleNavBar from '@/shared/components/navBar/TitleNavBar.tsx';
 import TextField from '@/shared/components/textField/TextField.tsx';
 import CtaButton from '@/shared/components/button/ctaButton/CtaButton.tsx';
@@ -28,8 +29,25 @@ const SignupPage = () => {
     isFormValid,
   } = useSignupForm();
 
+  const { mutate: patchSignup } = usePatchSignup();
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!isFormValid || !gender) return;
+
+    const formattedBirthday = `${birthYear}-${birthMonth}-${birthDay}`;
+
+    console.log(name, gender.value, formattedBirthday);
+
+    patchSignup({
+      name,
+      gender: gender.value,
+      birthday: formattedBirthday,
+    });
+  };
+
   return (
-    <form>
+    <form onSubmit={handleSubmit}>
       <TitleNavBar title="회원가입" isBackIcon={false} isLoginBtn={false} />
 
       <div className={styles.container}>
@@ -63,7 +81,7 @@ const SignupPage = () => {
               placeholder="YYYY"
               maxLength={4}
               value={birthYear}
-              onChange={handleBirthYearChange} // 이렇게!
+              onChange={handleBirthYearChange}
               isError={birthYear !== '' && (yearFormatError || yearAgeError)}
               inputMode="numeric"
             />
@@ -103,23 +121,23 @@ const SignupPage = () => {
           <div className={styles.flexbox}>
             <LargeFilled
               buttonSize="medium"
-              isSelected={gender?.value === 'male'}
-              onClick={() => setGender({ value: 'male', label: '남성' })}
+              isSelected={gender?.value === 'MALE'}
+              onClick={() => setGender({ value: 'MALE', label: '남성' })}
             >
               남성
             </LargeFilled>
             <LargeFilled
               buttonSize="medium"
-              isSelected={gender?.value === 'female'}
-              onClick={() => setGender({ value: 'female', label: '여성' })}
+              isSelected={gender?.value === 'FEMALE'}
+              onClick={() => setGender({ value: 'FEMALE', label: '여성' })}
             >
               여성
             </LargeFilled>
             <LargeFilled
               buttonSize="medium"
-              isSelected={gender?.value === 'nonbinary'}
+              isSelected={gender?.value === 'NONBINARY'}
               onClick={() =>
-                setGender({ value: 'nonbinary', label: '논바이너리' })
+                setGender({ value: 'NONBINARY', label: '논바이너리' })
               }
             >
               논바이너리
@@ -129,7 +147,9 @@ const SignupPage = () => {
       </div>
 
       <div className={styles.btnarea}>
-        <CtaButton isActive={isFormValid}>회원가입 완료하기</CtaButton>
+        <CtaButton isActive={isFormValid} type="submit">
+          회원가입 완료하기
+        </CtaButton>
       </div>
     </form>
   );

--- a/src/pages/signup/apis/signup.ts
+++ b/src/pages/signup/apis/signup.ts
@@ -1,0 +1,19 @@
+/* 회원가입 API 함수 */
+import axiosInstance from '@shared/apis/axiosInstance';
+import type { SignupRequest, SignupResponse } from '../types/apis/signup';
+
+export const patchSignup = async (
+  data: SignupRequest
+): Promise<SignupResponse> => {
+  try {
+    const response = await axiosInstance.patch<SignupResponse>(
+      '/api/v1/sign-up',
+      data
+    );
+    return response.data;
+  } catch (error: any) {
+    console.error('[signup] 요청 실패:', error.response?.data);
+    console.error('[signup] 상태 코드:', error.response?.status);
+    throw error;
+  }
+};

--- a/src/pages/signup/hooks/usePatchSignup.ts
+++ b/src/pages/signup/hooks/usePatchSignup.ts
@@ -1,0 +1,26 @@
+/* 회원가입 TanStack Query 훅 */
+
+import { useMutation } from '@tanstack/react-query';
+import { useNavigate } from 'react-router-dom';
+import { patchSignup } from '../apis/signup';
+import type { SignupRequest, SignupResponse } from '../types/apis/signup';
+import { ROUTES } from '@/routes/paths';
+
+export const usePatchSignup = () => {
+  const navigate = useNavigate();
+
+  return useMutation<SignupResponse, Error, SignupRequest>({
+    mutationFn: patchSignup,
+    // 회원가입 성공 시 실행되는 함수
+    onSuccess: (response) => {
+      console.log('[usePatchSignup] 회원가입 성공:', response);
+      // 회원가입 완료 페이지 이동
+      navigate(ROUTES.SIGNUPCOMPLETE);
+    },
+    // 회원가입 실패 시 실행되는 함수
+    onError: (error) => {
+      console.error('[usePatchSignup] 회원가입 실패:', error);
+      alert('회원가입에 실패했습니다. 다시 시도해주세요.');
+    },
+  });
+};

--- a/src/pages/signup/hooks/usePatchSignup.ts
+++ b/src/pages/signup/hooks/usePatchSignup.ts
@@ -11,6 +11,7 @@ export const usePatchSignup = () => {
 
   return useMutation<SignupResponse, Error, SignupRequest>({
     mutationFn: patchSignup,
+    retry: 3,
     // 회원가입 성공 시 실행되는 함수
     onSuccess: (response) => {
       console.log('[usePatchSignup] 회원가입 성공:', response);

--- a/src/pages/signup/types/apis/signup.ts
+++ b/src/pages/signup/types/apis/signup.ts
@@ -1,0 +1,12 @@
+// 회원가입 api 관련 타입
+
+export interface SignupRequest {
+  name: string;
+  gender: 'MALE' | 'FEMALE' | 'NONBINARY';
+  birthday: string; // e.g. "2001-01-10"
+}
+
+export interface SignupResponse {
+  code: number;
+  msg: string;
+}

--- a/src/pages/signup/types/formOptions.ts
+++ b/src/pages/signup/types/formOptions.ts
@@ -1,4 +1,4 @@
 export interface GenderOption {
-  value: 'male' | 'female' | 'nonbinary';
+  value: 'MALE' | 'FEMALE' | 'NONBINARY';
   label: string;
 }


### PR DESCRIPTION
## 📌 Summary

- close #187 

회원가입 API 연동 및 관련 커스텀 훅, 타입, API 함수 구현

회원가입 정보를 서버에 전달하는 patchSignup 함수를 구현하고, 이 함수를 `mutationFn`으로 사용하는 useMutation 훅(usePatchSignup)을 구현했습니다. 회원가입 페이지에서 회원가입 완료 버튼을 누르면, usePatchSignup의 `mutate` 함수를 실행하여 회원가입 API를 호출합니다. API 호출이 성공하면 회원가입 완료 페이지로 이동합니다.

## 📄 Tasks

- 회원가입 response/request 타입 정의
- 회원가입 API 함수 구현 
- 회원가입 커스텀 훅 구현

## 🔍 To Reviewer

.

## 📸 Screenshot

.
