### PR TITLE
[fix] 소셜 로그인 signupToken 회원가입 플로우 반영

### DIFF
--- a/src/pages/login/apis/kakaoLogin.ts
+++ b/src/pages/login/apis/kakaoLogin.ts
@@ -11,14 +11,14 @@ import type { BaseResponse } from '@shared/types/apis';
  * 카카오 OAuth 로그인 콜백 API 함수
  *
  * 카카오 인증 서버에서 받은 인가 코드(code)와 환경(env)을 백엔드 콜백 API로 전달합니다.
- * 백엔드는 인가 코드를 검증하고 사용자 정보와 액세스 토큰을 반환합니다.
+ * 백엔드는 인가 코드를 검증하고 신규/기존 사용자 여부와 임시 signupToken(신규 회원) 등을 반환합니다.
  *
  * 이 함수는 KakaoCallback 컴포넌트에서 URL 파라미터로부터 파싱한 인가 코드와
  * 환경 정보를 백엔드 `/oauth/kakao/callback` API로 전달하는 역할을 합니다.
  *
  * @param code - 카카오 인증 서버에서 받은 인가 코드 (URL 파라미터에서 파싱)
  * @param env - 환경 정보 ('local' | 'preview' | 'dev')
- * @returns Promise<LoginApiResponse> - 사용자 정보와 액세스 토큰
+ * @returns Promise<LoginApiResponse> - 사용자 여부 정보 + (기존 회원일 때만) 액세스 토큰
  *
  * @example
  * ```typescript
@@ -26,8 +26,9 @@ import type { BaseResponse } from '@shared/types/apis';
  * const code = new URL(window.location.href).searchParams.get('code');
  * const env = window.location.hostname === 'localhost' ? 'local' : 'dev';
  * const response = await getKakaoLogin(code, env);
- * console.log(response.data.user); // 사용자 정보
- * console.log(response.accessToken); // 액세스 토큰
+ * console.log(response.data.isNewUser); // 신규 회원 여부
+ * console.log(response.data.signupToken); // 신규 회원 임시 토큰(신규 회원일 때만)
+ * console.log(response.accessToken); // 액세스 토큰(기존 회원일 때만)
  * ```
  */
 
