### PR TITLE
[fix] 카카오 인증 헤더 예외처리 (+ Skeleton UI )

### DIFF
--- a/src/pages/home/HomePage.tsx
+++ b/src/pages/home/HomePage.tsx
@@ -11,13 +11,13 @@ import { useUserStore } from '@/store/useUserStore';
 const HomePage = () => {
   const { data: hasHistory, isLoading, isError } = useLandingData();
 
-  if (isLoading) return <div>Loading...</div>;
-  if (isError) return <div>Error</div>;
-  console.log(hasHistory);
-
   const accessToken = useUserStore((state) => state.accessToken);
   // 인증 여부: prop이 있으면 우선 사용, 없으면 accessToken 존재 여부로 판단
   const isAuthenticated = !!accessToken;
+
+  if (isLoading) return <div>Loading...</div>;
+  if (isError) return <div>Error</div>;
+  console.log(hasHistory);
 
   return (
     <main className={styles.page}>

--- a/src/pages/onboarding/components/steps/step3/MoodBoard.tsx
+++ b/src/pages/onboarding/components/steps/step3/MoodBoard.tsx
@@ -9,6 +9,8 @@
  * @param {function} onImageSelect - 이미지 선택/해제 처리 함수
  * @returns JSX.Element - 무드보드 컴포넌트
  */
+
+import { useEffect, useState } from 'react';
 import * as styles from './MoodBoard.css';
 import {
   MOOD_BOARD_CONSTANTS,
@@ -16,6 +18,7 @@ import {
 } from '@/pages/onboarding/types/apis/moodBoard';
 import { useMoodBoardImage } from '@/pages/onboarding/hooks/useMoodBoardImage.hooks';
 import CardImage from '@/shared/components/card/cardImage/CardImage';
+import SkeletonCardImage from '@/shared/components/card/cardImage/SkeletonCardImage';
 
 interface MoodBoardProps {
   selectedImages: number[];
@@ -34,17 +37,34 @@ const MoodBoard = ({ selectedImages, onImageSelect }: MoodBoardProps) => {
     return index !== -1 ? index + 1 : 0;
   };
 
-  // 이미지 API 호출
   const { data, isPending, isError } = useMoodBoardImage(
     MOOD_BOARD_CONSTANTS.DEFAULT_LIMIT
   );
-
-  // 로딩/에러 처리
-  if (isPending) return <div>이미지 불러오는 중...</div>;
-  if (isError) return <div>이미지 불러오기 실패</div>;
-
-  // 받아온 이미지 데이터
   const images = data?.data?.moodBoardResponseList || [];
+
+  // 3초간만 스켈레톤 보여주기
+  const [showSkeleton, setShowSkeleton] = useState(true);
+  useEffect(() => {
+    const timer = setTimeout(() => setShowSkeleton(false), 3000);
+    return () => clearTimeout(timer);
+  }, []);
+
+  if (isPending || images.length === 0 || showSkeleton) {
+    return (
+      <div className={styles.container}>
+        <div className={styles.gridbox}>
+          {Array.from(
+            { length: MOOD_BOARD_CONSTANTS.DEFAULT_LIMIT },
+            (_, idx) => (
+              <SkeletonCardImage key={idx} />
+            )
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  if (isError) return <div>이미지 불러오기 실패</div>;
 
   return (
     <div className={styles.container}>

--- a/src/shared/apis/axiosInstance.ts
+++ b/src/shared/apis/axiosInstance.ts
@@ -1,7 +1,9 @@
 import axios, { AxiosError } from 'axios';
+import { useNavigate } from 'react-router-dom';
 import { ERROR_CODES } from '../constants/apiErrorCode';
 import type { AxiosRequestConfig } from 'axios';
 import type { BaseResponse } from '../types/apis';
+import { ROUTES } from '@/routes/paths';
 
 const axiosInstance = axios.create({
   baseURL: import.meta.env.VITE_API_BASE_URL,
@@ -69,6 +71,8 @@ axiosInstance.interceptors.response.use(
       } catch (refreshError) {
         console.error('[axiosInstance] 토큰 재발급 실패:', refreshError);
         alert('세션이 만료되었습니다. 다시 로그인해주세요.');
+        const navigate = useNavigate();
+        navigate(ROUTES.LOGIN);
         return Promise.reject(refreshError);
       }
     }

--- a/src/shared/apis/axiosInstance.ts
+++ b/src/shared/apis/axiosInstance.ts
@@ -70,7 +70,8 @@ axiosInstance.interceptors.response.use(
       } catch (refreshError) {
         console.error('[axiosInstance] 토큰 재발급 실패:', refreshError);
         alert('세션이 만료되었습니다. 다시 로그인해주세요.');
-        window.location.href = ROUTES.LOGIN;
+        // 인터셉터에서는 직접 네비게이션하지 않고 에러를 던짐
+        // 컴포넌트에서 에러를 처리하여 네비게이션 처리
         return Promise.reject(refreshError);
       }
     }

--- a/src/shared/apis/axiosInstance.ts
+++ b/src/shared/apis/axiosInstance.ts
@@ -2,7 +2,6 @@ import axios, { AxiosError } from 'axios';
 import { ERROR_CODES } from '../constants/apiErrorCode';
 import type { AxiosRequestConfig } from 'axios';
 import type { BaseResponse } from '../types/apis';
-import { ROUTES } from '@/routes/paths';
 
 const axiosInstance = axios.create({
   baseURL: import.meta.env.VITE_API_BASE_URL,

--- a/src/shared/apis/axiosInstance.ts
+++ b/src/shared/apis/axiosInstance.ts
@@ -71,8 +71,7 @@ axiosInstance.interceptors.response.use(
       } catch (refreshError) {
         console.error('[axiosInstance] 토큰 재발급 실패:', refreshError);
         alert('세션이 만료되었습니다. 다시 로그인해주세요.');
-        const navigate = useNavigate();
-        navigate(ROUTES.LOGIN);
+        window.location.href = ROUTES.LOGIN;
         return Promise.reject(refreshError);
       }
     }

--- a/src/shared/apis/axiosInstance.ts
+++ b/src/shared/apis/axiosInstance.ts
@@ -11,20 +11,27 @@ const axiosInstance = axios.create({
   withCredentials: true,
 });
 
+// 인증 제외 API 경로 (Authorization 헤더 제거 대상)
+const EXCLUDE_AUTH_URLS = ['/oauth/kakao/callback'];
+
 // 요청 시 accessToken 자동 삽입
 axiosInstance.interceptors.request.use((config) => {
   const accessToken = localStorage.getItem('accessToken');
-  if (accessToken) {
-    // console.log('[axiosInstance] 요청에 accessToken 추가됨');
+
+  // accessToken을 제외해야 하는 요청인지 확인
+  const isExcluded = EXCLUDE_AUTH_URLS.includes(config.url ?? '');
+
+  if (!isExcluded && accessToken) {
     config.headers.Authorization = `Bearer ${accessToken}`;
+    // console.log('[axiosInstance] 요청에 accessToken 추가됨');
   }
+
   return config;
 });
 
 // 응답 시 accessToken 만료 에러 감지 및 재발급 처리
 axiosInstance.interceptors.response.use(
   (response) => response,
-
   async (error: AxiosError<BaseResponse<null>>) => {
     const originalRequest = error.config as AxiosRequestConfig & {
       _retry?: boolean;
@@ -32,6 +39,7 @@ axiosInstance.interceptors.response.use(
 
     console.error('[axiosInstance] 응답 에러 발생:', error.response?.data);
 
+    // accessToken 만료 에러 처리
     if (
       error?.response?.data?.code === ERROR_CODES.ACCESS_TOKEN_EXPIRED &&
       !originalRequest._retry
@@ -39,33 +47,28 @@ axiosInstance.interceptors.response.use(
       originalRequest._retry = true;
 
       try {
-        // 만료된 액세스토큰 빼고 리프레시 토큰 쿠키로 재발급 요청
         const res = await axios.post(
           `${import.meta.env.VITE_API_BASE_URL}/reissue`,
           null,
           {
             withCredentials: true,
-            // Authorization 헤더 아예 제거해서 만료 토큰 보내지 X
-            headers: {},
+            headers: {}, // Authorization 헤더 제거
           }
         );
 
         const newAccessToken = res.headers['access-token'];
         if (!newAccessToken) throw new Error('새 액세스 토큰이 없습니다.');
 
-        // console.log('[axiosInstance] 액세스 토큰 재발급 성공:', newAccessToken);
         localStorage.setItem('accessToken', newAccessToken);
 
-        // 새로운 액세스 토큰 넣어서 원래 요청 재시도
         if (originalRequest.headers) {
           originalRequest.headers.Authorization = `Bearer ${newAccessToken}`;
         }
-        return axiosInstance(originalRequest);
+
+        return axiosInstance(originalRequest); // 원래 요청 재시도
       } catch (refreshError) {
         console.error('[axiosInstance] 토큰 재발급 실패:', refreshError);
         alert('세션이 만료되었습니다. 다시 로그인해주세요.');
-        // 인터셉터에서는 직접 네비게이션하지 않고 에러를 던짐
-        // 컴포넌트에서 에러를 처리하여 네비게이션 처리
         return Promise.reject(refreshError);
       }
     }

--- a/src/shared/apis/axiosInstance.ts
+++ b/src/shared/apis/axiosInstance.ts
@@ -1,5 +1,4 @@
 import axios, { AxiosError } from 'axios';
-import { useNavigate } from 'react-router-dom';
 import { ERROR_CODES } from '../constants/apiErrorCode';
 import type { AxiosRequestConfig } from 'axios';
 import type { BaseResponse } from '../types/apis';

--- a/src/shared/components/card/cardImage/CardImage.css.ts
+++ b/src/shared/components/card/cardImage/CardImage.css.ts
@@ -1,7 +1,11 @@
-import { style } from '@vanilla-extract/css';
+import { keyframes, style } from '@vanilla-extract/css';
 import { recipe } from '@vanilla-extract/recipes';
 import { fontStyle } from '@/shared/styles/fontStyle';
 import { colorVars } from '@/shared/styles/tokens/color.css';
+const shimmer = keyframes({
+  '0%': { transform: 'translateX(-100%)' },
+  '100%': { transform: 'translateX(100%)' },
+});
 
 export const cardcontainer = recipe({
   base: {
@@ -30,7 +34,7 @@ export const cardcontainer = recipe({
   },
   variants: {
     state: {
-      default: {},
+      default: { backgroundColor: colorVars.color.gray100 },
       pressed: {
         outline: 'none',
         selectors: {
@@ -114,6 +118,29 @@ export const checkbox = recipe({
       disabled: {
         display: 'none',
       },
+    },
+  },
+});
+
+export const skeletonCardImg = style({
+  width: '100%',
+  height: '100%',
+  borderRadius: '12px',
+  backgroundColor: colorVars.color.gray100,
+  position: 'relative',
+  overflow: 'hidden',
+
+  selectors: {
+    '&::after': {
+      content: '""',
+      position: 'absolute',
+      top: 0,
+      left: 0,
+      height: '100%',
+      width: '60%',
+      background:
+        'linear-gradient(90deg, transparent, rgba(255,255,255,0.4), transparent)',
+      animation: `${shimmer} 1s infinite`,
     },
   },
 });

--- a/src/shared/components/card/cardImage/SkeletonCardImage.tsx
+++ b/src/shared/components/card/cardImage/SkeletonCardImage.tsx
@@ -1,0 +1,11 @@
+import * as styles from './CardImage.css.ts';
+
+const SkeletonCard = () => {
+  return (
+    <div className={styles.cardcontainer({ state: 'default' })}>
+      <div className={styles.skeletonCardImg} />
+    </div>
+  );
+};
+
+export default SkeletonCard;


### PR DESCRIPTION
## 📌 Summary

- close #217 
- close #202 

OAuth 콜백 경로(/oauth/kakao/callback)에 불필요한 Authorization 헤더 자동 삽입 문제를 수정하고, 
만료된 토큰이 콜백 요청에 붙어 인증 실패하던 문제를 해결했습니다. 

+ 무드보드 Skeleton UI를 적용했습니다.


## 📄 Tasks

- [x] axios 요청 인터셉터에 인증 제외 URL 목록 추가 및 처리 로직 구현
- [x] oauth/kakao/callback 요청 시 Authorization 헤더 삽입 제외 처리
- [x] 기존 토큰 재발급 로직 유지 및 에러 처리 개선

**변경 전**
1. 모든 API 요청에 대해 localStorage에 accessToken이 있으면 무조건 Authorization 헤더가 삽입됨
2. OAuth 콜백 요청에도 Authorization 헤더가 포함되어 카카오 인증 서버에서 오류 발생 가능
3. 시크릿 탭에서는 localStorage가 비어 있어 문제가 없었으나, 일반 탭에서는 만료된 토큰이 남아 있어 인증 실패 발생

**변경 후**
1. OAuth 콜백 경로(/oauth/kakao/callback)를 예외 처리하여 Authorization 헤더 삽입을 막음
2. 이로 인해 OAuth 콜백 요청 시 인증 서버와 정상 통신 가능
3. 시크릿 탭과 일반 탭 모두 로그인 과정이 안정적으로 작동


## 🔍 To Reviewer

- 인터셉터가 콜백 경로에 Authorization 헤더를 제외하는지 확인 부탁드립니다.
- 토큰 만료 시 자동 재발급이 정상 동작하는지 확인 부탁드립니다.
- 로그인 흐름 및 OAuth 콜백 정상 작동 여부 검증 부탁드립니다.


## 📸 Screenshot
