### PR TITLE
[fix] 카카오 로그인 콜백 백엔드 JSON 노출 버그 수정

### DIFF
--- a/src/pages/login/KakaoCallback.tsx
+++ b/src/pages/login/KakaoCallback.tsx
@@ -6,11 +6,11 @@
  *
  * 전체 로그인 흐름:
  * 1. 사용자가 카카오 로그인 버튼 클릭
- * 2. 프론트엔드가 백엔드 `/oauth/kakao?env=local|preview|prod`로 리다이렉트
+ * 2. 프론트엔드가 백엔드 `/oauth/kakao?env=local|preview|dev`로 리다이렉트
  * 3. 백엔드가 `env`를 기반으로 redirect_uri 계산
  *    - local: http://localhost:5173/oauth/kakao/callback
  *    - preview: http://preview.houme.kr/oauth/kakao/callback
- *    - prod: https://www.houme.kr/oauth/kakao/callback
+ *    - dev: https://www.houme.kr/oauth/kakao/callback
  * 4. 백엔드가 카카오 인증 서버로 리다이렉트 (redirect_uri 포함)
  * 5. 카카오 인증 완료 후 프론트엔드 `/oauth/kakao/callback?code=인가코드`로 리다이렉트
  * 6. 이 컴포넌트가 렌더링되고 인가 코드(code)를 파싱
@@ -47,7 +47,7 @@ const KakaoCallback = () => {
     const url = new URL(window.location.href);
     const code = url.searchParams.get('code');
 
-    // 환경 감지: hostname 기반으로 local/preview/prod 결정
+    // 환경 감지: hostname 기반으로 local/preview/dev 결정
     const hostname = window.location.hostname;
     const env = getAuthEnvironment(hostname);
 

--- a/src/pages/login/LoginPage.tsx
+++ b/src/pages/login/LoginPage.tsx
@@ -16,12 +16,12 @@ const LoginPage = () => {
    * 카카오 로그인 버튼 클릭 핸들러
    *
    * 로그인 흐름:
-   * 1. 프론트엔드가 현재 환경을 감지하여 `local` | `preview` | `prod` 쿼리 파라미터 결정
-   * 2. 백엔드 `/oauth/kakao?env=local|preview|prod`로 리다이렉트
+   * 1. 프론트엔드가 현재 환경을 감지하여 `local` | `preview` | `dev` 쿼리 파라미터 결정
+   * 2. 백엔드 `/oauth/kakao?env=local|preview|dev`로 리다이렉트
    * 3. 백엔드가 `env` 쿼리 파라미터를 기반으로 프론트엔드 URL 결정
    *    - `env=local`: http://localhost:5173
    *    - `env=preview`: http://preview.houme.kr
-   *    - `env=prod`: https://www.houme.kr
+   *    - `env=dev`: https://www.houme.kr
    * 4. 백엔드가 카카오 인증 서버로 리다이렉트 (동적 redirect_uri 포함)
    * 5. 카카오 인증 완료 후 프론트엔드 `/oauth/kakao/callback?code=인가코드`로 리다이렉트
    * 6. KakaoCallback 컴포넌트에서 인가 코드(code)를 파싱
@@ -31,7 +31,7 @@ const LoginPage = () => {
     // CTA 버튼 클릭 시 GA 이벤트 전송
     logLoginSocialClickBtnCTA();
 
-    // 현재 환경 감지: hostname 기반으로 local/preview/prod 결정
+    // 현재 환경 감지: hostname 기반으로 local/preview/dev 결정
     const hostname = window.location.hostname;
     const env = getAuthEnvironment(hostname);
 

--- a/src/pages/login/apis/kakaoLogin.ts
+++ b/src/pages/login/apis/kakaoLogin.ts
@@ -17,14 +17,14 @@ import type { BaseResponse } from '@shared/types/apis';
  * 환경 정보를 백엔드 `/oauth/kakao/callback` API로 전달하는 역할을 합니다.
  *
  * @param code - 카카오 인증 서버에서 받은 인가 코드 (URL 파라미터에서 파싱)
- * @param env - 환경 정보 ('local' | 'preview' | 'prod')
+ * @param env - 환경 정보 ('local' | 'preview' | 'dev')
  * @returns Promise<LoginApiResponse> - 사용자 정보와 액세스 토큰
  *
  * @example
  * ```typescript
  * // KakaoCallback 컴포넌트에서:
  * const code = new URL(window.location.href).searchParams.get('code');
- * const env = window.location.hostname === 'localhost' ? 'local' : 'prod';
+ * const env = window.location.hostname === 'localhost' ? 'local' : 'dev';
  * const response = await getKakaoLogin(code, env);
  * console.log(response.data.user); // 사용자 정보
  * console.log(response.accessToken); // 액세스 토큰

--- a/src/pages/login/types/environment.ts
+++ b/src/pages/login/types/environment.ts
@@ -1,1 +1,1 @@
-export type AuthEnvironment = 'local' | 'preview' | 'prod';
+export type AuthEnvironment = 'local' | 'preview' | 'dev';

--- a/src/pages/login/utils/environment.ts
+++ b/src/pages/login/utils/environment.ts
@@ -9,5 +9,5 @@ export const getAuthEnvironment = (hostname: string): AuthEnvironment => {
     return 'preview';
   }
 
-  return 'prod';
+  return 'dev';
 };


### PR DESCRIPTION
## 📌 Summary

- close #406

프론트 로그인 환경값을 백엔드 분기(local/preview/dev)와 일치시키고 관련 주석/설명을 정리했습니다.

## 📄 Tasks

- AuthEnvironment 타입에서 prod → dev로 변경
- hostname 기반 env 결정 로직을 dev로 통일
- 로그인 플로우 주석 및 문서화 내용의 env 표기 수정

## 🔍 To Reviewer

- 

## 📸 Screenshot

- 
