### PR TITLE
[feat] 랜딩페이지 애니메이션 구현

### DIFF
--- a/src/pages/home/components/introSection/IntroSection.css.ts
+++ b/src/pages/home/components/introSection/IntroSection.css.ts
@@ -1,6 +1,17 @@
-import { style } from '@vanilla-extract/css';
+import { style, keyframes } from '@vanilla-extract/css';
 import { fontStyle } from '@/shared/styles/fontStyle';
 import { colorVars } from '@/shared/styles/tokens/color.css';
+
+const fadeInUp = keyframes({
+  '0%': {
+    opacity: 0,
+    transform: 'translateY(1rem)',
+  },
+  '100%': {
+    opacity: 1,
+    transform: 'translateY(0)',
+  },
+});
 
 export const wrapper = style({
   display: 'flex',
@@ -15,6 +26,7 @@ export const titleWrapper = style({
   display: 'flex',
   flexDirection: 'column',
   width: '100%',
+  animation: `${fadeInUp} 1.2s ease-out forwards`,
 });
 
 export const title = style({
@@ -36,6 +48,7 @@ export const placeholderBox = style({
   height: '22rem',
   backgroundColor: colorVars.color.gray100,
   borderRadius: '16px',
+  animation: `${fadeInUp} 1.2s ease-out forwards`,
 });
 
 export const buttonGroup = style({


### PR DESCRIPTION
## 📌 Summary

- close #210 

- 랜딩페이지 애니메이션을 구현합니다.

## 📄 Tasks

- 랜딩페이지의 introsection의 애니메이션을 구현합니다.
- 다른 부분보다 1.2초 늦게 나옵니다.


## 🔍 To Reviewer


https://github.com/user-attachments/assets/e9d480a1-82bf-4261-8975-97f3a40dfb41

- 제가 구현한 화면 기록 첨부합니다.

## 📸 Screenshot

<img width="691" height="520" alt="image" src="https://github.com/user-attachments/assets/a6f25915-5a49-44d1-9a3b-a28177200b41" />

- 피그마 캡쳐 첨부합니다.
