### PR TITLE
[fix] SaveButton className 병합 누락

### DIFF
--- a/src/shared/components/button/saveButton/SaveButton.tsx
+++ b/src/shared/components/button/saveButton/SaveButton.tsx
@@ -10,17 +10,27 @@ interface SaveButtonProps extends React.ComponentProps<'button'> {
   onClick: () => void;
 }
 
-const SaveButton = ({ isSelected, onClick, ...props }: SaveButtonProps) => {
+const SaveButton = ({
+  isSelected,
+  onClick,
+  className,
+  ...props
+}: SaveButtonProps) => {
+  const mergedClassName = `${styles.buttonWrapper}${
+    className ? ` ${className}` : ''
+  }`;
+
   return (
     <button
+      {...props}
       type="button"
       onClick={onClick}
       aria-pressed={isSelected}
-      className={styles.buttonWrapper}
-      {...props}
+      className={mergedClassName}
     >
       {isSelected ? <SaveOnIcon /> : <SaveOffIcon />}
     </button>
   );
 };
+
 export default SaveButton;

--- a/src/shared/components/button/saveButton/SaveButton.tsx
+++ b/src/shared/components/button/saveButton/SaveButton.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import clsx from 'clsx';
+
 import SaveOnIcon from '@assets/icons/icnHeartColor.svg?react';
 import SaveOffIcon from '@assets/icons/icnHeartGray.svg?react';
 
@@ -16,17 +18,13 @@ const SaveButton = ({
   className,
   ...props
 }: SaveButtonProps) => {
-  const mergedClassName = `${styles.buttonWrapper}${
-    className ? ` ${className}` : ''
-  }`;
-
   return (
     <button
       {...props}
       type="button"
       onClick={onClick}
       aria-pressed={isSelected}
-      className={mergedClassName}
+      className={clsx(styles.buttonWrapper, className)}
     >
       {isSelected ? <SaveOnIcon /> : <SaveOffIcon />}
     </button>

--- a/src/shared/components/button/saveButton/SaveButton.tsx
+++ b/src/shared/components/button/saveButton/SaveButton.tsx
@@ -5,7 +5,7 @@ import SaveOffIcon from '@assets/icons/icnHeartGray.svg?react';
 
 import * as styles from './SaveButton.css';
 
-interface SaveButtonProps extends React.ComponentProps<'button'> {
+interface SaveButtonProps extends Omit<React.ComponentProps<'button'>, 'type'> {
   isSelected: boolean;
   onClick: () => void;
 }

--- a/src/stories/SaveButton.stories.tsx
+++ b/src/stories/SaveButton.stories.tsx
@@ -11,6 +11,7 @@ const meta: Meta<typeof SaveButton> = {
   argTypes: {
     isSelected: { control: 'boolean' },
     onClick: { action: 'toggle' },
+    className: { control: 'text' },
   },
 };
 
@@ -49,4 +50,19 @@ export const Selected: Story = {
     isSelected: true,
   },
   render: (args) => <RenderButton {...args} />,
+};
+
+export const WithClassName: Story = {
+  args: {
+    isSelected: false,
+    className: 'sb-savebutton-outline',
+  },
+  render: (args) => (
+    <>
+      <style>
+        {`.sb-savebutton-outline { outline: 2px solid #ff0000; outline-offset: 2px; }`}
+      </style>
+      <RenderButton {...args} />
+    </>
+  ),
 };


### PR DESCRIPTION
## 📌 Summary

- close #440

SaveButton에서 외부 className 전달 시 내부 스타일이 사라지지 않도록 className 병합을 보장하고, props 적용 순서를 정리했습니다.

## 📄 Tasks

- SaveButton 내부 className + 외부 className 병합
- {...props}가 className을 덮어쓰지 않도록 적용 순서 정리
- Storybook에 className 전달 케이스 스토리 추가

## 🔍 To Reviewer

- SaveButton에 className을 전달해도 기본 스타일이 유지되는지 확인 부탁드립니다.

## 📸 Screenshot

- N/A