### PR TITLE
[fix] 생성 결과 카드 찜 토스트 디자인 수정

### DIFF
--- a/src/pages/generate/pages/result/curationSheet/CardProductItem.tsx
+++ b/src/pages/generate/pages/result/curationSheet/CardProductItem.tsx
@@ -90,6 +90,11 @@ const CardProductItem = memo(
       onGotoMypage();
     };
 
+    const handleUndoUnfavorite = () => {
+      if (recommendId === null || isMutating) return;
+      toggleJjym(recommendId);
+    };
+
     const handleToggle = () => {
       if (recommendId === null) {
         notify({
@@ -106,17 +111,33 @@ const CardProductItem = memo(
 
       toggleJjym(recommendId, {
         onSuccess: (data) => {
-          if (!wasSaved && data.favorited) {
-            const now = Date.now();
-            if (now - toastCooldownRef.current < TOAST_COOLDOWN_MS) {
-              return; // 연속 클릭 시 스낵바 중복 방지
-            }
-            toastCooldownRef.current = now;
-            // 스낵바 중복 노출 방지 가드
+          const showFavoriteToast = !wasSaved && data.favorited;
+          const showUnfavoriteToast = wasSaved && !data.favorited;
+
+          if (!showFavoriteToast && !showUnfavoriteToast) return;
+
+          const now = Date.now();
+          if (now - toastCooldownRef.current < TOAST_COOLDOWN_MS) {
+            return; // 연속 클릭 시 스낵바 중복 방지
+          }
+          toastCooldownRef.current = now;
+
+          if (showFavoriteToast) {
             notify({
               text: '상품을 찜했어요! 찜한 가구로 이동할까요?',
               type: TOAST_TYPE.NAVIGATE,
               onClick: handleNavigateAndFocus,
+              options: { style: { marginBottom: '2rem' } },
+            });
+            return;
+          }
+
+          if (showUnfavoriteToast) {
+            notify({
+              text: '상품의 찜이 해제 되었어요',
+              type: TOAST_TYPE.NAVIGATE,
+              onClick: handleUndoUnfavorite,
+              actionLabel: '취소하기',
               options: { style: { marginBottom: '2rem' } },
             });
           }

--- a/src/pages/generate/pages/result/curationSheet/CardProductItem.tsx
+++ b/src/pages/generate/pages/result/curationSheet/CardProductItem.tsx
@@ -114,7 +114,7 @@ const CardProductItem = memo(
             toastCooldownRef.current = now;
             // 스낵바 중복 노출 방지 가드
             notify({
-              text: '상품을 찜했어요! 위시리스트로 이동할까요?',
+              text: '상품을 찜했어요! 찜한 가구로 이동할까요?',
               type: TOAST_TYPE.NAVIGATE,
               onClick: handleNavigateAndFocus,
               options: { style: { marginBottom: '2rem' } },

--- a/src/pages/generate/pages/result/curationSheet/CardProductItem.tsx
+++ b/src/pages/generate/pages/result/curationSheet/CardProductItem.tsx
@@ -68,7 +68,13 @@ const CardProductItem = memo(
 
     const savedProductIds = useSavedItemsStore((s) => s.savedProductIds);
     const isSaved = hasRecommendId ? savedProductIds.has(recommendId) : false;
-    const toastCooldownRef = useRef(0); // 최근 스낵바 노출 시각(ms)
+    const toastCooldownRef = useRef<{
+      kind: 'favorite' | 'unfavorite' | null;
+      shownAt: number;
+    }>({
+      kind: null,
+      shownAt: 0,
+    }); // 최근 스낵바 노출 종류/시각(ms)
 
     const { mutate: toggleJjym } = usePostJjymMutation();
     const { notify } = useToast();
@@ -79,6 +85,8 @@ const CardProductItem = memo(
           mutation.options.mutationKey?.[0] === 'jjym' &&
           mutation.state.variables === (recommendId ?? undefined), // 이 카드 id만 추적
       }) > 0;
+    const isMutatingRef = useRef(false);
+    isMutatingRef.current = isMutating; // 토스트 액션 핸들러 최신 동기화
 
     const handleNavigateAndFocus = () => {
       if (recommendId === null) return;
@@ -91,7 +99,7 @@ const CardProductItem = memo(
     };
 
     const handleUndoUnfavorite = () => {
-      if (recommendId === null || isMutating) return;
+      if (recommendId === null || isMutatingRef.current) return;
       toggleJjym(recommendId);
     };
 
@@ -116,18 +124,24 @@ const CardProductItem = memo(
 
           if (!showFavoriteToast && !showUnfavoriteToast) return;
 
+          const toastKind = showFavoriteToast ? 'favorite' : 'unfavorite';
           const now = Date.now();
-          if (now - toastCooldownRef.current < TOAST_COOLDOWN_MS) {
+          if (
+            toastCooldownRef.current.kind === toastKind &&
+            now - toastCooldownRef.current.shownAt < TOAST_COOLDOWN_MS
+          ) {
             return; // 연속 클릭 시 스낵바 중복 방지
           }
-          toastCooldownRef.current = now;
+          toastCooldownRef.current = {
+            kind: toastKind,
+            shownAt: now,
+          };
 
           if (showFavoriteToast) {
             notify({
               text: '상품을 찜했어요! 찜한 가구로 이동할까요?',
               type: TOAST_TYPE.NAVIGATE,
               onClick: handleNavigateAndFocus,
-              options: { style: { marginBottom: '2rem' } },
             });
             return;
           }
@@ -138,7 +152,6 @@ const CardProductItem = memo(
               type: TOAST_TYPE.NAVIGATE,
               onClick: handleUndoUnfavorite,
               actionLabel: '취소하기',
-              options: { style: { marginBottom: '2rem' } },
             });
           }
         },

--- a/src/shared/components/toast/Toast.css.ts
+++ b/src/shared/components/toast/Toast.css.ts
@@ -16,7 +16,8 @@ export const container = recipe({
   variants: {
     type: {
       navigate: {
-        width: '34.3rem', // 343px
+        width: 'calc(100vw - 3.2rem)', // viewport minus horizontal 16px gutters
+        maxWidth: '40.8rem', // 440px layout minus 32px gutters
         height: '4.4rem', // 44px
         justifyContent: 'space-between',
         gap: 0,

--- a/src/shared/components/toast/Toast.css.ts
+++ b/src/shared/components/toast/Toast.css.ts
@@ -4,12 +4,25 @@ import { recipe } from '@vanilla-extract/recipes';
 import { fontStyle } from '@/shared/styles/fontStyle';
 import { colorVars } from '@/shared/styles/tokens/color.css';
 
-export const container = style({
-  display: 'inline-flex',
-  gap: '1.5rem',
-  padding: '1rem 2rem',
-  borderRadius: '30px',
-  background: colorVars.color.gray900,
+export const container = recipe({
+  base: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: '1.5rem',
+    padding: '1rem 2rem',
+    borderRadius: '30px',
+    background: colorVars.color.gray900,
+  },
+  variants: {
+    type: {
+      navigate: {
+        width: '34.3rem', // 343px
+        height: '4.4rem', // 44px
+        justifyContent: 'space-between',
+        gap: 0,
+      },
+    },
+  },
 });
 
 export const text = recipe({
@@ -20,7 +33,9 @@ export const text = recipe({
   variants: {
     type: {
       navigate: {
+        ...fontStyle('body_r_14'),
         color: colorVars.color.gray300,
+        textAlign: 'center',
       },
     },
   },
@@ -28,6 +43,7 @@ export const text = recipe({
 
 export const action = style({
   ...fontStyle('body_m_14'),
+  flexShrink: 0,
   textDecoration: 'underline',
   color: colorVars.color.gray000,
 });

--- a/src/shared/components/toast/Toast.tsx
+++ b/src/shared/components/toast/Toast.tsx
@@ -35,7 +35,11 @@ const Toast = ({ text, type, onClick, closeToast }: ToastProps) => {
   };
 
   return (
-    <div className={styles.container}>
+    <div
+      className={styles.container({
+        type: type === TOAST_TYPE.NAVIGATE ? 'navigate' : undefined,
+      })}
+    >
       {ICON_MAP[type]}
       <span
         className={styles.text({

--- a/src/shared/components/toast/Toast.tsx
+++ b/src/shared/components/toast/Toast.tsx
@@ -12,6 +12,7 @@ interface ToastProps {
   text: string;
   type: ToastType;
   onClick?: () => void;
+  actionLabel?: string;
   closeToast?: ToastContentProps['closeToast'];
   // react-toastify의 ToastContentProps로부터 closeToast 함수 가져옴 -> Toast 컴포넌트에서 closeToast 받아서 사용
   // 타입은 optional이지만 toast() 함수로 컴포넌트 렌더링 시 react-toastify는 무조건 closeToast 주입(그렇게 설계됨)
@@ -24,7 +25,13 @@ const ICON_MAP: Record<ToastType, JSX.Element> = {
   [TOAST_TYPE.WARNING]: <WarningIcon />,
 };
 
-const Toast = ({ text, type, onClick, closeToast }: ToastProps) => {
+const Toast = ({
+  text,
+  type,
+  onClick,
+  actionLabel = '보러가기',
+  closeToast,
+}: ToastProps) => {
   const handleActionClick = () => {
     if (onClick) {
       onClick();
@@ -54,7 +61,7 @@ const Toast = ({ text, type, onClick, closeToast }: ToastProps) => {
           className={styles.action}
           onClick={handleActionClick}
         >
-          보러가기
+          {actionLabel}
         </button>
       )}
     </div>

--- a/src/shared/components/toast/ToastTest.tsx
+++ b/src/shared/components/toast/ToastTest.tsx
@@ -11,7 +11,7 @@ const ToastTest = () => {
         type="button"
         onClick={() =>
           notify({
-            text: '상품을 찜했어요! 위시리스트로 이동할까요?',
+            text: '상품을 찜했어요! 찜한 가구로 이동할까요?',
             type: TOAST_TYPE.NAVIGATE,
             onClick: () => {
               console.log('토스트 클릭');

--- a/src/shared/components/toast/useToast.tsx
+++ b/src/shared/components/toast/useToast.tsx
@@ -10,6 +10,7 @@ interface UseToastParams {
   type?: ToastType;
   options?: ToastOptions;
   onClick?: () => void;
+  actionLabel?: string;
   ariaLabel?: string;
   marginBottom?: string;
 }
@@ -25,6 +26,7 @@ export const useToast = () => {
       type = TOAST_TYPE.INFO,
       options,
       onClick,
+      actionLabel,
       ariaLabel = '토스트 알림',
       marginBottom = '2rem',
     }: UseToastParams) => {
@@ -35,7 +37,12 @@ export const useToast = () => {
 
       // 2) 새 토스트를 띄우고, 반환된 ID를 저장
       toastId.current = toast(
-        <Toast text={text} type={type} onClick={onClick} />,
+        <Toast
+          text={text}
+          type={type}
+          onClick={onClick}
+          actionLabel={actionLabel}
+        />,
         {
           ...options,
           ariaLabel: ariaLabel,

--- a/src/stories/Toast.stories.tsx
+++ b/src/stories/Toast.stories.tsx
@@ -46,10 +46,12 @@ export const Warning: Story = {
 };
 
 export const Navigate: Story = {
+  argTypes: {
+    onClick: { action: 'navigate' },
+  },
   args: {
     text: '상품을 찜했어요! 찜한 가구로 이동할까요?',
     type: TOAST_TYPE.NAVIGATE,
-    onClick: () => undefined,
   },
 };
 

--- a/src/stories/Toast.stories.tsx
+++ b/src/stories/Toast.stories.tsx
@@ -45,6 +45,14 @@ export const Warning: Story = {
   },
 };
 
+export const Navigate: Story = {
+  args: {
+    text: '상품을 찜했어요! 찜한 가구로 이동할까요?',
+    type: TOAST_TYPE.NAVIGATE,
+    onClick: () => undefined,
+  },
+};
+
 export const CustomMargin: Story = {
   args: {
     text: '하단 여백이 변경된 토스트 예시',


### PR DESCRIPTION
## 📌 Summary

- close #448

생성 결과 페이지에서 카드 찜/찜 해제 시 노출되는 네비게이션형 토스트를 디자인 시안과 일치하도록 수정했습니다.
기존 찜 성공 토스트 동작은 유지하면서, 찜 해제 시 토스트 문구와 액션을 추가했습니다.
찜 해제 토스트의 `취소하기`를 누르면 동일 상품을 즉시 재찜하도록 연결했습니다.

## 📄 Tasks

- 네비게이션형 토스트 레이아웃 정렬 및 타이포 정합성 개선
- 찜 토스트 메시지 카피 수정
- 찜 해제 토스트 문구(`상품의 찜이 해제 되었어요`) 및 액션 라벨(`취소하기`) 추가
- 토스트 액션 라벨 커스터마이즈 지원(`actionLabel`) 추가
- Storybook에 네비게이션 토스트 스토리 추가

## 🔍 To Reviewer

- 찜 해제 후 `취소하기` 클릭 시 동일 상품 재찜이 의도대로 동작하는지 확인 부탁드립니다.
- 기존 찜 성공 토스트(`보러가기`)의 UI/동작 회귀가 없는지 확인 부탁드립니다.

## 📸 Screenshot

- N/A
