### PR TITLE
[feat] zustand 사용자 정보 동기화 훅 생성 및 bottom sheet 연결

### DIFF
--- a/src/pages/onboarding/components/steps/step2/Step2FloorPlan.tsx
+++ b/src/pages/onboarding/components/steps/step2/Step2FloorPlan.tsx
@@ -45,11 +45,6 @@ const Step2FloorPlan = ({ context, onNext }: Step2FloorPlanProps) => {
     return <Loading text="Floor Plan 데이터를 불러오는 중..." />;
   }
 
-  // 에러 상태 처리
-  if (isError) {
-    return null;
-  }
-
   // 데이터가 없는 경우
   if (!floorPlanList || floorPlanList.length === 0) {
     return (

--- a/src/routes/ProtectedRoute.tsx
+++ b/src/routes/ProtectedRoute.tsx
@@ -5,7 +5,7 @@
 // createBrowserRouter 객체 트리에서 중간 노드로 사용해
 // 하위(children) 라우트를 한 번에 보호할 수 있습니다.
 import { Navigate, Outlet } from 'react-router-dom';
-import { useUserStore } from '@/store/useUserStore';
+import { useUserSync } from '@/shared/hooks/useUserSync';
 import { ROUTES } from '@/routes/paths';
 
 interface ProtectedRouteProps {
@@ -17,10 +17,12 @@ function ProtectedRoute({
   isAuthenticated,
   redirectTo = ROUTES.LOGIN,
 }: ProtectedRouteProps) {
-  // zustand에서 accessToken 가져오기(로그인 상태 확인)
-  const accessToken = useUserStore((state) => state.accessToken);
-  // 인증 여부: prop이 있으면 우선 사용, 없으면 accessToken 존재 여부로 판단
-  const authenticated = isAuthenticated ?? !!accessToken;
+  // 사용자 정보 동기화 및 로그인 상태 확인
+  const { isLoggedIn } = useUserSync();
+
+  // 인증 여부: prop이 있으면 우선 사용, 없으면 useUserSync에서 가져온 로그인 상태로 판단
+  const authenticated = isAuthenticated ?? isLoggedIn;
+
   // 인증되지 않은 경우 즉시 리다이렉트
   if (!authenticated) {
     return <Navigate to={redirectTo} replace />;

--- a/src/shared/components/bottomSheet/noMatchSheet/NoMatchSheet.tsx
+++ b/src/shared/components/bottomSheet/noMatchSheet/NoMatchSheet.tsx
@@ -5,12 +5,12 @@ import TextField from '@components/textField/TextField';
 import CtaButton from '@components/button/ctaButton/CtaButton';
 import * as styles from './NoMatchSheet.css';
 import { useBottomSheetDrag } from '@/shared/hooks/useBottomSheetDrag';
+import { useUserStore } from '@/store/useUserStore';
 
 interface NoMatchSheetProps {
   isOpen: boolean;
   onClose: () => void;
   onSubmit: (region: string, address: string) => void;
-  user?: string;
   onExited?: () => void; // 애니메이션 끝나면 호출(unmount)
 }
 
@@ -18,10 +18,10 @@ const NoMatchSheet = ({
   isOpen,
   onClose,
   onSubmit,
-  user,
   onExited,
 }: NoMatchSheetProps) => {
-  const displayName = user?.trim() || '사용자';
+  // zustand에서 userName 가져오기
+  const userName = useUserStore((state) => state.userName);
 
   const [region, setRegion] = useState('');
   const [address, setAddress] = useState('');
@@ -71,7 +71,8 @@ const NoMatchSheet = ({
             </span>
             <span className={styles.descriptionText}>
               아래 버튼을 통해 주소를 공유해주시면, <br />
-              {displayName}님의 스타일링을 위해 빠르게 반영해드릴게요!
+              {userName ? `${userName}님의` : '사용자님의'} 스타일링을 위해
+              빠르게 반영해드릴게요!
             </span>
           </div>
           <div className={styles.fieldWrapper}>

--- a/src/shared/hooks/useUserSync.ts
+++ b/src/shared/hooks/useUserSync.ts
@@ -1,0 +1,29 @@
+import { useEffect } from 'react';
+import { useUserStore } from '@/store/useUserStore';
+import { useMyPageUser } from '@/pages/mypage/hooks/useMypage';
+
+/**
+ * 사용자 정보를 전역 상태와 동기화하는 훅
+ * 로그인된 사용자의 정보를 API에서 가져와서 전역 상태에 저장
+ */
+export const useUserSync = () => {
+  const accessToken = useUserStore((state) => state.accessToken);
+  const setUserName = useUserStore((state) => state.setUserName);
+  const isLoggedIn = !!accessToken;
+
+  const { data: userData } = useMyPageUser({
+    enabled: isLoggedIn,
+  });
+
+  // API에서 사용자 정보를 가져올 때 전역 상태에 userName 동기화
+  useEffect(() => {
+    if (userData?.name) {
+      setUserName(userData.name);
+    }
+  }, [userData?.name, setUserName]);
+
+  return {
+    userData,
+    isLoggedIn,
+  };
+};


### PR DESCRIPTION
## 📌 Summary

- close #230 

## 📄 Tasks

- 기존 zustand로 사용자 이름을 관리했던 내용을 다른 페이지에서 불러오기 위해서 정보 동기화 훅을 생성
- accessToken으로 로그인 여부 판별하고, 로그인 상태일 때만 유저 데이터를 가져오기 위해 isLoggedIn 변수 정의. (기존 protectesRoute.ts에 있던 내용)

- useMyPageUser를 통해 마이페이지 유저 정보 API를 불러오고
- userData.name이 존재할 경우, zustand 스토어 + localStorage에 유저 이름을 저장  → 컴포넌트에서는 유저 정보, 로그인 상태를 가져와 사용 가능

`const userName = useUserStore((state) => state.userName);`

## 🔍 To Reviewer
- 마이페이지나 다른 부분까지 건들이면 너무 커질 것 같아서 bottom sheet에만 적용했습니다.

## 📸 Screenshot

<img width="399" height="438" alt="스크린샷 2025-07-18 오전 4 23 12" src="https://github.com/user-attachments/assets/422b27de-a887-4d9a-9cca-2660fc105e58" />