@@ -44,16 +45,25 @@ export const getKakaoLogin = async (
   // console.log('[kakaoLogin] 응답 헤더:', response.headers);
   // console.log('[kakaoLogin] 응답 데이터:', response.data);
 
-  // 서버 응답 헤더에서 액세스 토큰 추출
+  const data = response.data.data;
+
+  // 서버 응답 헤더에서 액세스 토큰 추출 (기존 회원만)
   const accessToken = response.headers['access-token'];
-  if (!accessToken) {
+  if (!data.isNewUser && !accessToken) {
     throw new Error(
       RESPONSE_MESSAGE[HTTP_STATUS.UNAUTHORIZED] || '액세스 토큰이 없습니다.'
     );
   }
 
+  if (data.isNewUser && !data.signupToken) {
+    throw new Error(
+      RESPONSE_MESSAGE[HTTP_STATUS.BAD_REQUEST] ||
+        '회원가입 임시 토큰(signupToken)이 없습니다.'
+    );
+  }
+
   return {
-    data: response.data.data,
-    accessToken,
+    data,
+    accessToken: accessToken || undefined,
   };
 };

--- a/src/pages/login/apis/kakaoOAuthCallback.ts
+++ b/src/pages/login/apis/kakaoOAuthCallback.ts
@@ -25,14 +25,14 @@ import type { BaseResponse } from '@shared/types/apis';
  * // KakaoCallback 컴포넌트에서:
  * const code = new URL(window.location.href).searchParams.get('code');
  * const env = window.location.hostname === 'localhost' ? 'local' : 'dev';
- * const response = await getKakaoLogin(code, env);
+ * const response = await getKakaoOAuthCallback(code, env);
  * console.log(response.data.isNewUser); // 신규 회원 여부
  * console.log(response.data.signupToken); // 신규 회원 임시 토큰(신규 회원일 때만)
  * console.log(response.accessToken); // 액세스 토큰(기존 회원일 때만)
  * ```
  */
 
-export const getKakaoLogin = async (
+export const getKakaoOAuthCallback = async (
   code: string,
   env: AuthEnvironment
 ): Promise<LoginApiResponse> => {
@@ -42,8 +42,8 @@ export const getKakaoLogin = async (
     { params: { code, env } }
   );
 
-  // console.log('[kakaoLogin] 응답 헤더:', response.headers);
-  // console.log('[kakaoLogin] 응답 데이터:', response.data);
+  // console.log('[kakaoOAuthCallback] 응답 헤더:', response.headers);
+  // console.log('[kakaoOAuthCallback] 응답 데이터:', response.data);
 
   const data = response.data.data;
 

--- a/src/pages/login/constants/kakaoLoginPath.tsx
+++ b/src/pages/login/constants/kakaoLoginPath.tsx
@@ -15,7 +15,7 @@
  * - 백엔드가 카카오 인증 URL을 생성하고 리다이렉트 처리
  *
  * @see src/pages/login/LoginPage.tsx
- * @see src/pages/login/apis/kakaoLogin.ts
+ * @see src/pages/login/apis/kakaoOAuthCallback.ts
  */
 const clientId = import.meta.env.VITE_KAKAO_CLIENT_ID;
 const redirectUrl = import.meta.env.VITE_KAKAO_REDIRECT_URI;

--- a/src/pages/login/hooks/useKakaoLogin.ts
+++ b/src/pages/login/hooks/useKakaoLogin.ts
@@ -39,9 +39,14 @@ export const useKakaoLoginMutation = () => {
       // 신규 회원: signupToken 기반으로 회원가입 진행
       if (response.data.isNewUser) {
         const signupToken = response.data.signupToken;
-        if (signupToken) {
-          sessionStorage.setItem('signupToken', signupToken);
+        if (!signupToken) {
+          console.error(
+            '[useKakaoLoginMutation] 신규 회원 응답에 signupToken이 없습니다.'
+          );
+          return;
         }
+
+        sessionStorage.setItem('signupToken', signupToken);
 
         navigate(ROUTES.SIGNUP, {
           state: {

--- a/src/pages/login/hooks/useKakaoLogin.ts
+++ b/src/pages/login/hooks/useKakaoLogin.ts
@@ -36,17 +36,29 @@ export const useKakaoLoginMutation = () => {
   >({
     mutationFn: ({ code, env }) => getKakaoLogin(code, env),
     onSuccess: (response) => {
-      const accessToken = response.accessToken;
+      // 신규 회원: signupToken 기반으로 회원가입 진행
+      if (response.data.isNewUser) {
+        const signupToken = response.data.signupToken;
+        if (signupToken) {
+          sessionStorage.setItem('signupToken', signupToken);
+        }
 
-      // zustand에 저장 (localStorage 동시 저장)
-      setAccessToken(accessToken);
-
-      // 가입 여부에 따라 리다이렉트 (response.data가 true면 신규회원, false면 기존회원)
-      if (response.data) {
-        navigate(ROUTES.SIGNUP);
-      } else {
-        navigate(ROUTES.HOME);
+        navigate(ROUTES.SIGNUP, {
+          state: {
+            signupToken,
+            prefill: response.data.prefill,
+          },
+        });
+        return;
       }
+
+      // 기존 회원: access-token 헤더로 로그인 완료
+      if (response.accessToken) {
+        // zustand에 저장 (localStorage 동시 저장)
+        setAccessToken(response.accessToken);
+      }
+
+      navigate(ROUTES.HOME);
     },
     onError: () => {
       // 오류 처리는 KakaoCallback 컴포넌트에서 useErrorHandler로 처리

--- a/src/pages/login/hooks/useKakaoLogin.ts
+++ b/src/pages/login/hooks/useKakaoLogin.ts
@@ -20,7 +20,7 @@ import { useNavigate } from 'react-router-dom';
 import { ROUTES } from '@/routes/paths';
 import { useUserStore } from '@/store/useUserStore';
 
-import { getKakaoLogin } from '../apis/kakaoLogin';
+import { getKakaoOAuthCallback } from '../apis/kakaoOAuthCallback';
 
 import type { LoginApiResponse } from '../types/auth';
 import type { AuthEnvironment } from '../types/environment';
@@ -34,7 +34,7 @@ export const useKakaoLoginMutation = () => {
     Error,
     { code: string; env: AuthEnvironment }
   >({
-    mutationFn: ({ code, env }) => getKakaoLogin(code, env),
+    mutationFn: ({ code, env }) => getKakaoOAuthCallback(code, env),
     onSuccess: (response) => {
       // 신규 회원: signupToken 기반으로 회원가입 진행
       if (response.data.isNewUser) {

--- a/src/pages/login/types/auth.ts
+++ b/src/pages/login/types/auth.ts
@@ -1,10 +1,13 @@
 // 카카오 로그인 관련 타입
+export interface KakaoLoginPrefill {
+  email: string;
+  nickname: string;
+}
+
 export interface KakaoLoginResponse {
-  user: {
-    id: number;
-    email: string;
-    nickname: string;
-  };
+  isNewUser: boolean;
+  signupToken: string | null;
+  prefill: KakaoLoginPrefill | null;
 }
 
 // 로그아웃 관련 타입
@@ -15,5 +18,5 @@ export interface LogoutResponse {
 // 로그인 API 응답 타입
 export interface LoginApiResponse {
   data: KakaoLoginResponse;
-  accessToken: string;
+  accessToken?: string;
 }

--- a/src/pages/signup/SignupPage.tsx
+++ b/src/pages/signup/SignupPage.tsx
@@ -21,12 +21,26 @@ interface SignupLocationState {
   signupToken?: string | null;
 }
 
+// Type Guard: SignupLocationState 검증
+const isSignupLocationState = (
+  value: unknown
+): value is SignupLocationState => {
+  if (!value || typeof value !== 'object') return false;
+
+  const state = value as Record<string, unknown>;
+  if (!('signupToken' in state)) return false;
+
+  const signupToken = state.signupToken;
+  return signupToken == null || typeof signupToken === 'string';
+};
+
 const SignupPage = () => {
   const location = useLocation();
   const navigate = useNavigate();
 
-  const routeSignupToken =
-    (location.state as SignupLocationState | null)?.signupToken ?? null;
+  const routeSignupToken = isSignupLocationState(location.state)
+    ? location.state.signupToken ?? null
+    : null;
   const signupToken = routeSignupToken ?? sessionStorage.getItem('signupToken');
 
   useEffect(() => {
@@ -96,6 +110,8 @@ const SignupPage = () => {
       birthday: formattedBirthday,
     });
   };
+
+  if (!signupToken) return null;
 
   return (
     <form onSubmit={handleSubmit}>

--- a/src/pages/signup/SignupPage.tsx
+++ b/src/pages/signup/SignupPage.tsx
@@ -9,7 +9,7 @@ import TextField from '@/shared/components/textField/TextField.tsx';
 import { ERROR_MESSAGES } from '@/shared/constants/clientErrorMessage.ts';
 import { ROUTES } from '@/routes/paths';
 
-import { useSignupMutation } from './apis/signup';
+import { usePostSignupMutation } from './apis/signup';
 import useSignupForm from './hooks/useSignupForm';
 import * as styles from './SignupPage.css';
 import {
@@ -76,7 +76,7 @@ const SignupPage = () => {
     hasError,
   } = useSignupForm();
 
-  const { mutate: signUp } = useSignupMutation();
+  const { mutate: signUp } = usePostSignupMutation();
 
   const errorSentRef = useRef(false);
 

--- a/src/pages/signup/SignupPage.tsx
+++ b/src/pages/signup/SignupPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
 
 import CtaButton from '@/shared/components/button/ctaButton/CtaButton.tsx';
 import ErrorMessage from '@/shared/components/button/ErrorButton/ErrorMessage';
@@ -6,6 +7,7 @@ import LargeFilled from '@/shared/components/button/largeFilledButton/LargeFille
 import TitleNavBar from '@/shared/components/navBar/TitleNavBar.tsx';
 import TextField from '@/shared/components/textField/TextField.tsx';
 import { ERROR_MESSAGES } from '@/shared/constants/clientErrorMessage.ts';
+import { ROUTES } from '@/routes/paths';
 
 import { useSignupMutation } from './apis/signup';
 import useSignupForm from './hooks/useSignupForm';
@@ -15,7 +17,30 @@ import {
   logSignupFormViewError,
 } from './utils/analytics';
 
+interface SignupLocationState {
+  signupToken?: string | null;
+}
+
 const SignupPage = () => {
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  const routeSignupToken =
+    (location.state as SignupLocationState | null)?.signupToken ?? null;
+  const signupToken = routeSignupToken ?? sessionStorage.getItem('signupToken');
+
+  useEffect(() => {
+    if (routeSignupToken) {
+      sessionStorage.setItem('signupToken', routeSignupToken);
+    }
+  }, [routeSignupToken]);
+
+  useEffect(() => {
+    if (!signupToken) {
+      navigate(ROUTES.LOGIN, { replace: true });
+    }
+  }, [signupToken, navigate]);
+
   const {
     name,
     birthYear,
@@ -37,7 +62,7 @@ const SignupPage = () => {
     hasError,
   } = useSignupForm();
 
-  const { mutate: patchSignup } = useSignupMutation();
+  const { mutate: signUp } = useSignupMutation();
 
   const errorSentRef = useRef(false);
 
@@ -58,13 +83,14 @@ const SignupPage = () => {
     // CTA 버튼 클릭 시 GA 이벤트 전송
     logSignupFormClickBtnCTA();
 
-    if (!isFormValid || !gender) return;
+    if (!isFormValid || !gender || !signupToken) return;
 
     const formattedBirthday = `${birthYear}-${birthMonth}-${birthDay}`;
 
     // console.log(name, gender.value, formattedBirthday);
 
-    patchSignup({
+    signUp({
+      signupToken,
       name,
       gender: gender.value,
       birthday: formattedBirthday,
@@ -170,7 +196,7 @@ const SignupPage = () => {
       </div>
 
       <div className={styles.btnarea}>
-        <CtaButton isActive={isFormValid} type="submit">
+        <CtaButton isActive={isFormValid && !!signupToken} type="submit">
           회원가입 완료하기
         </CtaButton>
       </div>

--- a/src/pages/signup/SignupPage.tsx
+++ b/src/pages/signup/SignupPage.tsx
@@ -1,13 +1,14 @@
 import { useEffect, useRef } from 'react';
+
 import { useLocation, useNavigate } from 'react-router-dom';
 
+import { ROUTES } from '@/routes/paths';
 import CtaButton from '@/shared/components/button/ctaButton/CtaButton.tsx';
 import ErrorMessage from '@/shared/components/button/ErrorButton/ErrorMessage';
 import LargeFilled from '@/shared/components/button/largeFilledButton/LargeFilledButton.tsx';
 import TitleNavBar from '@/shared/components/navBar/TitleNavBar.tsx';
 import TextField from '@/shared/components/textField/TextField.tsx';
 import { ERROR_MESSAGES } from '@/shared/constants/clientErrorMessage.ts';
-import { ROUTES } from '@/routes/paths';
 
 import { usePostSignupMutation } from './apis/signup';
 import useSignupForm from './hooks/useSignupForm';
@@ -39,7 +40,7 @@ const SignupPage = () => {
   const navigate = useNavigate();
 
   const routeSignupToken = isSignupLocationState(location.state)
-    ? location.state.signupToken ?? null
+    ? (location.state.signupToken ?? null)
     : null;
   const signupToken = routeSignupToken ?? sessionStorage.getItem('signupToken');
 

--- a/src/pages/signup/apis/signup.ts
+++ b/src/pages/signup/apis/signup.ts
@@ -41,7 +41,7 @@ export const useSignupMutation = () => {
 
   return useMutation<SignupResponse, Error, SignupRequest>({
     mutationFn: postSignup,
-    retry: 3,
+    retry: false,
     onSuccess: (response) => {
       setUserName(response.userName); // userName 전역 저장 (zustand)
       setAccessToken(response.accessToken);

--- a/src/pages/signup/apis/signup.ts
+++ b/src/pages/signup/apis/signup.ts
@@ -2,34 +2,50 @@ import { useMutation } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
 
 import { ROUTES } from '@/routes/paths';
-import { HTTPMethod, request } from '@/shared/apis/request';
+import axiosInstance from '@/shared/apis/axiosInstance';
+import { RESPONSE_MESSAGE, HTTP_STATUS } from '@/shared/constants/response';
 import { useUserStore } from '@/store/useUserStore';
 
 import { API_ENDPOINT } from '@constants/apiEndpoints';
 
+import type { BaseResponse } from '@/shared/types/apis';
 import type { SignupRequest, SignupResponse } from '../types/apis/signup';
 
 /* 회원가입 API 함수 */
-export const patchSignup = async (
+export const postSignup = async (
   data: SignupRequest
 ): Promise<SignupResponse> => {
-  return request({
-    method: HTTPMethod.PATCH,
-    url: API_ENDPOINT.USER.SIGN_UP,
-    body: data as unknown as Record<string, unknown>,
-  });
+  const response = await axiosInstance.post<BaseResponse<string>>(
+    API_ENDPOINT.USER.SIGN_UP,
+    data
+  );
+
+  const accessToken = response.headers['access-token'];
+  if (!accessToken) {
+    throw new Error(
+      RESPONSE_MESSAGE[HTTP_STATUS.UNAUTHORIZED] || '액세스 토큰이 없습니다.'
+    );
+  }
+
+  return {
+    userName: response.data.data,
+    accessToken,
+  };
 };
 
 /* 회원가입 TanStack Query 훅 */
 export const useSignupMutation = () => {
   const navigate = useNavigate();
   const setUserName = useUserStore((state) => state.setUserName);
+  const setAccessToken = useUserStore((state) => state.setAccessToken);
 
   return useMutation<SignupResponse, Error, SignupRequest>({
-    mutationFn: patchSignup,
+    mutationFn: postSignup,
     retry: 3,
     onSuccess: (response) => {
-      setUserName(response.data); // userName 전역 저장 (zustand)
+      setUserName(response.userName); // userName 전역 저장 (zustand)
+      setAccessToken(response.accessToken);
+      sessionStorage.removeItem('signupToken');
       navigate(ROUTES.GENERATE_START);
     },
     onError: (error) => {

--- a/src/pages/signup/apis/signup.ts
+++ b/src/pages/signup/apis/signup.ts
@@ -34,7 +34,7 @@ export const postSignup = async (
 };
 
 /* 회원가입 TanStack Query 훅 */
-export const useSignupMutation = () => {
+export const usePostSignupMutation = () => {
   const navigate = useNavigate();
   const setUserName = useUserStore((state) => state.setUserName);
   const setAccessToken = useUserStore((state) => state.setAccessToken);
@@ -49,7 +49,7 @@ export const useSignupMutation = () => {
       navigate(ROUTES.GENERATE_START);
     },
     onError: (error) => {
-      console.error('[useSignupMutation] 회원가입 실패:', error); // 에러는 useErrorHandler에서 처리
+      console.error('[usePostSignupMutation] 회원가입 실패:', error); // 에러는 useErrorHandler에서 처리
     },
   });
 };

--- a/src/pages/signup/apis/signup.ts
+++ b/src/pages/signup/apis/signup.ts
@@ -4,11 +4,11 @@ import { useNavigate } from 'react-router-dom';
 import { ROUTES } from '@/routes/paths';
 import axiosInstance from '@/shared/apis/axiosInstance';
 import { RESPONSE_MESSAGE, HTTP_STATUS } from '@/shared/constants/response';
+import type { BaseResponse } from '@/shared/types/apis';
 import { useUserStore } from '@/store/useUserStore';
 
 import { API_ENDPOINT } from '@constants/apiEndpoints';
 
-import type { BaseResponse } from '@/shared/types/apis';
 import type { SignupRequest, SignupResponse } from '../types/apis/signup';
 
 /* 회원가입 API 함수 */

--- a/src/pages/signup/hooks/usePatchSignup.ts
+++ b/src/pages/signup/hooks/usePatchSignup.ts
@@ -1,4 +1,4 @@
 /* 회원가입 TanStack Query 훅 */
 /* Legacy alias */
 
-export { useSignupMutation as usePatchSignup } from '../apis/signup';
+export { usePostSignupMutation as usePatchSignup } from '../apis/signup';

--- a/src/pages/signup/hooks/usePatchSignup.ts
+++ b/src/pages/signup/hooks/usePatchSignup.ts
@@ -1,4 +1,0 @@
-/* 회원가입 TanStack Query 훅 */
-/* Legacy alias */
-
-export { usePostSignupMutation as usePatchSignup } from '../apis/signup';

--- a/src/pages/signup/hooks/usePatchSignup.ts
+++ b/src/pages/signup/hooks/usePatchSignup.ts
@@ -1,36 +1,4 @@
 /* 회원가입 TanStack Query 훅 */
+/* Legacy alias */
 
-import { useMutation } from '@tanstack/react-query';
-import { useNavigate } from 'react-router-dom';
-
-import { ROUTES } from '@/routes/paths';
-import { useUserStore } from '@/store/useUserStore';
-
-import { postSignup } from '../apis/signup';
-
-import type { SignupRequest, SignupResponse } from '../types/apis/signup';
-
-export const usePatchSignup = () => {
-  const navigate = useNavigate();
-  const setUserName = useUserStore((state) => state.setUserName);
-  const setAccessToken = useUserStore((state) => state.setAccessToken);
-
-  return useMutation<SignupResponse, Error, SignupRequest>({
-    mutationFn: postSignup,
-    retry: 3,
-    // 회원가입 성공 시 실행되는 함수
-    onSuccess: (response) => {
-      // console.log('[usePatchSignup] 회원가입 성공:', response);
-      setUserName(response.userName); // userName 전역 저장
-      setAccessToken(response.accessToken);
-      sessionStorage.removeItem('signupToken');
-      // 회원가입 완료 페이지 이동
-      navigate(ROUTES.GENERATE_START);
-    },
-    // 회원가입 실패 시 실행되는 함수
-    onError: (error) => {
-      console.error('[usePatchSignup] 회원가입 실패:', error);
-      // alert 제거 - useErrorHandler에서 처리하도록 위임
-    },
-  });
-};
+export { useSignupMutation as usePatchSignup } from '../apis/signup';

--- a/src/pages/signup/hooks/usePatchSignup.ts
+++ b/src/pages/signup/hooks/usePatchSignup.ts
@@ -6,22 +6,24 @@ import { useNavigate } from 'react-router-dom';
 import { ROUTES } from '@/routes/paths';
 import { useUserStore } from '@/store/useUserStore';
 
-import { patchSignup } from '../apis/signup';
+import { postSignup } from '../apis/signup';
 
 import type { SignupRequest, SignupResponse } from '../types/apis/signup';
 
 export const usePatchSignup = () => {
   const navigate = useNavigate();
   const setUserName = useUserStore((state) => state.setUserName);
+  const setAccessToken = useUserStore((state) => state.setAccessToken);
 
   return useMutation<SignupResponse, Error, SignupRequest>({
-    mutationFn: patchSignup,
+    mutationFn: postSignup,
     retry: 3,
     // 회원가입 성공 시 실행되는 함수
     onSuccess: (response) => {
       // console.log('[usePatchSignup] 회원가입 성공:', response);
-      // console.log(response.data);
-      setUserName(response.data); // userName 전역 저장
+      setUserName(response.userName); // userName 전역 저장
+      setAccessToken(response.accessToken);
+      sessionStorage.removeItem('signupToken');
       // 회원가입 완료 페이지 이동
       navigate(ROUTES.GENERATE_START);
     },

--- a/src/pages/signup/types/apis/signup.ts
+++ b/src/pages/signup/types/apis/signup.ts
@@ -1,13 +1,13 @@
 // 회원가입 api 관련 타입
 
 export interface SignupRequest {
+  signupToken: string;
   name: string;
   gender: 'MALE' | 'FEMALE' | 'NONBINARY';
   birthday: string; // e.g. "2001-01-10"
 }
 
 export interface SignupResponse {
-  code: number;
-  msg: string;
-  data: string;
+  userName: string;
+  accessToken: string;
 }


### PR DESCRIPTION
## 📌 Summary

- close #412

카카오 소셜 로그인/회원가입 플로우를 서버 스펙(PR #392)과 일치하도록 수정했습니다.
CodeRabbit 리뷰 반영으로 signupToken/라우팅 안정성과 네이밍 컨벤션을 정리했습니다.

## 📄 Tasks

- `/oauth/kakao/callback` 응답 스펙(isNewUser/signupToken/prefill) 반영
- 신규 회원: signupToken 저장 후 `/signup` 이동 (signupToken 누락 방어)
- 기존 회원: access-token 헤더로 로그인 처리
- `/api/v1/sign-up` PATCH → POST 변경 + signupToken 포함
- 회원가입 성공 시 access-token 저장
- (CodeRabbit) 회원가입 POST mutation 재시도 비활성화(`retry: false`)로 중복 요청 방지
- (CodeRabbit) `location.state` 타입 가드 + signupToken 없을 때 early return로 안전성 강화
- (CodeRabbit) 네이밍 컨벤션 정리: `getKakaoOAuthCallback`, `usePostSignupMutation` (레거시 `usePatchSignup` 제거)

## 🔍 To Reviewer

- 서버 PR #392 스펙 기준으로 동작 확인 부탁드립니다.
- 신규/기존 유저 각각 로그인 플로우 수동 QA 확인 부탁드립니다.

## 📸 Screenshot

-
