### PR TITLE
[refactor] 로그인/회원가입 API 구조 일관성 개선 

### DIFF
--- a/src/pages/login/KakaoCallback.tsx
+++ b/src/pages/login/KakaoCallback.tsx
@@ -17,6 +17,7 @@ import { useEffect } from 'react';
 import { useKakaoLogin } from './hooks/useKakaoLogin';
 import Loading from '@/shared/components/loading/Loading';
 import { useErrorHandler } from '@/shared/hooks/useErrorHandler';
+import { RESPONSE_MESSAGE, HTTP_STATUS } from '@/shared/constants/response';
 
 const KakaoCallback = () => {
   // 오류 핸들러
@@ -36,7 +37,9 @@ const KakaoCallback = () => {
     } else {
       console.error('[KakaoCallback] 인가 코드가 없습니다.');
       handleError(
-        new Error('인가 코드가 없습니다'),
+        new Error(
+          RESPONSE_MESSAGE[HTTP_STATUS.BAD_REQUEST] || '인가 코드가 없습니다'
+        ),
         'auth',
         '로그인 처리 중 오류가 발생했습니다.'
       );

--- a/src/pages/login/apis/kakaoLogin.ts
+++ b/src/pages/login/apis/kakaoLogin.ts
@@ -17,6 +17,7 @@
 import axiosInstance from '@shared/apis/axiosInstance';
 import type { BaseResponse } from '@shared/types/apis';
 import type { KakaoLoginResponse, LoginApiResponse } from '../types/auth';
+import { RESPONSE_MESSAGE, HTTP_STATUS } from '@/shared/constants/response';
 
 export const getKakaoLogin = async (
   code: string
@@ -40,7 +41,9 @@ export const getKakaoLogin = async (
       '[kakaoLogin] 사용 가능한 헤더:',
       Object.keys(response.headers)
     );
-    throw new Error('액세스 토큰이 없습니다.');
+    throw new Error(
+      RESPONSE_MESSAGE[HTTP_STATUS.UNAUTHORIZED] || '액세스 토큰이 없습니다.'
+    );
   }
 
   return {

--- a/src/pages/login/apis/logout.ts
+++ b/src/pages/login/apis/logout.ts
@@ -12,21 +12,12 @@
  * console.log(result.message); // "로그아웃되었습니다"
  * ```
  */
-import axiosInstance from '@shared/apis/axiosInstance';
 import type { LogoutResponse } from '../types/auth';
+import { HTTPMethod, request } from '@/shared/apis/request';
 
-// AxiosInstance를 직접 사용해서 서버에 로그아웃 요청
 export const postLogout = async (): Promise<LogoutResponse> => {
-  // console.log('[logout] 로그아웃 요청 시작');
-
-  try {
-    const response = await axiosInstance.post<LogoutResponse>('/logout');
-
-    // console.log('[logout] 응답 성공:', response.data);
-    return response.data;
-  } catch (error: any) {
-    console.error('[logout] 요청 실패:', error.response?.data);
-    console.error('[logout] 상태 코드:', error.response?.status);
-    throw error;
-  }
+  return request({
+    method: HTTPMethod.POST,
+    url: '/logout',
+  });
 };

--- a/src/pages/login/components/TokenRefreshTest.tsx
+++ b/src/pages/login/components/TokenRefreshTest.tsx
@@ -1,16 +1,18 @@
 // 엑세스 토큰 만료 및 리프레시 토큰 재발급 테스트용 컴포넌트
 
-import axiosInstance from '@shared/apis/axiosInstance';
+import { HTTPMethod, request } from '@/shared/apis/request';
 
 const TokenRefreshTest = () => {
   const getTokenTest = async () => {
     try {
-      const res = await axiosInstance.get('/access-test');
+      const res = await request({
+        method: HTTPMethod.GET,
+        url: '/access-test',
+      });
 
       console.log('API 응답:', res);
     } catch (err: any) {
-      const message = err?.response?.data?.message || err.message;
-      console.error('API 요청 에러:', err, message);
+      console.error('API 요청 에러:', err);
     }
   };
 

--- a/src/pages/signup/apis/signup.ts
+++ b/src/pages/signup/apis/signup.ts
@@ -1,19 +1,13 @@
 /* 회원가입 API 함수 */
-import axiosInstance from '@shared/apis/axiosInstance';
 import type { SignupRequest, SignupResponse } from '../types/apis/signup';
+import { HTTPMethod, request } from '@/shared/apis/request';
 
 export const patchSignup = async (
   data: SignupRequest
 ): Promise<SignupResponse> => {
-  try {
-    const response = await axiosInstance.patch<SignupResponse>(
-      '/api/v1/sign-up',
-      data
-    );
-    return response.data;
-  } catch (error: any) {
-    console.error('[signup] 요청 실패:', error.response?.data);
-    console.error('[signup] 상태 코드:', error.response?.status);
-    throw error;
-  }
+  return request({
+    method: HTTPMethod.PATCH,
+    url: '/api/v1/sign-up',
+    body: data as unknown as Record<string, unknown>,
+  });
 };

--- a/src/shared/apis/axiosInstance.ts
+++ b/src/shared/apis/axiosInstance.ts
@@ -1,5 +1,6 @@
 import axios, { AxiosError } from 'axios';
 import { ERROR_CODES } from '../constants/apiErrorCode';
+import { RESPONSE_MESSAGE, HTTP_STATUS } from '../constants/response';
 import type { AxiosRequestConfig } from 'axios';
 import type { BaseResponse } from '../types/apis';
 
@@ -57,7 +58,12 @@ axiosInstance.interceptors.response.use(
         );
 
         const newAccessToken = res.headers['access-token'];
-        if (!newAccessToken) throw new Error('새 액세스 토큰이 없습니다.');
+        if (!newAccessToken) {
+          throw new Error(
+            RESPONSE_MESSAGE[HTTP_STATUS.UNAUTHORIZED] ||
+              '새 액세스 토큰이 없습니다.'
+          );
+        }
 
         localStorage.setItem('accessToken', newAccessToken);
 


### PR DESCRIPTION
## 📌 Summary

- close #271 

TanStack Query 자체 문제는 없었고, API 호출 계층의 일관성이 깨져 있던 부분을 정리했습니다.

request.ts 래퍼를 기준으로 API 함수 패턴을 통일하고, response.ts 상수로 에러 메시지를 표준화했습니다.
또 인증/토큰 로직이 필요한 일부 예외(kakaoLogin)는 기존 흐름을 유지하되 메시지 표준화만 반영해놓았습니다!

## 📄 Tasks

### 1. API 호출 방식 일관화
- 모든 axios 직접 호출 제거
- 공통 래퍼 request.ts 사용으로 통일
- 요청 body 타입은 data as unknown as Record<string, unknown> 적용

### 2. 에러 메시지 표준화

- 하드코딩된 에러/상태 메시지 제거
- src/shared/constants/response.ts 내 상수(HTTP_STATUS, RESPONSE_MESSAGE)로 통일

### 3. 파일 변경사항

`src/pages/signup/apis/signup.ts`
- axios → request.ts 변경
- body 타입 단언 추가

`src/pages/login/apis/logout.ts`, `src/pages/login/components/TokenRefreshTest.tsx`
- axios → request.ts 변경

`src/pages/login/apis/kakaoLogin.ts`
- axios → request.ts 변경
- 헤더 토큰 추출 로직은 기존 유지
- 에러 메시지 → response.ts 상수 사용

`src/pages/login/KakaoCallback.tsx`, `src/shared/apis/axiosInstance.ts`
- 하드코딩 메시지 제거 → response.ts 상수 사용

`src/pages/onboarding/apis/MoodBoardImage.ts` → 미반영

퍼널 구조 내의 무드보드 스텝에서 사용된 이미지 api 사용 구조에도 같은 api 로직이 사용되어 리팩토링이 필요하나, 
지성님의 폴더구조 및 네이밍 변경사항이 아직 반영되지 않았으므로 이 파일만 예외적으로 추후에 머지된 후 반영하도록 하겠습니다.

<br/>

**TanStack Query → 쿼리 키/캐시 정책/훅 사용 방식에는 변경 사항 없습니다!**


## 🔍 To Reviewer

데이터 패칭 계층의 관심사 분리 및 일관성 확보를 위해 진행한 리팩토링으로, 추가적인 기능이나 UX 상의 변화는 없습니다.

<br/>

request.ts는 내부에서 `AxiosResponse<BaseResponse<T>>`의 `response.data.data`만 추출해 반환합니다. 
따라서 호출부에서는 기존의 `response.data`(또는 `response.data.data`) 접근을 제거하고, request의 반환값 자체를 바로 사용하도록 변경했습니다. 예외적으로 응답 헤더/상태 코드가 필요한 케이스(kakaoLogin)는 기존처럼 axiosInstance를 사용하고, 에러 메시지만 response.ts 상수로 표준화했습니다.

<br/>

리팩토링 사항 반영 후 확인해보아야 할 흐름은 아래과 같습니다. 
제가 여러 차례 돌려보면서 테스트해보겠지만 만약 이 단계 중 문제가 발생한다면 말씀해주세요!
```
- 카카오 로그인 플로우: 콜백 → 토큰 저장 → 리다이렉트 정상 동작
- 회원가입 PATCH: 정상 응답/에러 시 콘솔 메시지 표준화 확인
- 로그아웃 POST: 세션 종료 및 상태 초기화 확인
- 토큰 만료 시 재발급: axiosInstance 인터셉터가 정상 재시도하는지 확인
```

<br/>

>**[API 레이어 분산으로 인한 낮은 응집도 해결]**
기존에는 API 함수(apis/)와 Query hooks(hooks/queries)가 분리되어 코드들이 두 파일에 분산되어 있었습니다. 하지만 API와 쿼리 훅은 서로 밀접하게 관련된 로직이고, 따라서 한 파일에 모아둬 응집도를 높이는게 유지보수하기에 좋을 것 같아 기존에 hooks/queries에 별도로 선언해뒀떤 쿼리 훅 코드들을 apis 폴더에 API 함수들과 함께 선언했습니다.


원래 지성님의 pr이 머지가 되면 그 구조에 맞추어 한번에 이 브랜치에서 처리 후 진행하려고 했는데, 아직 반영이 되지 않아서 api 로직 일관성 개선 부분까지만 리팩토링을 했고, 회의로 컨벤션에 대해 더 정확히 논의한 이후에 이 부분에 대한 정리가 끝나면 A-2 스프린트 뷰 작업 직전에 진행하겠습니다!


## 📸 Screenshot

.
