### PR TITLE
[refactor] LoadingPage useEffect 리팩터링

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ storybook-static
 CLAUDE.md
 .taskmaster
 .cursor
+docs/
 
 dev-debug.log
 # Dependency directories

--- a/src/pages/generate/components/loading/LoadingPage.tsx
+++ b/src/pages/generate/components/loading/LoadingPage.tsx
@@ -35,7 +35,7 @@ const LoadingPage = () => {
   } | null;
   const requestData: GenerateImageRequest | null =
     state?.generateImageRequest ?? null;
-  const generateImageRequest = useGenerateImageApi();
+  const { mutate: mutateGenerateImage } = useGenerateImageApi();
 
   // 상태 폴링은 requestData가 있을 때만 시작
   useGenerateImageStatusCheck(requestData?.houseId || 0, !!requestData);
@@ -44,7 +44,7 @@ const LoadingPage = () => {
     if (!requestData) return;
 
     console.log('이미지 생성 요청 시작:', requestData);
-    generateImageRequest.mutate(requestData, {
+    mutateGenerateImage(requestData, {
       onError: (error: any) => {
         // 재요청 코드 42900 확인
         if (error?.response?.data?.code === 42900) {
@@ -55,7 +55,7 @@ const LoadingPage = () => {
         }
       },
     });
-  }, [generateImageRequest, requestData]);
+  }, [mutateGenerateImage, requestData]);
   // ... 이미지 생성 api 코드 끝
 
   const [currentPage, setCurrentPage] = useState(0);

--- a/src/pages/generate/hooks/useGenerate.ts
+++ b/src/pages/generate/hooks/useGenerate.ts
@@ -23,13 +23,22 @@ import { useGenerateStore } from '../stores/useGenerateStore';
 
 import type { GenerateImageRequest } from '@pages/generate/types/generate';
 
-export const useStackData = (page: number, options: { enabled: boolean }) => {
+export const useStackData = (
+  page: number,
+  options: {
+    enabled: boolean;
+    onSuccess?: (data: Awaited<ReturnType<typeof getStackData>>) => void;
+    onError?: (err: unknown) => void;
+  }
+) => {
   return useQuery({
     queryKey: [QUERY_KEY.GENERATE_LOADING, page],
     queryFn: () => getStackData(page),
     staleTime: 2 * 60 * 1000,
     retry: 2,
-    ...options,
+    onSuccess: options.onSuccess,
+    onError: options.onError,
+    enabled: options.enabled,
   });
 };
 


### PR DESCRIPTION
## 📌 Summary

- close #285 

- useMutation 반환 객체 대신 mutate만 구조 분해 할당하여 useEffect 의존성 을 안정화하고 중복 호출 가능성을 줄였습니다.
  - 로딩 페이지의 이미지 요청 트리거와 에러 처리 로직을 단순화하고 정리했습니다
    - 요청 가드, onError 로깅/처리 일원화, 42900 대응은 유지
  - 데이터 조회 훅(useStackData)에 성공/실패 콜백 옵션(onSuccess/onError callback)을 추가하고, 호출부에서 인덱스 초기화와 에러 처리를 훅 옵션으로 위임했습니다.

## 📄 Tasks

- API 훅 반환 객체 대신 mutate 함수만 사용하도록 변경(의존성 안정화)
- 이미지 요청 및 에러 처리 로직 개선(요청 가드 추가, 42900 대응 로깅 정리)
- useStackData에 onSuccess/onError 옵션 추가 및 호출부 반영

## 🔍 To Reviewer

- 일단 PR은 올렸는데, 저번에 공유했던 것처럼 development에서는 로그인이 안되어서 이미지 생성 테스트를 못 하였습니다
  - 그래서 이번에 테스팅 도입할 겸 단위 테스트 코드 작성 후 최대한 점검하고 merge할까 생각 중입니다

## 📸 Screenshot

- 
