### PR TITLE
[fix] preview 결과 큐레이션 카드 UI 회귀 복구

### DIFF
--- a/src/pages/generate/pages/result/curationSheet/CurationSheet.css.ts
+++ b/src/pages/generate/pages/result/curationSheet/CurationSheet.css.ts
@@ -84,11 +84,9 @@ export const gridbox = style({
   width: '100%',
   height: 'fit-content',
   display: 'grid',
-  gridTemplateColumns: 'repeat(2, 16.4rem)',
+  gridTemplateColumns: 'repeat(2, minmax(16.4rem, 1fr))',
   columnGap: '0.7rem',
   rowGap: 0,
-  justifyContent: 'space-between',
-  justifyItems: 'start',
 });
 
 export const statusContainer = style({

--- a/src/pages/generate/pages/result/curationSheet/CurationSheet.tsx
+++ b/src/pages/generate/pages/result/curationSheet/CurationSheet.tsx
@@ -38,6 +38,40 @@ type ProductPrefetchQueryKey = [
   },
 ];
 
+const RESULT_CARD_UI_FALLBACK = {
+  productName: '상품명 준비중',
+  mallName: '브랜드 준비중',
+  originalPrice: 0,
+  discountPrice: 0,
+  discountRate: 0,
+  colorHexes: ['#E7EBF0', '#D7DFE8', '#C3CFDD', '#AEBED0'],
+  saveCount: 0,
+} as const;
+
+const normalizeText = (value: unknown, fallback: string) => {
+  if (typeof value !== 'string') return fallback;
+  const normalized = value.trim();
+  return normalized.length > 0 ? normalized : fallback;
+};
+
+const toFiniteNumber = (value: unknown) => {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? numeric : null;
+};
+
+const normalizeColorHexes = (value: unknown) => {
+  if (!Array.isArray(value)) return [...RESULT_CARD_UI_FALLBACK.colorHexes];
+
+  const normalized = value
+    .filter((hex): hex is string => typeof hex === 'string')
+    .map((hex) => hex.trim())
+    .filter((hex) => /^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/.test(hex));
+
+  return normalized.length > 0
+    ? normalized
+    : [...RESULT_CARD_UI_FALLBACK.colorHexes];
+};
+
 interface CurationSheetProps {
   groupId?: number | null;
 }
@@ -96,37 +130,41 @@ export const CurationSheet = ({ groupId = null }: CurationSheetProps) => {
         ? byProductId
         : index + 1;
 
-      const originalPrice = Number(product.furnitureProductOriginalPrice);
-      const discountPrice = Number(product.furnitureProductDiscountPrice);
-      const discountRate = Number(product.furnitureProductDiscountRate);
-      const saveCount = Number(product.furnitureProductSaveCount);
+      const originalPrice = toFiniteNumber(
+        product.furnitureProductOriginalPrice
+      );
+      const discountPrice = toFiniteNumber(
+        product.furnitureProductDiscountPrice
+      );
+      const discountRate = toFiniteNumber(product.furnitureProductDiscountRate);
+      const saveCount = toFiniteNumber(product.furnitureProductSaveCount);
 
       return {
         id: recommendId,
         isRecommendId: Boolean(recommendId),
         furnitureProductId: safeProductId,
-        furnitureProductName: product.furnitureProductName,
-        furnitureProductMallName: product.furnitureProductMallName,
+        furnitureProductName: normalizeText(
+          product.furnitureProductName,
+          RESULT_CARD_UI_FALLBACK.productName
+        ),
+        furnitureProductMallName: normalizeText(
+          product.furnitureProductMallName,
+          RESULT_CARD_UI_FALLBACK.mallName
+        ),
         furnitureProductImageUrl:
           product.furnitureProductImageUrl || product.baseFurnitureImageUrl,
         furnitureProductSiteUrl: product.furnitureProductSiteUrl,
-        furnitureProductOriginalPrice: Number.isFinite(originalPrice)
-          ? originalPrice
-          : undefined,
-        furnitureProductDiscountPrice: Number.isFinite(discountPrice)
-          ? discountPrice
-          : undefined,
-        furnitureProductDiscountRate: Number.isFinite(discountRate)
-          ? discountRate
-          : undefined,
-        furnitureProductColorHexes: Array.isArray(
+        furnitureProductOriginalPrice:
+          originalPrice ?? RESULT_CARD_UI_FALLBACK.originalPrice,
+        furnitureProductDiscountPrice:
+          discountPrice ?? RESULT_CARD_UI_FALLBACK.discountPrice,
+        furnitureProductDiscountRate:
+          discountRate ?? RESULT_CARD_UI_FALLBACK.discountRate,
+        furnitureProductColorHexes: normalizeColorHexes(
           product.furnitureProductColorHexes
-        )
-          ? product.furnitureProductColorHexes
-          : undefined,
-        furnitureProductSaveCount: Number.isFinite(saveCount)
-          ? saveCount
-          : undefined,
+        ),
+        furnitureProductSaveCount:
+          saveCount ?? RESULT_CARD_UI_FALLBACK.saveCount,
       };
     });
   }, [productsData]);


### PR DESCRIPTION
## 📌 Summary

- close #445

preview(mypage->result) 결과 페이지 큐레이션 카드 UI 회귀를 복구했습니다.

## 📄 Tasks

- CurationSheet 카드 그리드 반응형(minmax) 복구
- API 숫자/텍스트/컬러 데이터 미존재 시 UI 기본값(0/placeholder) 적용 복구

## 🔍 To Reviewer

- 기존 정책대로 숫자 데이터가 비어도 0으로 노출되도록 복구했습니다. (0원/0%/0)

## 📸 Screenshot

- (필요 시 첨부)
