### PR TITLE
[refactor] 무드보드 이미지 prefetching 시점 변경

### DIFF
--- a/src/pages/onboarding/components/steps/step2/FloorPlan.tsx
+++ b/src/pages/onboarding/components/steps/step2/FloorPlan.tsx
@@ -9,7 +9,6 @@ import NoMatchSheet from '@/shared/components/bottomSheet/noMatchSheet/NoMatchSh
 import FlipSheet from '@/shared/components/bottomSheet/flipSheet/FlipSheet';
 import { useToast } from '@/shared/components/toast/useToast';
 import { useBottomSheetAddress } from '@/pages/onboarding/hooks/useBottomSheetAddress';
-import { usePrefetchMoodBoard } from '@/pages/onboarding/hooks/useStep3Api.hooks';
 
 interface FloorPlanProps {
   floorPlanList: FloorPlanList[];
@@ -34,7 +33,6 @@ const FloorPlan = ({
   const [openSheet, setOpenSheet] = useState<OpenSheetKey>(null);
   const { notify } = useToast();
   const { mutate: postAddress } = useBottomSheetAddress();
-  const { prefetchMoodBoard } = usePrefetchMoodBoard();
 
   // toast를 NoMatchSheet의 상위 컴포넌트인 FloorPlan에서 호출해야
   // toast의 option에 준 autoClose가 정상적으로 적용됨
@@ -53,11 +51,6 @@ const FloorPlan = ({
 
   const handleImageClick = (id: number) => {
     onImageSelect(id);
-
-    // 무드보드 이미지 사전로딩
-    prefetchMoodBoard();
-    console.log('prefetch 완료');
-
     handleOpenSheet('flip');
   };
 

--- a/src/pages/onboarding/hooks/useStep2FloorPlan.hooks.ts
+++ b/src/pages/onboarding/hooks/useStep2FloorPlan.hooks.ts
@@ -2,6 +2,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import { useFloorPlanApi } from './useStep2Api.hooks';
 import { useFunnelStore } from '../stores/useFunnelStore';
+import { usePrefetchMoodBoard } from './useStep3Api.hooks';
 import type { CompletedFloorPlan, ImageGenerateSteps } from '../types/funnel';
 
 // interface SelectedFloorPlanTypes {
@@ -27,6 +28,11 @@ export const useStep2FloorPlan = (
     step2.floorPlanId || null
   );
   const [isMirror, setIsMirror] = useState<boolean>(step2.isMirror || false);
+
+  // 무드보드 이미지 사전로딩
+  const { prefetchMoodBoard } = usePrefetchMoodBoard();
+  prefetchMoodBoard();
+  console.log('prefetch 완료');
 
   // 컴포넌트 마운트 시 현재 스텝 설정
   useEffect(() => {


### PR DESCRIPTION
## 📌 Summary

- close #239 

> 관련 있는 Issue를 태그해주세요. (e.g. > - #1)

_해당 PR에 대한 작업 내용을 요약하여 작성해주세요._

## 📄 Tasks

- 무드보드 이미지 prefetching 시점을 FloorPlan 이미지 탭 시점에서 Step2 페이지 마운트 시점으로 변경했습니다.

_해당 PR에 수행한 작업을 작성해주세요._

## 🔍 To Reviewer

-

_리뷰어에게 요청하는 내용을 작성해주세요._

## 📸 Screenshot

-

_작업한 내용에 대한 스크린샷을 첨부해주세요._
