### PR TITLE
[feat] Clarity 히트맵 Prod/Preview 분리(Vercel env)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -31,6 +31,7 @@
 ### Operations
 
 - [ONNX Runtime(Web) 도입 기록](./operations/onnx-runtime-web.md)
+- [Microsoft Clarity (Prod/Preview split)](./operations/microsoft-clarity.md)
 
 ## 작성/유지 규칙(간단)
 

--- a/docs/operations/microsoft-clarity.md
+++ b/docs/operations/microsoft-clarity.md
@@ -1,0 +1,46 @@
+# Microsoft Clarity (Prod/Preview Split)
+
+This document explains how HOUME-CLIENT loads Microsoft Clarity (heatmaps / session replay) and how to split data between Vercel **Production** and **Preview** deployments.
+
+## Goal
+
+- Avoid mixing Production and Preview data by using different Clarity Project IDs.
+- Load Clarity only when an explicit Project ID is provided (no ID, no script).
+
+## Environment Variable
+
+- `VITE_CLARITY_PROJECT_ID`
+  - Type: string
+  - Scope: Vercel Environment Variables
+  - Behavior: when unset/empty, the client does not load Clarity.
+
+## Vercel Setup
+
+1. Create two Clarity projects:
+   - Production project (real users)
+   - Preview project (QA / feature branch previews)
+2. In Vercel, set `VITE_CLARITY_PROJECT_ID` with different values by environment:
+   - Production scope: Production Project ID
+   - Preview scope: Preview Project ID
+3. (Optional) Keep it unset in Development to avoid local noise.
+
+## Client Behavior
+
+- Implementation:
+  - `src/shared/config/clarity.ts` (`initClarity`)
+  - `src/main.tsx` (calls `initClarity()` during app bootstrap)
+- Loading rules:
+  - If `VITE_CLARITY_PROJECT_ID` is missing or blank: do nothing.
+  - If present: injects the Clarity script tag (`https://www.clarity.ms/tag/<projectId>`).
+
+## Verification Checklist
+
+- Network:
+  - Confirm a request to `https://www.clarity.ms/tag/<projectId>` is made on page load.
+- Clarity dashboard:
+  - Preview deployments should only show up in the Preview project.
+  - Production deployments should only show up in the Production project.
+
+## Disable / Rollback
+
+- Unset `VITE_CLARITY_PROJECT_ID` (or set it to an empty value) in the relevant Vercel environment.

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,6 +6,7 @@ import { createRoot } from 'react-dom/client';
 import { HelmetProvider } from 'react-helmet-async';
 import { ToastContainer } from 'react-toastify';
 
+import { initClarity } from '@/shared/config/clarity.ts';
 import {
   getSentryReactErrorHandlerOptions,
   initSentry,
@@ -17,6 +18,7 @@ import { queryClient } from './shared/apis/queryClient.ts';
 import { toastConfig } from './shared/types/toast.ts';
 
 initSentry();
+initClarity();
 
 // 개발 모드: 최초 진입 시 ?ab=single|multiple 을 로컬스토리지에 저장
 if (import.meta.env.DEV) {

--- a/src/shared/config/clarity.ts
+++ b/src/shared/config/clarity.ts
@@ -1,0 +1,35 @@
+type ClarityFn = (...args: unknown[]) => void;
+
+declare global {
+  interface Window {
+    clarity?: ClarityFn & { q?: unknown[][] };
+  }
+}
+
+const CLARITY_PROJECT_ID = import.meta.env.VITE_CLARITY_PROJECT_ID?.trim();
+
+export function initClarity() {
+  if (!CLARITY_PROJECT_ID) return;
+
+  if (typeof window === 'undefined' || typeof document === 'undefined') {
+    return;
+  }
+
+  // HMR guard
+  if (document.querySelector('script[data-houme-clarity="true"]')) {
+    return;
+  }
+
+  window.clarity =
+    window.clarity ||
+    function (...args: unknown[]) {
+      (window.clarity!.q = window.clarity!.q || []).push(args);
+    };
+
+  const script = document.createElement('script');
+  script.async = true;
+  script.src = `https://www.clarity.ms/tag/${CLARITY_PROJECT_ID}`;
+  script.dataset.houmeClarity = 'true';
+
+  document.head.appendChild(script);
+}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -5,6 +5,7 @@ interface ImportMetaEnv {
   readonly VITE_SENTRY_DSN?: string;
   readonly VITE_SENTRY_ENVIRONMENT?: string;
   readonly VITE_SENTRY_RELEASE?: string;
+  readonly VITE_CLARITY_PROJECT_ID?: string;
   readonly VITE_CURATION_OUTBOUND_UTM_QUERY?: string;
 }
 


### PR DESCRIPTION
## 📌 Summary

- close #437

Vercel 배포 환경(Production/Preview)별로 Microsoft Clarity Project ID를 분리할 수 있도록 클라이언트에 Clarity 스크립트 주입 로직을 추가했습니다.
`VITE_CLARITY_PROJECT_ID` 값이 있을 때만 스크립트를 로드합니다.

## 📄 Tasks

- Clarity script injection 추가 (env 기반)
- Vite env 타입 선언 추가
- 운영 문서 추가 (Vercel 스코프/검증 방법)

## 🔍 To Reviewer

- Vercel Production/Preview에 `VITE_CLARITY_PROJECT_ID`가 서로 다른 값으로 설정되어야 합니다.
- 로컬(Development)에서는 env 미설정 시 스크립트가 로드되지 않습니다.

## 📸 Screenshot

- N/A
