### PR TITLE
[Fix] 브라우저 캐싱 활성화 시 발생하는 S3 이미지 CORS 오류 해결

### DIFF
--- a/src/pages/generate/pages/result/components/GeneratedImg.css.ts
+++ b/src/pages/generate/pages/result/components/GeneratedImg.css.ts
@@ -110,6 +110,7 @@ export const imgAreaBlurred = recipe({
     objectFit: 'cover',
     objectPosition: 'center',
     filter: 'blur(15px)',
+    backgroundColor: 'lightgray',
   },
   variants: {
     mirrored: {

--- a/src/pages/generate/pages/result/components/GeneratedImgA.tsx
+++ b/src/pages/generate/pages/result/components/GeneratedImgA.tsx
@@ -158,13 +158,13 @@ const GeneratedImgA = ({
         ))}
         {lastImage && (
           <SwiperSlide key="blurred-last-image" className={styles.swiperSlide}>
-            <div
+            <img
+              crossOrigin="anonymous"
+              src={lastImage.imageUrl}
+              alt="이미지 더보기"
               className={styles.imgAreaBlurred({
                 mirrored: lastImage.isMirror,
               })}
-              style={{
-                background: `url(${lastImage.imageUrl}) lightgray 9.175px 11.881px / 96.774% 93.052% no-repeat`,
-              }}
             />
             <div className={styles.lockWrapper}>
               <LockIcon />


### PR DESCRIPTION
## 📌 Summary

- close #370 

> 관련 있는 Issue를 태그해주세요. (e.g. > - #1)

_해당 PR에 대한 작업 내용을 요약하여 작성해주세요._

## 📄 Tasks

### 문제 상황

<img width="680" height="45" alt="image" src="https://github.com/user-attachments/assets/ba306b48-b798-433f-a709-5b81bca829d5" />


마이페이지에서 이미지 생성 결과를 확인하기 위해 `result` 페이지로 이동했을 때 특정 상황에서 이미지 CORS 에러가 발생하는 문제를 확인했어요.

### 문제 원인

서버에는 S3 이미지에 CORS 처리가 잘 되어있는 상황이었어요. 문제의 원인이 프론트측에 있을 수도 있다고 생각해 어떤 환경에서 CORS 에러가 뜨는지 확인해봤고, `Network` 탭에서 `Disable Cache` 설정을 꺼뒀을 때, 즉 **브라우저 캐싱을 활성화했을 때 해당 에러가 발생**한다는 것을 알게 됐어요.

### background

> `generate/result` 페이지에서 브라우저 캐시를 활성화하면 S3 이미지 로드 시 CORS 에러 발생
캐시를 비활성화하면 정상 작동
> 
- CORS (Cross-Origin Resource Sharing)
    
    브라우저의 보안 정책인 CORS에 의해 다른 origin의 리소스를 가져올 때 서버가 허용 헤더를 보내야해요. 예를 들어 `localhost:5173`에서 `houme-bucket.s3.amazonaws.com`의 이미지를 가져오려면 S3가 `Access-Control-Allow-Origin` 헤더를 응답에 포함해야돼요.
    
- Cache Key
    
    브라우저가 응답을 캐시에 저장할 때 사용하는 식별자예요. 같은 URL(S3에 저장된 이미지의 URL 등)이라도 요청 방식(CORS 여부)에 따라 응답을 다른 캐시키로 저장돼요.
    
- `crossOrigin="anonymous"`
    
    <img> 태그에 이 속성을 추가하면 브라우저가 해당 이미지 요청을 “CORS 요청”으로 처리, 즉 요청 헤더에 현재 웹 페이지의 출처를 나타내는 `Origin` 헤더를 추가해서 요청을 보내요.
    
    → 이미지를 호스팅하는 S3 버킷은 브라우저의 `Origin` 헤더가 포함된 요청을 받아요. S3에 올바른 CORS 세팅이 적용되어있을 시 버킷의 CORS 구성에 따라 응답 헤더에 `Access-Control-Allow-Origin`을 포함해 응답해요.
    
    → 브라우저는 S3로부터 받은 응답에 유효한 `Access-Control-Allow-Origin` 헤더가 포함되어 있을 때만 해당 이미지 데이터에 접근할 수 있도록 허용해요.
    

### **현재 코드 점검**

<img width="403" height="306" alt="image" src="https://github.com/user-attachments/assets/5bcb042e-ec47-4705-821e-a8244ea5d42a" />

인테리어 결과 이미지를 띄우고 가구 객체를 추론하는 컴포넌트는 `DetectionHotspots` 컴포넌트예요. `GenerateImgA`, `GenerateImgB`는 `Swiper` 안에 `DetectionHotspots`를 넣고, `DetectionHotspots`에 S3 이미지 url을 전달해 이미지를 띄워요.

<img width="398" height="300" alt="image" src="https://github.com/user-attachments/assets/7395b9d1-002a-4886-b6cb-2f89bf62aefa" />

Swiper의 마지막 이미지는 `const lastImage = images[images.length - 1];`, 즉 서버에서 받은 이미지 배열을 저장하는 `images` 배열의 마지막 이미지와 동일한 이미지예요. 여기에 blur 효과만 주는 거니까, 결과적으로 S3에는 동일한 이미지를 두 번 요청하게 돼요.

`GenerateImgA`가  S3에서 이미지 2개를 받아 띄운다고 가정할게요. 

1. 이미지 배열 구조
    
    서버에서 이미지 2개를 받으면
    
    images = [이미지1, 이미지2]
    lastImage = images[1] = 이미지2
    
    이렇게 [이미지1, 이미지2, lastImage(이미지2 + blur)] 세 개의 이미지가 Swiper에 뜸

2. Swiper 슬라이드 구성
<img width="635" height="159" alt="image" src="https://github.com/user-attachments/assets/7dd59e46-4473-4e3d-85aa-c1b11960e2ea" />

3. 코드 구조

    ```tsx
    // 서버에서 받은 이미지를 Swiper에 띄우는 코드
    {images.map((image, index) => (
      <SwiperSlide>
        <DetectionHotspots imageUrl={image.imageUrl} />
      </SwiperSlide>
    ))}
    // 서버에서 받은 이미지 중 마지막 이미지를 blur처리해서 Swiper의 마지막 슬라이드에 띄우는 코드
    {lastImage && (
	    <SwiperSlide key="blurred-last-image"
	      <div
	        style={{
	          background: `url(${lastImage.imageUrl}) lightgray 9.175px 11.881px / 96.774% 93.052% no-repeat`,
	        }}
	      />
	    </SwiperSlide>
    )}
    ```


    
### 현재 코드 실제 동작 확인

Network 탭 기록

<img width="672" height="102" alt="image" src="https://github.com/user-attachments/assets/176f2b2d-545d-4d6b-9e9e-3f949fb44428" />


똑같은 이미지가 두 번 요청되고 있으며 그 중 하나에서 CORS 에러가 발생한 것 확인.

- 첫 번째 이미지 정보 확인
    - Network > Headers
        
        
        <img width="296" height="517" alt="image" src="https://github.com/user-attachments/assets/c4d5d9bd-86a4-4a27-a546-1082d12378e8" />

        
        Request Header의 Sec-Fetch-Mode가 no-cors, 즉 CORS 요청이 아닌 일반 이미지 요청인 것 확인
        
    - Network > Initiator
        
        
        <img width="294" height="333" alt="image" src="https://github.com/user-attachments/assets/74583337-e57a-4b38-968c-6e73a09ac24e" />

        
        ‘No initiator data’
        
        CSS background: url(...)로 요청된 이미지는 브라우저가 스타일 파싱 중에 요청, 즉 JavaScript 콜스택이 없으므로 Initiator 정보가 나오지 않음. 따라서 `url(${lastImage.imageUrl})` 에 의해 이미지 요청이 간 것 확인 가능
        
    
    **확인할 수 있는 점**
    
    - blur이미지를 띄우기 위한 코드인 `url(${lastImage.imageUrl})`에 의해 CORS 요청이 아닌 요청이 갔음
    - 따라서 요청에 Origin 헤더가 안 붙고, S3도 Access-Control-Allow-Origin 헤더 없이 응답
    - 이 응답이 캐시에 저장됨(브라우저의 disable cache 꺼뒀으니까)
        
        실제로 새로고침하면
        
        
        <img width="487" height="444" alt="image" src="https://github.com/user-attachments/assets/51450ed7-5bbb-4564-acfd-e221344bc08f" />

        
        Status Code에 `200 OK (from disk cache)`라고 뜨며 캐싱된 것 확인 가능.
        
- 두 번째 이미지 정보 확인
    - Network > Headers
        
        
        <img width="343" height="361" alt="image" src="https://github.com/user-attachments/assets/a24df68e-f71f-4938-abf7-ad61cb3b9767" />

        
        요청이 서버에 도달하기 전에 브라우저단에서 차단돼 별다른 정보가 없고 Response Headers도 0개임. 
        
        +) "Provisional headers are shown"는 캐시에서 응답을 가져왔을때 등 캐싱 관련 상황이 발생했을 때 뜰 수 있는 경고 메시지
        
    - Network > Initiator
        
        
        <img width="341" height="339" alt="image" src="https://github.com/user-attachments/assets/a9700bec-3ef8-4307-83e3-f74e4c453e3f" />

        
        ```tsx
        {images.map((image, index) => (
          <SwiperSlide>
            <DetectionHotspots imageUrl={image.imageUrl} />
          </SwiperSlide>
        ))}
        ```
        
        이 요청이 `DetectionHotspots`에 의한 이미지 요청인 것을 알 수 있음.
        
    
    **확인할 수 있는 점**
    
    - 이 요청이 `DetectionHotspots`에서 실행된 이미지 요청이다.
    - 위에서 요청된 이미지와 똑같은 이미지 요청이 발생했으며, 이번에는 `<img crossOrigin="anonymous">` 설정에 의해 CORS 요청됨

### CORS 에러 발생 과정 정리

1. CSS background: `url(${lastImage.imageUrl})`에서 이미지2에 대한 S3 요청이 먼저 발생함. 이때 CSS background: url(...)이나 일반 img 태그는 CORS 요청이 아님(일반 요청임)
2. 따라서 이 요청에는 Origin 헤더가 안 붙고, S3도 Access-Control-Allow-Origin 헤더 없이 응답함
3. 이 응답이 캐시에 저장됨
4. 이후 `DetectionHotspots`에서 이미지2에 대한 요청을 다시 보냄. 이때 `DetectionHotspots`는 내부적으로 `<img crossOrigin="anonymous">`와 같이 이미지를 요청하는데, `crossOrigin="anonymous"`나 JavaScript로 이전에 요청한 것과 같은 이미지를 CORS 요청하면 브라우저가 캐시된 응답을 재사용하려 함
5. 근데 캐시된 응답에 CORS 헤더가 없음 → CORS 에러 발생

- **같은 이미지를 서로 다른 방식(일반 요청, CORS 요청)으로 보내 브라우저 캐시 충돌이 발생하는 것이 원인**
- **브라우저 캐시는 원본 요청 헤더를 저장하지 않으며, 캐시된 응답을 재사용할 때 CORS 헤더 유무만 확인함**
- **no-cors 응답이 캐시되면 이후 CORS 요청에서 사용 불가**

### 해결 방안

같은 이미지를 로드하는 모든 곳에서 CORS 요청으로 통일

```html
// 변경 전: CSS background (no-cors 요청)
<div
  style={{
    background: `url(${lastImage.imageUrl}) lightgray ...`,
  }}
/>

// 변경 후: img 태그 + crossOrigin (CORS 요청)
<img
  crossOrigin="anonymous"
  src={lastImage.imageUrl}
  alt="이미지 더보기"
  className={styles.imgAreaBlurred(...)}
/>
```

### 참고자료

<img width="669" height="124" alt="image" src="https://github.com/user-attachments/assets/64d720cf-fb6c-4586-a114-069ffbac0ddf" />

제가 겪은 문제 원인, 해결 방안과 90%정도 일치하는 아티클을 발견했어요. 정리가 잘 되어있으니 참고해도 좋을 것 같아요.

_해당 PR에 수행한 작업을 작성해주세요._

## 🔍 To Reviewer

-

_리뷰어에게 요청하는 내용을 작성해주세요._

## 📸 Screenshot

-

_작업한 내용에 대한 스크린샷을 첨부해주세요._
