### PR TITLE
[fix] 결과 캐러셀 네비 버튼 상태 불일치

### DIFF
--- a/src/pages/generate/pages/result/components/GeneratedImgA.tsx
+++ b/src/pages/generate/pages/result/components/GeneratedImgA.tsx
@@ -115,6 +115,8 @@ const GeneratedImgA = ({
 
   const lastImage = images[images.length - 1];
   const totalSlideCount = lastImage ? images.length + 1 : images.length;
+  const isPrevDisabled = !swiper || currentSlideIndex === 0;
+  const isNextDisabled = !swiper || currentSlideIndex === totalSlideCount - 1;
 
   /**
    * 더보기 모달 오픈
@@ -199,9 +201,9 @@ const GeneratedImgA = ({
           type="button"
           onClick={() => swiper?.slidePrev()}
           className={styles.slidePrevBtn}
-          disabled={!swiper || currentSlideIndex === 0}
+          disabled={isPrevDisabled}
         >
-          {currentSlideIndex === 0 ? <SlidePrevDisabled /> : <SlidePrev />}
+          {isPrevDisabled ? <SlidePrevDisabled /> : <SlidePrev />}
         </button>
         {images.map((image, index) => {
           const cachedDetection =
@@ -250,13 +252,9 @@ const GeneratedImgA = ({
           type="button"
           onClick={() => swiper?.slideNext()}
           className={styles.slideNextBtn}
-          disabled={!swiper || currentSlideIndex === totalSlideCount - 1}
+          disabled={isNextDisabled}
         >
-          {currentSlideIndex === totalSlideCount - 1 ? (
-            <SlideNextDisabled />
-          ) : (
-            <SlideNext />
-          )}
+          {isNextDisabled ? <SlideNextDisabled /> : <SlideNext />}
         </button>
       </Swiper>
     </div>


### PR DESCRIPTION
## 📌 Summary

- close #439

결과 페이지 캐러셀 네비 버튼의 disabled 조건과 아이콘(활성/비활성) 조건을 동일 플래그로 통일했습니다.

## 📄 Tasks

- isPrevDisabled / isNextDisabled 플래그로 disabled 조건 단일화
- 아이콘 선택 조건도 동일 플래그 사용

## 🔍 To Reviewer

- 초기 렌더 타이밍에 next 버튼이 disabled인데 활성 아이콘으로 보이지 않는지 확인 부탁드립니다

## 📸 Screenshot

- N/A
