### PR TITLE
[feat] 로그인 여부에 따른 NavBar 옵션 분기 처리

### DIFF
--- a/src/pages/home/HomePage.css.ts
+++ b/src/pages/home/HomePage.css.ts
@@ -15,7 +15,7 @@ export const gradFrame = style({
   width: '100%',
   background:
     'linear-gradient(180deg, #A696FF -15.93%, #DDD6FF 13.05%, #FFF 47.05%, #FFF 100%)',
-  height: '51rem',
+  height: '53.4rem',
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'center',

--- a/src/pages/home/HomePage.tsx
+++ b/src/pages/home/HomePage.tsx
@@ -4,14 +4,17 @@ import StepGuideSection from './components/stepGuideSection/StepGuideSection';
 import ReviewSection from './components/reviewSection/ReviewSection';
 import * as styles from './HomePage.css';
 import CtaButton from '@/shared/components/button/ctaButton/CtaButton';
-
-const isLoggedIn = false;
+import { useAuthStore } from '@/store/useAuthStore';
 
 const HomePage = () => {
+  const accessToken = useAuthStore((state) => state.accessToken);
+  // 인증 여부: prop이 있으면 우선 사용, 없으면 accessToken 존재 여부로 판단
+  const isAuthenticated = !!accessToken;
+
   return (
     <main className={styles.page}>
       <div className={styles.gradFrame}>
-        <LogoNavBar buttonType={isLoggedIn ? 'profile' : 'login'} />
+        <LogoNavBar buttonType={isAuthenticated ? 'profile' : 'login'} />
         <div className={styles.introSection}>
           <IntroSection />
         </div>

--- a/src/shared/components/navBar/LogoNavBar.css.ts
+++ b/src/shared/components/navBar/LogoNavBar.css.ts
@@ -18,7 +18,7 @@ export const leftdiv = style({
   display: 'flex',
   justifyContent: 'center',
   alignItems: 'center',
-  height: '4.8rem',
+  height: '7.2rem',
 });
 
 export const profileicon = style({
@@ -32,6 +32,6 @@ export const rightdiv = style({
   justifyContent: 'center',
   alignItems: 'center',
   width: '4.8rem',
-  height: '4.8rem',
+  height: '7.2rem',
   padding: '1.2rem 0',
 });

--- a/src/shared/components/navBar/LogoNavBar.css.ts
+++ b/src/shared/components/navBar/LogoNavBar.css.ts
@@ -6,7 +6,6 @@ export const container = style({
   display: 'flex',
   width: '100%',
   height: '7.2rem',
-  paddingRight: '1.6rem',
   justifyContent: 'space-between',
   alignItems: 'center',
   textAlign: 'center',
@@ -31,7 +30,7 @@ export const rightdiv = style({
   display: 'flex',
   justifyContent: 'center',
   alignItems: 'center',
-  width: '4.8rem',
-  height: '7.2rem',
-  padding: '1.2rem 0',
+  width: '8rem',
+  height: '4.8rem',
+  padding: '1.2rem 1.6rem',
 });


### PR DESCRIPTION
## 📌 Summary

- close #211 

랜딩 페이지(/home)에서 유저의 로그인 여부에 따라 다른 네비게이션 옵션을 처리하였습니다.

## 📄 Tasks

- 유저의 로그인 여부에 따라 옵션 처리 분기
- 디자인 변경사항 반영 및 height 값 재적용

## 🔍 To Reviewer

보호 페이지 라우팅에 적용했던 useAuthStore 훅을 사용해 분기 처리를 진행했습니다.

## 📸 Screenshot

### 로그인 O
<img width="300" alt="스크린샷 2025-07-17 오전 2 20 48" src="https://github.com/user-attachments/assets/4fdb55f6-bafa-473c-bf9b-b6b3d63c4cb0" />

### 로그인 X
<img width="300" alt="스크린샷 2025-07-17 오전 2 19 39" src="https://github.com/user-attachments/assets/1581e17f-0a69-4d81-be96-894dce191027" />
