### PR TITLE
[feat] 마이페이지 TitleNavbar 설정 옵션 추가

### DIFF
--- a/src/routes/paths.ts
+++ b/src/routes/paths.ts
@@ -9,6 +9,7 @@ export const ROUTES = {
   IMAGE_SETUP: '/imageSetup',
   GENERATE: '/generate',
   MYPAGE: '/mypage',
+  SETTING: '/mypage/setting',
   OAUTH: '/oauth/kakao/callback',
 } as const;
 

--- a/src/shared/components/navBar/LogoNavBar.tsx
+++ b/src/shared/components/navBar/LogoNavBar.tsx
@@ -5,8 +5,8 @@ import { ROUTES } from '@/routes/paths';
 import LogoIcon from '@shared/assets/icons/logoIcon.svg?react';
 import ProfileIcon from '@shared/assets/icons/profileIcon.svg?react';
 
-import * as btnStyles from './LoginNavBtn.css';
 import * as styles from './LogoNavBar.css';
+import * as btnStyles from './NavBtn.css';
 
 type ButtonType = 'login' | 'profile' | null;
 

--- a/src/shared/components/navBar/NavBtn.css.ts
+++ b/src/shared/components/navBar/NavBtn.css.ts
@@ -9,6 +9,7 @@ export const loginNav = style({
   color: colorVars.color.gray900,
   textDecoration: 'underline',
   textUnderlineOffset: '3px',
+  cursor: 'pointer',
 });
 
 export const settingNav = style({
@@ -16,4 +17,5 @@ export const settingNav = style({
   height: '4.8rem',
   textAlign: 'center',
   color: colorVars.color.gray700,
+  cursor: 'pointer',
 });

--- a/src/shared/components/navBar/NavBtn.css.ts
+++ b/src/shared/components/navBar/NavBtn.css.ts
@@ -3,8 +3,17 @@ import { style } from '@vanilla-extract/css';
 import { colorVars } from '@/shared/styles/tokens/color.css';
 
 export const loginNav = style({
+  width: '4.8rem',
+  height: '4.8rem',
   textAlign: 'center',
   color: colorVars.color.gray900,
   textDecoration: 'underline',
   textUnderlineOffset: '3px',
+});
+
+export const settingNav = style({
+  width: '3.2rem',
+  height: '4.8rem',
+  textAlign: 'center',
+  color: colorVars.color.gray900,
 });

--- a/src/shared/components/navBar/NavBtn.css.ts
+++ b/src/shared/components/navBar/NavBtn.css.ts
@@ -15,5 +15,5 @@ export const settingNav = style({
   width: '3.2rem',
   height: '4.8rem',
   textAlign: 'center',
-  color: colorVars.color.gray900,
+  color: colorVars.color.gray700,
 });

--- a/src/shared/components/navBar/TitleNavBar.css.ts
+++ b/src/shared/components/navBar/TitleNavBar.css.ts
@@ -45,7 +45,6 @@ export const rightdiv = style({
   display: 'flex',
   justifyContent: 'center',
   alignItems: 'center',
-  width: '8rem',
   height: '4.8rem',
   padding: '1.2rem 1.6rem',
   ...fontStyle('body_r_14'),

--- a/src/shared/components/navBar/TitleNavBar.tsx
+++ b/src/shared/components/navBar/TitleNavBar.tsx
@@ -4,20 +4,22 @@ import { ROUTES } from '@/routes/paths';
 
 import BackIcon from '@shared/assets/icons/backIcon.svg?react';
 
-import * as btnStyles from './LoginNavBtn.css';
+import * as btnStyles from './NavBtn.css';
 import * as styles from './TitleNavBar.css';
 
 interface TitleNavBarProps extends React.ComponentProps<'nav'> {
   title: string;
   isBackIcon?: boolean;
   isLoginBtn?: boolean;
+  isSettingBtn?: boolean;
   onBackClick?: () => void;
 }
 
 const TitleNavBar = ({
   title,
   isBackIcon = true,
-  isLoginBtn = true,
+  isLoginBtn = false,
+  isSettingBtn = false,
   onBackClick,
   ...props
 }: TitleNavBarProps) => {
@@ -43,6 +45,15 @@ const TitleNavBar = ({
             className={btnStyles.loginNav}
           >
             로그인
+          </button>
+        )}
+        {isSettingBtn && (
+          <button
+            type="button"
+            onClick={() => navigate(ROUTES.LOGIN)}
+            className={btnStyles.settingNav}
+          >
+            설정
           </button>
         )}
       </div>

--- a/src/shared/components/navBar/TitleNavBar.tsx
+++ b/src/shared/components/navBar/TitleNavBar.tsx
@@ -50,7 +50,7 @@ const TitleNavBar = ({
         {isSettingBtn && (
           <button
             type="button"
-            onClick={() => navigate(ROUTES.LOGIN)}
+            onClick={() => navigate(ROUTES.SETTING)}
             className={btnStyles.settingNav}
           >
             설정


### PR DESCRIPTION
## 📌 Summary

- close #297 

마이페이지 Title Navigation Bar 컴포넌트 - 설정 옵션 추가

## 📄 Tasks


TitleNavBar 컴포넌트에 설정 옵션을 추가했습니다. 해당 옵션은 마이페이지에서 사용됩니다.

제목 문자열과 뒤로 가기 버튼 표시 여부, 로그인 버튼 표시 여부, 설정 버튼 표시 여부 `(new!)` 는 해당 navbar를 사용하는 부모 컴포넌트에서 props로 관리합니다. 설정 버튼 클릭 시 `/mypage/setting` 페이지로 navigate 됩니다.



## 🔍 To Reviewer


```tsx
<TitleNavBar title={"제목"} isBackIcon={true}  isLoginBtn={false} isSettingBtn={true}/>
```

설정 옵션은 `isSettingBtn` 값으로 관리합니다.

isBackIcon, isLoginBtn, isSettingBtn의 기본값은 false로 설정해놓았습니다. 
각 옵션 값이 필요하지 않은 경우 props 생략이 가능하고, 필요한 경우에 위와 같이 true값을 props로 넘겨주면 사용 가능합니다. 

<br/>

<img width="647" height="346" alt="스크린샷 2025-09-17 오전 1 40 03" src="https://github.com/user-attachments/assets/6eba35ea-5e1a-42f9-bdde-dee663c320f9" />

<br/>
<br/>

'설정' 버튼 클릭 시 설정 페이지로 이동하기 위해 위와 같이 Routes Path 상수값에
`SETTING: '/mypage/setting',`을 추가해놓은 상황입니다. 

추후 설정 페이지 라우팅하실 때 참고하시면 될 것 같습니다! @sndks 

## 📸 Screenshot

<img width="510" alt="스크린샷 2025-09-17 오전 1 30 54" src="https://github.com/user-attachments/assets/6e8f31fe-dbe3-468a-8360-41aabc3bf1ba" />


<br/>


