### PR TITLE
[chore] Storybook viewport 375/440만 유지

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -56,14 +56,6 @@ const preview: Preview = {
     },
     viewport: {
       options: {
-        mobile360: {
-          name: 'Mobile 360',
-          styles: {
-            width: '360px',
-            height: '667px',
-          },
-          type: 'mobile',
-        },
         mobile375: {
           name: 'Mobile 375',
           styles: {
@@ -79,22 +71,6 @@ const preview: Preview = {
             height: '667px',
           },
           type: 'mobile',
-        },
-        tablet: {
-          name: 'Tablet',
-          styles: {
-            width: '768px',
-            height: '1024px',
-          },
-          type: 'tablet',
-        },
-        desktop: {
-          name: 'Desktop',
-          styles: {
-            width: '1440px',
-            height: '900px',
-          },
-          type: 'desktop',
         },
       },
     },


### PR DESCRIPTION
## 📌 Summary

- close #428

Storybook viewport 옵션을 코드의 레이아웃 기준(375~440)에 맞춰 375/440만 남기도록 정리했습니다.

## 📄 Tasks

- Storybook viewport 옵션에서 Mobile 360/Tablet/Desktop 제거
- Mobile 375, Mobile 440만 유지

## 🔍 To Reviewer

- Storybook에서 viewport 드롭다운이 375/440만 남는지 확인 부탁드립니다.

## 📸 Screenshot

- N/A
