### PR TITLE
[feat] 이미지 생성 전역 상태 관리 훅 생성 후 progress bar 연결

### DIFF
--- a/src/pages/generate/components/loading/LoadingPage.tsx
+++ b/src/pages/generate/components/loading/LoadingPage.tsx
@@ -8,6 +8,7 @@ import {
   useHateStackMutation,
   useGenerateImageApi,
 } from '../../hooks/useGenerate';
+import { useGenerateStore } from '../../stores/useGenerateStore';
 import type { GenerateImageRequest } from '../../types/GenerateType';
 import LikeButton from '@/shared/components/button/likeButton/LikeButton';
 import DislikeButton from '@/shared/components/button/likeButton/DislikeButton';
@@ -20,6 +21,7 @@ const LoadingPage = () => {
   const location = useLocation();
   const navigate = useNavigate();
   const { handleError } = useErrorHandler('generate');
+  const { resetGenerate } = useGenerateStore();
 
   // TODO: location.state의 타입 검증 로직 개선 필요(런타임 오류 방지)
   const requestData: GenerateImageRequest | null =
@@ -31,6 +33,9 @@ const LoadingPage = () => {
     if (requestData) {
       console.log('이미지 생성 요청 시작:', requestData);
 
+      // API 요청 시작 시 store 리셋
+      resetGenerate();
+
       // 이미 진행 중인 요청이 있으면 중복 실행 방지
       if (generateImageRequest.isIdle) {
         generateImageRequest.mutate(requestData);
@@ -41,7 +46,7 @@ const LoadingPage = () => {
       console.log('requestData is null, redirect to /onboarding');
       navigate(ROUTES.ONBOARDING);
     }
-  }, [requestData, navigate]); // generateImageRequest 의존성 제거
+  }, [requestData, navigate, resetGenerate]); // resetGenerate 의존성 추가
   // ... 이미지 생성 api 코드 끝
 
   const [currentPage, setCurrentPage] = useState(0);

--- a/src/pages/generate/hooks/useGenerate.ts
+++ b/src/pages/generate/hooks/useGenerate.ts
@@ -10,6 +10,7 @@ import {
   postLikeStack,
   postPreference,
 } from '../apis/generate';
+import { useGenerateStore } from '../stores/useGenerateStore';
 import type { GenerateImageRequest } from '../types/GenerateType';
 import { QUERY_KEY } from '@/shared/constants/queryKey';
 import { queryClient } from '@/shared/apis/queryClient';
@@ -72,19 +73,30 @@ export const useGenerateImageApi = () => {
   // const queryClient = useQueryClient();
   const navigate = useNavigate();
   const { resetFunnel } = useFunnelStore();
+  const { setApiCompleted } = useGenerateStore();
 
   const generateImageRequest = useMutation({
-    mutationFn: (userInfo: GenerateImageRequest) => generateImage(userInfo),
+    mutationFn: (userInfo: GenerateImageRequest) => {
+      console.log('🚀 이미지 제작 시작:', new Date().toLocaleTimeString());
+      return generateImage(userInfo);
+    },
     onSuccess: (data) => {
-      console.log('이미지 생성 요청 결과: ', data);
-      // 성공 시 자동으로 ResultPage로 이동
-      navigate('/generate/result', {
-        state: {
-          result: data,
-        },
-        replace: true,
-      });
-      resetFunnel(); // 성공 시에도 초기화
+      console.log('✅ 이미지 제작 완료:', new Date().toLocaleTimeString());
+
+      // API 완료 신호를 Zustand store에 저장
+      setApiCompleted(true);
+
+      // 약간의 지연 후 navigate (프로그레스 바가 100% 되는 시간 고려)
+      setTimeout(() => {
+        navigate('/generate/result', {
+          state: {
+            result: data,
+          },
+          replace: true,
+        });
+        resetFunnel(); // 성공 시에도 초기화
+      }, 2000); // 2초 지연 (프로그레스 바 완료 시간)
+
       queryClient.invalidateQueries({ queryKey: ['generateImage'] });
     },
   });

--- a/src/pages/generate/stores/useGenerateStore.ts
+++ b/src/pages/generate/stores/useGenerateStore.ts
@@ -1,0 +1,13 @@
+import { create } from 'zustand';
+
+interface GenerateState {
+  isApiCompleted: boolean;
+  setApiCompleted: (completed: boolean) => void;
+  resetGenerate: () => void;
+}
+
+export const useGenerateStore = create<GenerateState>((set) => ({
+  isApiCompleted: false,
+  setApiCompleted: (completed: boolean) => set({ isApiCompleted: completed }),
+  resetGenerate: () => set({ isApiCompleted: false }),
+}));


### PR DESCRIPTION
## 📌 Summary

- close #263 

이미지 생성 완료 타이밍과 progressBar 생성 타이밍이 달라서 최대한 타이밍이 맞출 수 있게 진행했습니다. 

## 📄 Tasks

#### Zustand Store 추가 (useGenerateStore.ts)
- API 완료 상태를 전역적으로 관리하는 store 생성
- isApiCompleted: API 완료 여부 상태
- setApiCompleted: API 완료 상태 변경 함수
- resetGenerate: 상태 초기화 함수

#### ProgressBar 컴포넌트 개선
- Zustand store의 isApiCompleted 상태 구독
- API 완료 신호 감지 시 90%에서 100%로 빠른 진행
- 프로그레스 바 100% 완료 시점 콘솔 로그 추가
- fallback 타이머 유지 (API 지연 시 대비)

#### API 훅 수정 (useGenerate.ts)
- API 요청 시작/완료 시점 콘솔 로그 추가
- API 완료 시 setApiCompleted(true) 호출
- navigate 실행을 2초 지연 (프로그레스 바 완료 대기)

#### LoadingPage 연동
-  API 요청 시작 시 store 상태 리셋
- 의존성 배열에 resetGenerate 추가


## 🔍 To Reviewer

-


## 📸 Screenshot

-

