### PR TITLE
[feat] 일부 컴포넌트의 컴포넌트 레벨 에러처리 강화, 인라인 폴백 UI 적용

### DIFF
--- a/src/layout/RootLayout.tsx
+++ b/src/layout/RootLayout.tsx
@@ -20,7 +20,7 @@ function RootLayout() {
   useScrollToTop();
   useGenerateWarmup();
   return (
-    <div>
+    <div style={{ display: 'flex', flexDirection: 'column', flex: 1 }}>
       <Outlet />
     </div>
   );

--- a/src/pages/generate/GeneratePage.tsx
+++ b/src/pages/generate/GeneratePage.tsx
@@ -45,7 +45,7 @@ const GeneratePage = () => {
   };
 
   return (
-    <main>
+    <main style={{ display: 'flex', flexDirection: 'column', flex: 1 }}>
       <TitleNavBar
         title={title}
         isBackIcon={!!isBackIcon}

--- a/src/pages/generate/pages/result/ResultPage.tsx
+++ b/src/pages/generate/pages/result/ResultPage.tsx
@@ -9,6 +9,7 @@ import type {
   MyPageUserData,
 } from '@/pages/mypage/types/apis/MyPage';
 import { createImageDetailPlaceholder } from '@/pages/mypage/utils/resultNavigation';
+import InlineError from '@/shared/components/inlineError/InlineError';
 
 import Loading from '@components/loading/Loading';
 import { useABTest } from '@pages/generate/hooks/useABTest';
@@ -112,12 +113,13 @@ const ResultPage = () => {
       : null;
 
   // 마이페이지에서 온 경우와 일반 생성 플로우에서 온 경우 구분
-  const { data: apiResult, isLoading } = useGetResultDataQuery(
-    parsedHouseId ?? 0,
-    {
-      enabled: shouldFetchExternalResult,
-    }
-  );
+  const {
+    data: apiResult,
+    isLoading,
+    isError: isResultError,
+  } = useGetResultDataQuery(parsedHouseId ?? 0, {
+    enabled: shouldFetchExternalResult,
+  });
 
   const mypageDetailQuery = useMyPageImageDetail(parsedHouseId ?? 0, {
     enabled: shouldFetchMypageDetail,
@@ -199,6 +201,11 @@ const ResultPage = () => {
   // 로딩 중이면 로딩 표시
   if (!result && (isLoading || mypageLoading)) {
     return <Loading />;
+  }
+
+  // API 에러 시 인라인 에러 표시
+  if (isResultError && !result) {
+    return <InlineError message="결과를 불러올 수 없습니다" />;
   }
 
   // 데이터 없으면 홈으로 리다이렉션

--- a/src/pages/generate/pages/result/curationSheet/CurationSheet.tsx
+++ b/src/pages/generate/pages/result/curationSheet/CurationSheet.tsx
@@ -361,25 +361,27 @@ export const CurationSheet = ({ groupId = null }: CurationSheetProps) => {
     <section className={styles.container}>
       <h2 className={styles.title}>이 공간의 가구 큐레이션</h2>
 
-      <div className={styles.filterSection}>
-        {categories.length === 0 ? (
-          // 감지/로딩 중에는 세 번째 길이(long) 스켈레톤 칩 하나만 노출
-          <span
-            className={`${styles.filterSkeletonChip} ${styles.filterSkeletonChipWidth[FILTER_SKELETON_WIDTH]}`}
-            aria-hidden
-          />
-        ) : (
-          categories.map((category) => (
-            <FilterChip
-              key={category.id}
-              isSelected={selectedCategoryId === category.id}
-              onClick={() => handleCategorySelect(category.id)}
-            >
-              {category.categoryName}
-            </FilterChip>
-          ))
-        )}
-      </div>
+      {!categoriesQuery.isError && (
+        <div className={styles.filterSection}>
+          {categories.length === 0 ? (
+            // 감지/로딩 중에는 세 번째 길이(long) 스켈레톤 칩 하나만 노출
+            <span
+              className={`${styles.filterSkeletonChip} ${styles.filterSkeletonChipWidth[FILTER_SKELETON_WIDTH]}`}
+              aria-hidden
+            />
+          ) : (
+            categories.map((category) => (
+              <FilterChip
+                key={category.id}
+                isSelected={selectedCategoryId === category.id}
+                onClick={() => handleCategorySelect(category.id)}
+              >
+                {category.categoryName}
+              </FilterChip>
+            ))
+          )}
+        </div>
+      )}
 
       <div className={styles.content}>{renderProductSection()}</div>
     </section>

--- a/src/pages/imageSetup/components/layout/FunnelLayout.css.ts
+++ b/src/pages/imageSetup/components/layout/FunnelLayout.css.ts
@@ -1,0 +1,13 @@
+import { style } from '@vanilla-extract/css';
+
+export const wrapper = style({
+  display: 'flex',
+  flexDirection: 'column',
+  flex: 1,
+});
+
+export const content = style({
+  display: 'flex',
+  flexDirection: 'column',
+  flex: 1,
+});

--- a/src/pages/imageSetup/components/layout/FunnelLayout.tsx
+++ b/src/pages/imageSetup/components/layout/FunnelLayout.tsx
@@ -4,6 +4,7 @@ import { useNavigate } from 'react-router-dom';
 import TitleNavBar from '@/shared/components/navBar/TitleNavBar';
 import Popup from '@/shared/components/overlay/popup/Popup';
 
+import * as styles from './FunnelLayout.css';
 import {
   logSelectHouseInfoClickModalContinue,
   logSelectHouseInfoClickModalExit,
@@ -40,14 +41,14 @@ const FunnelLayout = ({ children, currentStep }: FunnelLayoutProps) => {
   };
 
   return (
-    <div>
+    <div className={styles.wrapper}>
       <TitleNavBar
         title="스타일링 이미지 생성"
         isBackIcon={true}
         isLoginBtn={false}
         onBackClick={currentStep === 'HouseInfo' ? handleBackClick : undefined}
       />
-      <div>{children}</div>
+      <div className={styles.content}>{children}</div>
     </div>
   );
 };

--- a/src/pages/imageSetup/hooks/useFloorPlan.ts
+++ b/src/pages/imageSetup/hooks/useFloorPlan.ts
@@ -13,7 +13,7 @@ export const useFloorPlan = (
   onNext: (data: CompletedFloorPlan) => void
 ) => {
   // FloorPlan 컴포넌트 렌더링 -> useFloorPlan 훅 실행 -> 서버가 사용자 선택 정보 기반으로 도면 반환
-  const { data, isLoading, error, isError } = useFloorPlanQuery();
+  const { data, isLoading, error, isError, refetch } = useFloorPlanQuery();
   // console.log('도면 데이터: ', data);
 
   // Zustand store에서 저장된 데이터
@@ -73,6 +73,7 @@ export const useFloorPlan = (
     isLoading,
     error,
     isError,
+    refetch,
 
     // 선택 상태
     selectedId,

--- a/src/pages/imageSetup/hooks/useFloorPlan.ts
+++ b/src/pages/imageSetup/hooks/useFloorPlan.ts
@@ -13,7 +13,7 @@ export const useFloorPlan = (
   onNext: (data: CompletedFloorPlan) => void
 ) => {
   // FloorPlan 컴포넌트 렌더링 -> useFloorPlan 훅 실행 -> 서버가 사용자 선택 정보 기반으로 도면 반환
-  const { data, isLoading, error, isError, refetch } = useFloorPlanQuery();
+  const { data, isPending, error, isError, refetch } = useFloorPlanQuery();
   // console.log('도면 데이터: ', data);
 
   // Zustand store에서 저장된 데이터
@@ -70,7 +70,7 @@ export const useFloorPlan = (
   return {
     // API 데이터
     floorPlanList: data?.floorPlanList,
-    isLoading,
+    isPending,
     error,
     isError,
     refetch,

--- a/src/pages/imageSetup/hooks/useHouseInfo.ts
+++ b/src/pages/imageSetup/hooks/useHouseInfo.ts
@@ -1,6 +1,8 @@
 import { useEffect, useState } from 'react';
 
 import { queryClient } from '@/shared/apis/queryClient';
+import { useToast } from '@/shared/components/toast/useToast';
+import { TOAST_TYPE } from '@/shared/types/toast';
 
 import { useHousingSelectionMutation } from '../apis/houseInfo';
 import { useFunnelStore } from '../stores/useFunnelStore';
@@ -16,6 +18,7 @@ import type { ImageSetupSteps } from '../types/funnel/steps';
 export const useHouseInfo = (context: ImageSetupSteps['HouseInfo']) => {
   // 주거 옵션 선택 API
   const housingSelection = useHousingSelectionMutation();
+  const { notify } = useToast();
 
   // Zustand store에서 저장된 데이터
   const savedHouseInfo = useFunnelStore((state) => state.houseInfo);
@@ -127,6 +130,12 @@ export const useHouseInfo = (context: ImageSetupSteps['HouseInfo']) => {
           queryClient.invalidateQueries({ queryKey: ['floorPlan'] });
 
           onNext(completedData);
+        },
+        onError: () => {
+          notify({
+            text: '주거 정보 저장 중 오류가 발생했어요',
+            type: TOAST_TYPE.WARNING,
+          });
         },
       }
     );

--- a/src/pages/imageSetup/pages/activityInfo/ActivityInfo.css.ts
+++ b/src/pages/imageSetup/pages/activityInfo/ActivityInfo.css.ts
@@ -5,6 +5,7 @@ import { animationTokens } from '@/shared/styles/tokens/animation.css';
 export const container = style({
   display: 'flex',
   flexDirection: 'column',
+  flex: 1,
   width: '100%',
 });
 

--- a/src/pages/imageSetup/pages/activityInfo/ActivityInfo.tsx
+++ b/src/pages/imageSetup/pages/activityInfo/ActivityInfo.tsx
@@ -3,6 +3,7 @@ import { FUNNELHEADER_IMAGES } from '@/pages/imageSetup/constants/headerImages';
 import { useActivityInfo } from '@/pages/imageSetup/hooks/activityInfo/useActivityInfo';
 import { useCreditCheck } from '@/pages/imageSetup/hooks/useCreditCheck';
 import CtaButton from '@/shared/components/button/ctaButton/CtaButton';
+import InlineError from '@/shared/components/inlineError/InlineError';
 import Loading from '@/shared/components/loading/Loading';
 
 import * as styles from './ActivityInfo.css';
@@ -21,7 +22,8 @@ const ActivityInfo = ({ context }: ActivityInfoProps) => {
   const {
     data: activityOptionsData,
     isPending,
-    error,
+    isError,
+    refetch,
   } = useActivityOptionsQuery();
 
   // console.log(activityOptionsData);
@@ -47,9 +49,9 @@ const ActivityInfo = ({ context }: ActivityInfoProps) => {
     }
   };
 
-  // 에러 처리
-  if (error) {
-    return <div>데이터를 불러올 수 없습니다.</div>;
+  // API 에러 시 인라인 에러 표시
+  if (isError) {
+    return <InlineError onRetry={refetch} />;
   }
 
   // pending / 데이터가 없는 경우

--- a/src/pages/imageSetup/pages/activityInfo/ActivityInfo.tsx
+++ b/src/pages/imageSetup/pages/activityInfo/ActivityInfo.tsx
@@ -49,30 +49,8 @@ const ActivityInfo = ({ context }: ActivityInfoProps) => {
     }
   };
 
-  // API 에러 시 인라인 에러 표시
-  if (isError) {
-    return <InlineError onRetry={refetch} />;
-  }
-
-  // pending / 데이터가 없는 경우
-  if (isPending || !activityOptionsData || !categorySelections) {
-    return <Loading />;
-  }
-
-  const activityTypeOptions = activityOptionsData.activities;
-  const bedOptions = activityOptionsData.categories[0];
-  const sofaOptions = activityOptionsData.categories[1];
-  const storageOptions = activityOptionsData.categories[2];
-  const tableOptions = activityOptionsData.categories[3];
-  const selectiveOptions = activityOptionsData.categories[4];
-
-  // 선택된 가구 총 개수 계산
-  const totalSelectedFurniture =
-    categorySelections.bed.selectedValues.length +
-    categorySelections.sofa.selectedValues.length +
-    categorySelections.storage.selectedValues.length +
-    categorySelections.table.selectedValues.length +
-    categorySelections.selective.selectedValues.length;
+  const isReady =
+    !isError && !isPending && activityOptionsData && categorySelections;
 
   return (
     <div className={styles.container}>
@@ -83,115 +61,127 @@ const ActivityInfo = ({ context }: ActivityInfoProps) => {
         image={FUNNELHEADER_IMAGES[4]}
       />
 
-      <div className={styles.contents}>
-        <div>
-          <HeadingText
-            title="주요 활동"
-            subtitle="선택한 활동에 최적화된 동선을 알려드려요."
-          />
-          <div className={styles.activityButton}>
-            <ButtonGroup<string>
-              options={activityTypeOptions}
-              selectedValues={activitySelection.selectedValues}
-              onSelectionChange={activitySelection.handleActivityChange}
-              keyExtractor={(option) => option.code}
-              selectionMode="single"
-              buttonSize="large"
-              layout="grid-2"
+      {isError ? (
+        <InlineError onRetry={refetch} />
+      ) : !isReady ? (
+        <Loading />
+      ) : (
+        <div className={styles.contents}>
+          <div>
+            <HeadingText
+              title="주요 활동"
+              subtitle="선택한 활동에 최적화된 동선을 알려드려요."
             />
-          </div>
-          {selectedActivityLabel && (
-            <div className={styles.caption}>
-              <Caption
-                code={selectedActivityLabel}
-                option={getRequiredFurnitureLabels()}
+            <div className={styles.activityButton}>
+              <ButtonGroup<string>
+                options={activityOptionsData.activities}
+                selectedValues={activitySelection.selectedValues}
+                onSelectionChange={activitySelection.handleActivityChange}
+                keyExtractor={(option) => option.code}
+                selectionMode="single"
+                buttonSize="large"
+                layout="grid-2"
               />
             </div>
-          )}
+            {selectedActivityLabel && (
+              <div className={styles.caption}>
+                <Caption
+                  code={selectedActivityLabel}
+                  option={getRequiredFurnitureLabels()}
+                />
+              </div>
+            )}
+          </div>
+
+          <div className={styles.furnitures}>
+            <HeadingText
+              title="가구"
+              subtitle={`선택한 가구들로 이미지를 생성해드려요. (${
+                categorySelections.bed.selectedValues.length +
+                categorySelections.sofa.selectedValues.length +
+                categorySelections.storage.selectedValues.length +
+                categorySelections.table.selectedValues.length +
+                categorySelections.selective.selectedValues.length
+              }/6)`}
+            />
+            <ButtonGroup<number>
+              title={activityOptionsData.categories[0].nameKr}
+              titleSize="small"
+              hasBorder={true}
+              options={activityOptionsData.categories[0].furnitures}
+              selectedValues={categorySelections.bed.selectedValues}
+              onSelectionChange={categorySelections.bed.handleChange}
+              keyExtractor={(option) => option.id!}
+              selectionMode="single"
+              buttonSize="xsmall"
+              layout="grid-4"
+              buttonStatuses={categorySelections.bed.furnitureStatus}
+            />
+
+            <ButtonGroup<number>
+              title={activityOptionsData.categories[1].nameKr}
+              titleSize="small"
+              hasBorder={true}
+              options={activityOptionsData.categories[1].furnitures}
+              selectedValues={categorySelections.sofa.selectedValues}
+              onSelectionChange={categorySelections.sofa.handleChange}
+              keyExtractor={(option) => option.id!}
+              selectionMode="single"
+              buttonSize="medium"
+              layout="grid-2"
+              buttonStatuses={categorySelections.sofa.furnitureStatus}
+            />
+
+            <ButtonGroup<number>
+              title={activityOptionsData.categories[2].nameKr}
+              titleSize="small"
+              options={activityOptionsData.categories[2].furnitures}
+              selectedValues={categorySelections.storage.selectedValues}
+              onSelectionChange={categorySelections.storage.handleChange}
+              keyExtractor={(option) => option.id!}
+              selectionMode="multiple"
+              buttonSize="large"
+              layout="grid-2"
+              buttonStatuses={categorySelections.storage.furnitureStatus}
+            />
+
+            <ButtonGroup<number>
+              title={activityOptionsData.categories[3].nameKr}
+              titleSize="small"
+              options={activityOptionsData.categories[3].furnitures}
+              selectedValues={categorySelections.table.selectedValues}
+              onSelectionChange={categorySelections.table.handleChange}
+              keyExtractor={(option) => option.id!}
+              selectionMode="multiple"
+              buttonSize="small"
+              layout="grid-3"
+              buttonStatuses={categorySelections.table.furnitureStatus}
+            />
+
+            <ButtonGroup<number>
+              title={activityOptionsData.categories[4].nameKr}
+              titleSize="small"
+              options={activityOptionsData.categories[4].furnitures}
+              selectedValues={categorySelections.selective.selectedValues}
+              onSelectionChange={categorySelections.selective.handleChange}
+              keyExtractor={(option) => option.id!}
+              selectionMode="multiple"
+              buttonSize="large"
+              layout="grid-2"
+              buttonStatuses={categorySelections.selective.furnitureStatus}
+            />
+          </div>
+
+          <div>
+            <CtaButton
+              isActive={isFormCompleted && (!isCreditChecked || hasCredit)}
+              onClick={handleImageGeneration}
+            >
+              이미지 생성하기
+            </CtaButton>
+          </div>
         </div>
-
-        <div className={styles.furnitures}>
-          <HeadingText
-            title="가구"
-            subtitle={`선택한 가구들로 이미지를 생성해드려요. (${totalSelectedFurniture}/6)`}
-          />
-          <ButtonGroup<number>
-            title={bedOptions.nameKr}
-            titleSize="small"
-            hasBorder={true}
-            options={bedOptions.furnitures}
-            selectedValues={categorySelections.bed.selectedValues}
-            onSelectionChange={categorySelections.bed.handleChange}
-            keyExtractor={(option) => option.id!}
-            selectionMode="single"
-            buttonSize="xsmall"
-            layout="grid-4"
-            buttonStatuses={categorySelections.bed.furnitureStatus}
-          />
-
-          <ButtonGroup<number>
-            title={sofaOptions.nameKr}
-            titleSize="small"
-            hasBorder={true}
-            options={sofaOptions.furnitures}
-            selectedValues={categorySelections.sofa.selectedValues}
-            onSelectionChange={categorySelections.sofa.handleChange}
-            keyExtractor={(option) => option.id!}
-            selectionMode="single"
-            buttonSize="medium"
-            layout="grid-2"
-            buttonStatuses={categorySelections.sofa.furnitureStatus}
-          />
-
-          <ButtonGroup<number>
-            title={storageOptions.nameKr}
-            titleSize="small"
-            options={storageOptions.furnitures}
-            selectedValues={categorySelections.storage.selectedValues}
-            onSelectionChange={categorySelections.storage.handleChange}
-            keyExtractor={(option) => option.id!}
-            selectionMode="multiple"
-            buttonSize="large"
-            layout="grid-2"
-            buttonStatuses={categorySelections.storage.furnitureStatus}
-          />
-
-          <ButtonGroup<number>
-            title={tableOptions.nameKr}
-            titleSize="small"
-            options={tableOptions.furnitures}
-            selectedValues={categorySelections.table.selectedValues}
-            onSelectionChange={categorySelections.table.handleChange}
-            keyExtractor={(option) => option.id!}
-            selectionMode="multiple"
-            buttonSize="small"
-            layout="grid-3"
-            buttonStatuses={categorySelections.table.furnitureStatus}
-          />
-
-          <ButtonGroup<number>
-            title={selectiveOptions.nameKr}
-            titleSize="small"
-            options={selectiveOptions.furnitures}
-            selectedValues={categorySelections.selective.selectedValues}
-            onSelectionChange={categorySelections.selective.handleChange}
-            keyExtractor={(option) => option.id!}
-            selectionMode="multiple"
-            buttonSize="large"
-            layout="grid-2"
-            buttonStatuses={categorySelections.selective.furnitureStatus}
-          />
-        </div>
-
-        <div>
-          <CtaButton
-            isActive={isFormCompleted && (!isCreditChecked || hasCredit)}
-            onClick={handleImageGeneration}
-          >
-            이미지 생성하기
-          </CtaButton>
-        </div>
-      </div>
+      )}
     </div>
   );
 };

--- a/src/pages/imageSetup/pages/floorPlan/FloorPlan.css.ts
+++ b/src/pages/imageSetup/pages/floorPlan/FloorPlan.css.ts
@@ -6,6 +6,7 @@ export const container = style({
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'center',
+  flex: 1,
   width: '100%',
 });
 

--- a/src/pages/imageSetup/pages/floorPlan/FloorPlan.tsx
+++ b/src/pages/imageSetup/pages/floorPlan/FloorPlan.tsx
@@ -32,30 +32,7 @@ const FloorPlan = ({ context, onNext }: FloorPlanProps) => {
     handleFloorPlanSelection,
   } = useFloorPlan(context, onNext);
 
-  // 로딩 상태 처리
-  if (isPending) {
-    return <Loading />;
-  }
-
-  // API 에러 시 인라인 에러 표시
-  if (isError) {
-    return <InlineError onRetry={refetch} />;
-  }
-
-  // 데이터가 없는 경우
-  if (!floorPlanList || floorPlanList.length === 0) {
-    return (
-      <div className={styles.container}>
-        <FunnelHeader
-          title={`유사한 집 구조를 선택해주세요`}
-          detail={`템플릿을 선택하면 좌우반전을 할 수 있어요.`}
-          currentStep={2}
-          image={FUNNELHEADER_IMAGES[2]}
-        />
-        <div>사용 가능한 집 구조 템플릿이 없습니다.</div>
-      </div>
-    );
-  }
+  const hasFloorPlans = floorPlanList && floorPlanList.length > 0;
 
   return (
     <div className={styles.container}>
@@ -64,18 +41,26 @@ const FloorPlan = ({ context, onNext }: FloorPlanProps) => {
         detail={`템플릿을 선택하면 좌우반전을 할 수 있어요.`}
         currentStep={2}
         image={FUNNELHEADER_IMAGES[2]}
-        size="short"
+        size={hasFloorPlans ? 'short' : undefined}
       />
 
-      <FloorPlanList
-        floorPlanList={floorPlanList}
-        selectedId={selectedId}
-        isMirror={isMirror}
-        selectedImage={selectedImage}
-        onImageSelect={handleImageSelect}
-        onFlipToggle={handleFlipToggle}
-        onFloorPlanSelection={handleFloorPlanSelection}
-      />
+      {isError ? (
+        <InlineError message="도면을 불러울 수 없습니다" onRetry={refetch} />
+      ) : isPending ? (
+        <Loading />
+      ) : hasFloorPlans ? (
+        <FloorPlanList
+          floorPlanList={floorPlanList}
+          selectedId={selectedId}
+          isMirror={isMirror}
+          selectedImage={selectedImage}
+          onImageSelect={handleImageSelect}
+          onFlipToggle={handleFlipToggle}
+          onFloorPlanSelection={handleFloorPlanSelection}
+        />
+      ) : (
+        <div>사용 가능한 집 구조 템플릿이 없습니다.</div>
+      )}
     </div>
   );
 };

--- a/src/pages/imageSetup/pages/floorPlan/FloorPlan.tsx
+++ b/src/pages/imageSetup/pages/floorPlan/FloorPlan.tsx
@@ -21,7 +21,7 @@ interface FloorPlanProps {
 const FloorPlan = ({ context, onNext }: FloorPlanProps) => {
   const {
     floorPlanList,
-    isLoading,
+    isPending,
     isError,
     refetch,
     selectedId,
@@ -33,7 +33,7 @@ const FloorPlan = ({ context, onNext }: FloorPlanProps) => {
   } = useFloorPlan(context, onNext);
 
   // 로딩 상태 처리
-  if (isLoading) {
+  if (isPending) {
     return <Loading />;
   }
 

--- a/src/pages/imageSetup/pages/floorPlan/FloorPlan.tsx
+++ b/src/pages/imageSetup/pages/floorPlan/FloorPlan.tsx
@@ -1,10 +1,8 @@
 // Step2FloorPlan.tsx (UI만 담당)
-import { useEffect } from 'react';
-
 import { FUNNELHEADER_IMAGES } from '@/pages/imageSetup/constants/headerImages';
 import { useFloorPlan } from '@/pages/imageSetup/hooks/useFloorPlan';
+import InlineError from '@/shared/components/inlineError/InlineError';
 import Loading from '@/shared/components/loading/Loading';
-import { useErrorHandler } from '@/shared/hooks/useErrorHandler';
 
 import * as styles from './FloorPlan.css';
 import FloorPlanList from './FloorPlanList';
@@ -21,13 +19,11 @@ interface FloorPlanProps {
 }
 
 const FloorPlan = ({ context, onNext }: FloorPlanProps) => {
-  const { handleError } = useErrorHandler('imageSetup');
-
   const {
     floorPlanList,
     isLoading,
-    error,
     isError,
+    refetch,
     selectedId,
     isMirror,
     selectedImage,
@@ -36,16 +32,14 @@ const FloorPlan = ({ context, onNext }: FloorPlanProps) => {
     handleFloorPlanSelection,
   } = useFloorPlan(context, onNext);
 
-  useEffect(() => {
-    if (isError) {
-      handleError(error || new Error('Floor plan data load failed'), 'api');
-    }
-  }, [isError, error, handleError]);
-
-  /* 아래 if문들은 임시로 적용했습니다 */
   // 로딩 상태 처리
   if (isLoading) {
     return <Loading />;
+  }
+
+  // API 에러 시 인라인 에러 표시
+  if (isError) {
+    return <InlineError onRetry={refetch} />;
   }
 
   // 데이터가 없는 경우

--- a/src/pages/imageSetup/pages/floorPlan/FloorPlanList.tsx
+++ b/src/pages/imageSetup/pages/floorPlan/FloorPlanList.tsx
@@ -56,15 +56,27 @@ const FloorPlanList = ({
     // Submit CTA 버튼 클릭 시 GA 이벤트 전송
     logSelectFloorPlanClickBtnCTASubmit();
 
-    postAddress({ sigungu: region, roadName: address });
+    postAddress(
+      { sigungu: region, roadName: address },
+      {
+        onSuccess: () => {
+          notify({
+            text: '주소가 성공적으로 제출되었어요',
+            type: TOAST_TYPE.INFO,
+            options: {
+              autoClose: 3000,
+            },
+          });
+        },
+        onError: () => {
+          notify({
+            text: '주소 등록 중 오류가 발생했어요',
+            type: TOAST_TYPE.WARNING,
+          });
+        },
+      }
+    );
     handleCloseSheet();
-    notify({
-      text: '주소가 성공적으로 제출되었어요',
-      type: TOAST_TYPE.INFO,
-      options: {
-        autoClose: 3000,
-      },
-    });
   };
 
   const handleImageClick = (id: number) => {

--- a/src/pages/imageSetup/pages/houseInfo/HouseInfo.css.ts
+++ b/src/pages/imageSetup/pages/houseInfo/HouseInfo.css.ts
@@ -5,6 +5,7 @@ import { animationTokens } from '@/shared/styles/tokens/animation.css';
 export const container = style({
   display: 'flex',
   flexDirection: 'column',
+  flex: 1,
   width: '100%',
 });
 

--- a/src/pages/imageSetup/pages/houseInfo/HouseInfo.tsx
+++ b/src/pages/imageSetup/pages/houseInfo/HouseInfo.tsx
@@ -33,7 +33,11 @@ const HouseInfo = ({ context, onNext }: HouseInfoProps) => {
     hasError,
   } = useHouseInfo(context);
 
-  const { data: housingOptions } = useHousingOptionsQuery();
+  const {
+    data: housingOptions,
+    isError: isOptionsError,
+    refetch: refetchOptions,
+  } = useHousingOptionsQuery();
 
   const houseTypeOptions = housingOptions?.houseTypes || [];
   const roomTypeOptions = housingOptions?.roomTypes || [];
@@ -64,6 +68,16 @@ const HouseInfo = ({ context, onNext }: HouseInfoProps) => {
       logSelectHouseInfoClickBtnCTAInactive();
     }
   };
+
+  // API 에러 시 인라인 에러 표시
+  if (isOptionsError) {
+    return (
+      <InlineError
+        onRetry={refetchOptions}
+        message="주거 옵션을 불러올 수 없습니다"
+      />
+    );
+  }
 
   return (
     <div className={styles.container}>

--- a/src/pages/imageSetup/pages/houseInfo/HouseInfo.tsx
+++ b/src/pages/imageSetup/pages/houseInfo/HouseInfo.tsx
@@ -8,6 +8,7 @@ import type { CompletedHouseInfo } from '@/pages/imageSetup/types/funnel/houseIn
 import type { ImageSetupSteps } from '@/pages/imageSetup/types/funnel/steps';
 import CtaButton from '@/shared/components/button/ctaButton/CtaButton';
 import InlineError from '@/shared/components/inlineError/InlineError';
+import Loading from '@/shared/components/loading/Loading';
 
 import * as styles from './HouseInfo.css';
 import ButtonGroup from '../../components/buttonGroup/ButtonGroup';
@@ -35,6 +36,7 @@ const HouseInfo = ({ context, onNext }: HouseInfoProps) => {
 
   const {
     data: housingOptions,
+    isPending: isOptionsPending,
     isError: isOptionsError,
     refetch: refetchOptions,
   } = useHousingOptionsQuery();
@@ -68,6 +70,11 @@ const HouseInfo = ({ context, onNext }: HouseInfoProps) => {
       logSelectHouseInfoClickBtnCTAInactive();
     }
   };
+
+  // 로딩 상태 처리
+  if (isOptionsPending) {
+    return <Loading />;
+  }
 
   // API 에러 시 인라인 에러 표시
   if (isOptionsError) {

--- a/src/pages/imageSetup/pages/houseInfo/HouseInfo.tsx
+++ b/src/pages/imageSetup/pages/houseInfo/HouseInfo.tsx
@@ -71,21 +71,6 @@ const HouseInfo = ({ context, onNext }: HouseInfoProps) => {
     }
   };
 
-  // 로딩 상태 처리
-  if (isOptionsPending) {
-    return <Loading />;
-  }
-
-  // API 에러 시 인라인 에러 표시
-  if (isOptionsError) {
-    return (
-      <InlineError
-        onRetry={refetchOptions}
-        message="주거 옵션을 불러올 수 없습니다"
-      />
-    );
-  }
-
   return (
     <div className={styles.container}>
       <FunnelHeader
@@ -95,64 +80,76 @@ const HouseInfo = ({ context, onNext }: HouseInfoProps) => {
         image={FUNNELHEADER_IMAGES[1]}
       />
 
-      <div className={styles.contents}>
-        <ButtonGroup
-          title="주거 형태"
-          titleSize="large"
-          options={houseTypeOptions}
-          selectedValues={formData.houseType ? [formData.houseType] : []}
-          onSelectionChange={(values) =>
-            setFormData((prev) => ({
-              ...prev,
-              houseType: values[0] || undefined,
-            }))
-          }
-          selectionMode="single"
-          buttonSize="large"
-          layout="grid-2"
-          errors={errors.houseType}
+      {isOptionsError ? (
+        <InlineError
+          onRetry={refetchOptions}
+          message="주거 옵션을 불러올 수 없습니다"
         />
+      ) : isOptionsPending ? (
+        <Loading />
+      ) : (
+        <div className={styles.contents}>
+          <ButtonGroup
+            title="주거 형태"
+            titleSize="large"
+            options={houseTypeOptions}
+            selectedValues={formData.houseType ? [formData.houseType] : []}
+            onSelectionChange={(values) =>
+              setFormData((prev) => ({
+                ...prev,
+                houseType: values[0] || undefined,
+              }))
+            }
+            selectionMode="single"
+            buttonSize="large"
+            layout="grid-2"
+            errors={errors.houseType}
+          />
 
-        <ButtonGroup
-          title="구조"
-          titleSize="large"
-          options={roomTypeOptions}
-          selectedValues={formData.roomType ? [formData.roomType] : []}
-          onSelectionChange={(values) =>
-            setFormData((prev) => ({
-              ...prev,
-              roomType: values[0] || undefined,
-            }))
-          }
-          selectionMode="single"
-          buttonSize="large"
-          layout="grid-2"
-          errors={errors.roomType}
-        />
+          <ButtonGroup
+            title="구조"
+            titleSize="large"
+            options={roomTypeOptions}
+            selectedValues={formData.roomType ? [formData.roomType] : []}
+            onSelectionChange={(values) =>
+              setFormData((prev) => ({
+                ...prev,
+                roomType: values[0] || undefined,
+              }))
+            }
+            selectionMode="single"
+            buttonSize="large"
+            layout="grid-2"
+            errors={errors.roomType}
+          />
 
-        <ButtonGroup
-          title="평형"
-          titleSize="large"
-          options={areaTypeOptions}
-          selectedValues={formData.areaType ? [formData.areaType] : []}
-          onSelectionChange={(values) =>
-            setFormData((prev) => ({
-              ...prev,
-              areaType: values[0] || undefined,
-            }))
-          }
-          selectionMode="single"
-          buttonSize="large"
-          layout="grid-2"
-          errors={errors.areaType}
-        />
+          <ButtonGroup
+            title="평형"
+            titleSize="large"
+            options={areaTypeOptions}
+            selectedValues={formData.areaType ? [formData.areaType] : []}
+            onSelectionChange={(values) =>
+              setFormData((prev) => ({
+                ...prev,
+                areaType: values[0] || undefined,
+              }))
+            }
+            selectionMode="single"
+            buttonSize="large"
+            layout="grid-2"
+            errors={errors.areaType}
+          />
 
-        <div>
-          <CtaButton isActive={isFormCompleted} onClick={handleCtaButtonClick}>
-            집 구조 선택하기
-          </CtaButton>
+          <div>
+            <CtaButton
+              isActive={isFormCompleted}
+              onClick={handleCtaButtonClick}
+            >
+              집 구조 선택하기
+            </CtaButton>
+          </div>
         </div>
-      </div>
+      )}
     </div>
   );
 };

--- a/src/pages/imageSetup/pages/houseInfo/HouseInfo.tsx
+++ b/src/pages/imageSetup/pages/houseInfo/HouseInfo.tsx
@@ -7,6 +7,7 @@ import { useHouseInfo } from '@/pages/imageSetup/hooks/useHouseInfo';
 import type { CompletedHouseInfo } from '@/pages/imageSetup/types/funnel/houseInfo';
 import type { ImageSetupSteps } from '@/pages/imageSetup/types/funnel/steps';
 import CtaButton from '@/shared/components/button/ctaButton/CtaButton';
+import InlineError from '@/shared/components/inlineError/InlineError';
 
 import * as styles from './HouseInfo.css';
 import ButtonGroup from '../../components/buttonGroup/ButtonGroup';

--- a/src/pages/imageSetup/pages/interiorStyle/InteriorStyle.css.ts
+++ b/src/pages/imageSetup/pages/interiorStyle/InteriorStyle.css.ts
@@ -7,6 +7,7 @@ export const container = style({
   position: 'relative',
   flexDirection: 'column',
   alignItems: 'center',
+  flex: 1,
   width: '100%',
   marginBottom: '9.6rem',
 });

--- a/src/pages/imageSetup/pages/interiorStyle/InteriorStyle.tsx
+++ b/src/pages/imageSetup/pages/interiorStyle/InteriorStyle.tsx
@@ -1,4 +1,5 @@
 // Step 3
+import { useMoodBoardQuery } from '@/pages/imageSetup/apis/interiorStyle';
 import { FUNNELHEADER_IMAGES } from '@/pages/imageSetup/constants/headerImages';
 import { useInteriorStyle } from '@/pages/imageSetup/hooks/useInteriorStyle';
 import {
@@ -6,6 +7,8 @@ import {
   logSelectMoodboardClickBtnCTAInactive,
 } from '@/pages/imageSetup/utils/analytics';
 import CtaButton from '@/shared/components/button/ctaButton/CtaButton';
+import InlineError from '@/shared/components/inlineError/InlineError';
+import Loading from '@/shared/components/loading/Loading';
 
 import * as styles from './InteriorStyle.css';
 import MoodBoard from './MoodBoard';
@@ -25,6 +28,14 @@ const InteriorStyle = ({ context, onNext }: InteriorStyleProps) => {
   const { selectedImages, handleImageSelect, handleNext, isDataComplete } =
     useInteriorStyle(context, onNext);
 
+  const {
+    data: moodBoardData,
+    isPending,
+    isError,
+    refetch,
+  } = useMoodBoardQuery();
+  const images = moodBoardData?.moodBoardResponseList || [];
+
   // CTA 버튼 클릭 핸들러
   const handleCtaButtonClick = () => {
     if (isDataComplete) {
@@ -37,6 +48,18 @@ const InteriorStyle = ({ context, onNext }: InteriorStyleProps) => {
     }
   };
 
+  // API 에러 시 인라인 에러 표시
+  if (isError) {
+    return (
+      <InlineError onRetry={refetch} message="무드보드를 불러올 수 없습니다" />
+    );
+  }
+
+  // 로딩 상태 처리
+  if (isPending) {
+    return <Loading />;
+  }
+
   return (
     <div className={styles.container}>
       <FunnelHeader
@@ -47,6 +70,7 @@ const InteriorStyle = ({ context, onNext }: InteriorStyleProps) => {
       />
 
       <MoodBoard
+        images={images}
         selectedImages={selectedImages}
         onImageSelect={handleImageSelect}
       />

--- a/src/pages/imageSetup/pages/interiorStyle/InteriorStyle.tsx
+++ b/src/pages/imageSetup/pages/interiorStyle/InteriorStyle.tsx
@@ -48,18 +48,6 @@ const InteriorStyle = ({ context, onNext }: InteriorStyleProps) => {
     }
   };
 
-  // API 에러 시 인라인 에러 표시
-  if (isError) {
-    return (
-      <InlineError onRetry={refetch} message="무드보드를 불러올 수 없습니다" />
-    );
-  }
-
-  // 로딩 상태 처리
-  if (isPending) {
-    return <Loading />;
-  }
-
   return (
     <div className={styles.container}>
       <FunnelHeader
@@ -69,16 +57,27 @@ const InteriorStyle = ({ context, onNext }: InteriorStyleProps) => {
         image={FUNNELHEADER_IMAGES[3]}
       />
 
-      <MoodBoard
-        images={images}
-        selectedImages={selectedImages}
-        onImageSelect={handleImageSelect}
-      />
-      <div className={styles.buttonWrapper}>
-        <CtaButton isActive={isDataComplete} onClick={handleCtaButtonClick}>
-          주요 활동 선택하기
-        </CtaButton>
-      </div>
+      {isError ? (
+        <InlineError
+          onRetry={refetch}
+          message="무드보드를 불러올 수 없습니다"
+        />
+      ) : isPending ? (
+        <Loading />
+      ) : (
+        <>
+          <MoodBoard
+            images={images}
+            selectedImages={selectedImages}
+            onImageSelect={handleImageSelect}
+          />
+          <div className={styles.buttonWrapper}>
+            <CtaButton isActive={isDataComplete} onClick={handleCtaButtonClick}>
+              주요 활동 선택하기
+            </CtaButton>
+          </div>
+        </>
+      )}
     </div>
   );
 };

--- a/src/pages/imageSetup/pages/interiorStyle/MoodBoard.tsx
+++ b/src/pages/imageSetup/pages/interiorStyle/MoodBoard.tsx
@@ -10,8 +10,6 @@
  * @returns JSX.Element - 무드보드 컴포넌트
  */
 
-import { useEffect } from 'react';
-
 import { useMoodBoardQuery } from '@/pages/imageSetup/apis/interiorStyle';
 import {
   MOOD_BOARD_CONSTANTS,
@@ -19,7 +17,7 @@ import {
 } from '@/pages/imageSetup/types/apis/interiorStyle';
 import CardImage from '@/shared/components/card/cardImage/CardImage';
 import SkeletonCardImage from '@/shared/components/card/cardImage/SkeletonCardImage';
-import { useErrorHandler } from '@/shared/hooks/useErrorHandler';
+import InlineError from '@/shared/components/inlineError/InlineError';
 
 import * as styles from './MoodBoard.css';
 
@@ -29,8 +27,6 @@ interface MoodBoardProps {
 }
 
 const MoodBoard = ({ selectedImages, onImageSelect }: MoodBoardProps) => {
-  const { handleError } = useErrorHandler('imageSetup');
-
   /**
    * 이미지의 선택 순서를 반환하는 함수
    *
@@ -46,30 +42,12 @@ const MoodBoard = ({ selectedImages, onImageSelect }: MoodBoardProps) => {
   const {
     data: moodBoardData,
     isLoading,
-    error,
     isError,
+    refetch,
   } = useMoodBoardQuery();
   const images = moodBoardData?.moodBoardResponseList || [];
 
-  // 3초간만 스켈레톤 보여주기
-  // const [showSkeleton, setShowSkeleton] = useState(true);
-
-  useEffect(() => {
-    if (isError) {
-      handleError(
-        error || new Error('Mood board image load failed'),
-        'loading'
-      );
-    }
-  }, [isError, error, handleError]);
-
-  // useEffect(() => {
-  //   const timer = setTimeout(() => setShowSkeleton(false), 3000);
-  //   return () => clearTimeout(timer);
-  // }, []);
-
-  // 로딩/에러 처리
-  // if (isLoading || images.length === 0 || showSkeleton) {
+  // 로딩 상태 처리
   if (isLoading || images.length === 0) {
     return (
       <div className={styles.container}>
@@ -85,8 +63,11 @@ const MoodBoard = ({ selectedImages, onImageSelect }: MoodBoardProps) => {
     );
   }
 
+  // API 에러 시 인라인 에러 표시
   if (isError) {
-    return null;
+    return (
+      <InlineError onRetry={refetch} message="무드보드를 불러올 수 없습니다" />
+    );
   }
 
   return (

--- a/src/pages/imageSetup/pages/interiorStyle/MoodBoard.tsx
+++ b/src/pages/imageSetup/pages/interiorStyle/MoodBoard.tsx
@@ -41,14 +41,14 @@ const MoodBoard = ({ selectedImages, onImageSelect }: MoodBoardProps) => {
   // 이미지 API 호출
   const {
     data: moodBoardData,
-    isLoading,
+    isPending,
     isError,
     refetch,
   } = useMoodBoardQuery();
   const images = moodBoardData?.moodBoardResponseList || [];
 
   // 로딩 상태 처리
-  if (isLoading || images.length === 0) {
+  if (isPending || images.length === 0) {
     return (
       <div className={styles.container}>
         <div className={styles.gridbox}>

--- a/src/pages/imageSetup/pages/interiorStyle/MoodBoard.tsx
+++ b/src/pages/imageSetup/pages/interiorStyle/MoodBoard.tsx
@@ -4,29 +4,27 @@
  * 사용자가 이미지를 선택할 수 있는 무드보드 컴포넌트입니다.
  * 최대 5개까지 이미지를 선택할 수 있으며, 선택 순서대로 1~5번이 표시됩니다.
  * 5개가 선택되면 나머지 이미지들은 비활성화됩니다.
- *
- * @param {number[]} selectedImages - 선택된 이미지들의 ID 배열
- * @param {function} onImageSelect - 이미지 선택/해제 처리 함수
- * @returns JSX.Element - 무드보드 컴포넌트
  */
 
-import { useMoodBoardQuery } from '@/pages/imageSetup/apis/interiorStyle';
 import {
   MOOD_BOARD_CONSTANTS,
   type MoodBoardImageItem,
 } from '@/pages/imageSetup/types/apis/interiorStyle';
 import CardImage from '@/shared/components/card/cardImage/CardImage';
-import SkeletonCardImage from '@/shared/components/card/cardImage/SkeletonCardImage';
-import InlineError from '@/shared/components/inlineError/InlineError';
 
 import * as styles from './MoodBoard.css';
 
 interface MoodBoardProps {
+  images: MoodBoardImageItem[];
   selectedImages: number[];
   onImageSelect: (imageId: number) => void;
 }
 
-const MoodBoard = ({ selectedImages, onImageSelect }: MoodBoardProps) => {
+const MoodBoard = ({
+  images,
+  selectedImages,
+  onImageSelect,
+}: MoodBoardProps) => {
   /**
    * 이미지의 선택 순서를 반환하는 함수
    *
@@ -37,38 +35,6 @@ const MoodBoard = ({ selectedImages, onImageSelect }: MoodBoardProps) => {
     const index = selectedImages.indexOf(imageId);
     return index !== -1 ? index + 1 : 0;
   };
-
-  // 이미지 API 호출
-  const {
-    data: moodBoardData,
-    isPending,
-    isError,
-    refetch,
-  } = useMoodBoardQuery();
-  const images = moodBoardData?.moodBoardResponseList || [];
-
-  // 로딩 상태 처리
-  if (isPending || images.length === 0) {
-    return (
-      <div className={styles.container}>
-        <div className={styles.gridbox}>
-          {Array.from(
-            { length: MOOD_BOARD_CONSTANTS.DEFAULT_LIMIT },
-            (_, idx) => (
-              <SkeletonCardImage key={idx} />
-            )
-          )}
-        </div>
-      </div>
-    );
-  }
-
-  // API 에러 시 인라인 에러 표시
-  if (isError) {
-    return (
-      <InlineError onRetry={refetch} message="무드보드를 불러올 수 없습니다" />
-    );
-  }
 
   return (
     <div className={styles.wrapper}>

--- a/src/pages/mypage/MyPage.css.ts
+++ b/src/pages/mypage/MyPage.css.ts
@@ -7,5 +7,4 @@ export const contentWrapper = style({
   minHeight: '100vh',
   alignItems: 'center',
   alignSelf: 'stretch',
-  gap: '2.4rem',
 });

--- a/src/pages/mypage/MyPage.css.ts
+++ b/src/pages/mypage/MyPage.css.ts
@@ -1,6 +1,9 @@
 import { style } from '@vanilla-extract/css';
 
 export const contentWrapper = style({
+  display: 'flex',
+  flexDirection: 'column',
+  flex: 1,
   minHeight: '100vh',
   alignItems: 'center',
   alignSelf: 'stretch',

--- a/src/pages/mypage/MyPage.tsx
+++ b/src/pages/mypage/MyPage.tsx
@@ -5,9 +5,9 @@ import { useNavigate } from 'react-router-dom';
 
 import { ROUTES } from '@/routes/paths';
 import FeatureErrorFallback from '@/shared/components/errorFallback/FeatureErrorFallback';
+import InlineError from '@/shared/components/inlineError/InlineError';
 import Loading from '@/shared/components/loading/Loading';
 import TitleNavBar from '@/shared/components/navBar/TitleNavBar';
-import { useErrorHandler } from '@/shared/hooks/useErrorHandler';
 import { useUserStore } from '@/store/useUserStore';
 
 import TabNavBar from './components/navBar/TabNavBar';
@@ -18,7 +18,6 @@ import { useMyPageUser } from './hooks/useMypage';
 import * as styles from './MyPage.css';
 
 const MyPage = () => {
-  const { handleError } = useErrorHandler('mypage');
   const navigate = useNavigate();
 
   // sessionStorage에서 탭 정보 가져오기
@@ -42,7 +41,7 @@ const MyPage = () => {
     data: userData,
     isLoading: isUserLoading,
     isError: isUserError,
-    error,
+    refetch,
   } = useMyPageUser({
     enabled: isLoggedIn,
   });
@@ -51,13 +50,8 @@ const MyPage = () => {
     // 로그인되지 않았으면 로그인 페이지로 리디렉션
     if (!isLoggedIn) {
       navigate(ROUTES.LOGIN);
-      return;
     }
-    // 로그인 상태에서 API 에러가 발생한 경우 에러 처리
-    if (isUserError && error) {
-      handleError(error, 'api');
-    }
-  }, [isLoggedIn, navigate, isUserError, error, handleError]);
+  }, [isLoggedIn, navigate]);
 
   // 로그인되지 않았으면 아무것도 렌더링하지 않음 (리디렉션 중)
   if (!isLoggedIn) {
@@ -77,21 +71,25 @@ const MyPage = () => {
         onBackClick={() => navigate(ROUTES.HOME)}
       />
 
-      <ErrorBoundary FallbackComponent={FeatureErrorFallback}>
-        <ProfileSection
-          userName={profileName}
-          credit={profileCredit}
-          maxCredit={5}
-        />
+      {isUserError ? (
+        <InlineError onRetry={refetch} />
+      ) : (
+        <ErrorBoundary FallbackComponent={FeatureErrorFallback}>
+          <ProfileSection
+            userName={profileName}
+            credit={profileCredit}
+            maxCredit={5}
+          />
 
-        <TabNavBar activeTab={activeTab} onTabChange={setActiveTab} />
+          <TabNavBar activeTab={activeTab} onTabChange={setActiveTab} />
 
-        {activeTab === 'savedItems' ? (
-          <SavedItemsSection />
-        ) : (
-          <GeneratedImagesSection userProfile={userData} />
-        )}
-      </ErrorBoundary>
+          {activeTab === 'savedItems' ? (
+            <SavedItemsSection />
+          ) : (
+            <GeneratedImagesSection userProfile={userData} />
+          )}
+        </ErrorBoundary>
+      )}
 
       {isUserLoading && <Loading />}
     </div>

--- a/src/pages/mypage/components/history/HistorySection.tsx
+++ b/src/pages/mypage/components/history/HistorySection.tsx
@@ -13,7 +13,7 @@ import { useMyPageImagesQuery } from '../../hooks/useMypage';
  */
 const HistorySection = () => {
   const navigate = useNavigate();
-  const { data: imagesData, isLoading, isError } = useMyPageImagesQuery();
+  const { data: imagesData, isPending, isError } = useMyPageImagesQuery();
 
   // 생성 결과 상세로 이동
   const handleViewResult = (houseId: number) => {
@@ -26,7 +26,7 @@ const HistorySection = () => {
   };
 
   // 로딩 상태
-  if (isLoading) {
+  if (isPending) {
     return (
       <>
         <section className={styles.container}>

--- a/src/pages/mypage/components/navBar/TabNavBar.css.ts
+++ b/src/pages/mypage/components/navBar/TabNavBar.css.ts
@@ -7,6 +7,7 @@ import { colorVars } from '@styles/tokens/color.css';
 
 export const tabNavBar = style({
   display: 'flex',
+  width: '100%',
   justifyContent: 'center',
   alignItems: 'center',
 });

--- a/src/pages/mypage/components/section/generatedImages/GeneratedImagesSection.tsx
+++ b/src/pages/mypage/components/section/generatedImages/GeneratedImagesSection.tsx
@@ -29,7 +29,7 @@ const GeneratedImagesSection = ({
   userProfile,
 }: GeneratedImagesSectionProps) => {
   const navigate = useNavigate();
-  const { data: imagesData, isLoading, isError } = useMyPageImagesQuery();
+  const { data: imagesData, isPending, isError } = useMyPageImagesQuery();
   const { prefetchDetection } = useDetectionPrefetch();
   const prefetchedImageIdsRef = useRef<Set<number>>(new Set<number>());
   const [loadedImages, setLoadedImages] = useState<Record<number, boolean>>(
@@ -132,7 +132,7 @@ const GeneratedImagesSection = ({
   );
 
   // 로딩 중
-  if (isLoading) {
+  if (isPending) {
     return <Loading />;
   }
 

--- a/src/shared/components/inlineError/InlineError.css.ts
+++ b/src/shared/components/inlineError/InlineError.css.ts
@@ -1,0 +1,33 @@
+import { style } from '@vanilla-extract/css';
+
+import { fontStyle } from '@styles/fontStyle';
+import { colorVars } from '@styles/tokens/color.css';
+
+export const container = style({
+  width: '100%',
+  height: '100%',
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  justifyContent: 'center',
+  paddingBottom: '4.5rem',
+  gap: '0.8rem',
+  textAlign: 'center',
+});
+
+export const message = style({
+  ...fontStyle('body_m_14'),
+  color: colorVars.color.gray600,
+});
+
+export const retryButton = style({
+  marginTop: '0.4rem',
+  padding: '0.8rem 1.6rem',
+  borderRadius: '999px',
+  border: '1px solid',
+  borderColor: colorVars.color.gray300,
+  backgroundColor: colorVars.color.gray000,
+  ...fontStyle('caption_m_12'),
+  color: colorVars.color.gray600,
+  cursor: 'pointer',
+});

--- a/src/shared/components/inlineError/InlineError.css.ts
+++ b/src/shared/components/inlineError/InlineError.css.ts
@@ -5,7 +5,7 @@ import { colorVars } from '@styles/tokens/color.css';
 
 export const container = style({
   width: '100%',
-  height: '100%',
+  flex: 1,
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'center',

--- a/src/shared/components/inlineError/InlineError.tsx
+++ b/src/shared/components/inlineError/InlineError.tsx
@@ -1,0 +1,24 @@
+import * as styles from './InlineError.css';
+
+interface InlineErrorProps {
+  message?: string;
+  onRetry?: () => void;
+}
+
+const InlineError = ({
+  message = '데이터를 불러올 수 없습니다',
+  onRetry,
+}: InlineErrorProps) => {
+  return (
+    <div className={styles.container}>
+      <p className={styles.message}>{message}</p>
+      {onRetry && (
+        <button type="button" className={styles.retryButton} onClick={onRetry}>
+          다시 시도
+        </button>
+      )}
+    </div>
+  );
+};
+
+export default InlineError;

--- a/src/shared/styles/global.css.ts
+++ b/src/shared/styles/global.css.ts
@@ -38,7 +38,7 @@ export const layoutVars = createGlobalTheme(':root', {
  * 하위 컴포넌트들이 플렉스 아이템으로 배치됨
  */
 globalStyle('#root', {
-  height: '100%',
+  flex: 1,
   display: 'flex',
   flexDirection: 'column',
 });


### PR DESCRIPTION
## 📌 Summary

- close #458 

> 관련 있는 Issue를 태그해주세요. (e.g. > - #1)

_해당 PR에 대한 작업 내용을 요약하여 작성해주세요._

## 📄 Tasks

1. ~~ErrorBoundary 도입 및 Sentry 연동 (저번 PR)~~
2. ~~API 요청/응답 관련 에러/예외 핸들링 (저번 PR)~~
3. **일부 컴포넌트의 컴포넌트 레벨 에러처리 강화, 인라인 폴백 UI 적용 (이번 PR)**
4. 테스트 환경 구축

이전 2개 PR로 전역 안전망(ErrorBoundary, axios interceptor, queryClient 전역 에러 콜백)은 갖춰졌는데, 실제로 개별 쿼리/뮤테이션 레벨에서 에러가 발생하면 사용자에게 적절한 피드백을 주지 못하는 곳이 대부분이었어요.

**문제상황:**

1. **에러 처리가 아예 없는 쿼리/뮤테이션이 대부분** → GET 요청 실패 시 빈 화면 또는 깨진 UI, POST 요청 실패 시 사용자에게 아무 피드백 없음!
2. **기존 에러처리는 에러를 과하게 대처** → 단순 GET 실패(도면, 무드보드 GET 실패)나 POST 실패(시군구 입력 실패)인데 `handleError`로 홈까지 리다이렉트시킴

따라서 이번 PR에서는 컴포넌트 레벨에서의 로컬 에러 발생 시의 안정성을 높이는 작업을 진행했어요.

**+) 이떄까지 진행상황**

| 계층 | 구현방식 | 역할 | 구현 |
| --- | --- | --- | --- |
| ErrorBoundary (App/Route/Feature) | 렌더링 중 throw를 catch | 전역 안전망 | 첫 번째 PR |
| axios interceptor, queryClient | 응답 코드 체크 후 에러 분기처리 | API 레벨 안전망 | 두 번째 PR |
| **InlineError (`isError → fallback UI`)** | **쿼리 상태 체크 후 대체 UI 렌더링** | **컴포넌트 레벨 안전망** | **이번 PR** |
| **mutation onError toast** | **콜백으로 사용자 알림** | **컴포넌트 레벨 안전망** | **이번 PR** |

---


## 구현 내용

### InlineError 공통 컴포넌트 추가

GET 요청이 실패했을 때, 해당 컴포넌트 영역에 **인라인**으로 **에러 메시지와 '다시 시도' 버튼**을 보여주는 컴포넌트에요.

```tsx
interface InlineErrorProps {
  message?: string;       // default: '데이터를 불러올 수 없습니다'
  onRetry?: () => void;   // 있으면 '다시 시도' 버튼 표시
}
```

사용하는 쪽에서는 이렇게 써요:

```tsx
// HouseInfo.tsx
{isOptionsError ? (
  <InlineError onRetry={refetchOptions} message="주거 옵션을 불러올 수 없습니다" />
) : isOptionsPending ? (
  <Loading />
) : (
  <div className={styles.contents}>
    {/* 정상 컨텐츠 */}
  </div>
)}
```

`onRetry`에 TanStack Query의 `refetch`를 넘기면, 사용자가 '다시 시도'를 누를 때 해당 쿼리만 다시 요청해요.
퍼널의 모든 step, 마이페이지-생성된이미지, 마이페이지-찜한가구 에 `<InlineError>` 컴포넌트를 적용해뒀어요. 

_조촐한 디자인은 나중에 디자인 나오면 수정할 예정입니다ㅎㅎ_

| **마이페이지** | **퍼널** |
|:---:|:---:|
| <video src="https://github.com/user-attachments/assets/2be154d8-65f0-48f0-8262-5f41ffda788d" controls width="300" /> | <video src="https://github.com/user-attachments/assets/5021d2f6-23b8-4f32-8837-a52dbda05baa" controls width="300" /> |



---

### handleError(toast + redirect) → InlineError로 교체

기존에 FloorPlan, MoodBoard, MyPage에서는 GET 요청 실패 시 `useErrorHandler`로 에러 toast를 띄우고 **홈으로 강제 리다이렉트시켰어요**. 단순한 GET 요청 실패인데 아예 홈으로 튕기는 건 과하다고 판단해서, 해당 영역에 InlineError를 인라인으로 띄우는 방식으로 변경했어요.

⇒ `<Inline>` 컴포넌트에 ‘다시 시도’ 버튼이 있어 홈으로 튕기지 않고, 같은 페이지에서 똑같은 GET요청을 재시도(refetch)할 수 있어요.
(위 영상에서 에러 발생 시에도 기존처럼 홈으로 튕기지 않고 <InlineError> 컴포넌트가 뜨는 것 확인할 수 있으니 영상 참고해주세요)

| 파일 | Before | After |
| --- | --- | --- |
| FloorPlan.tsx | `useErrorHandler` → toast + 홈 리다이렉트 | `<InlineError onRetry={refetch} />` |
| MoodBoard.tsx → InteriorStyle.tsx 넘어가는 구간 | `useErrorHandler` → toast + 홈 리다이렉트 | `<InlineError onRetry={refetch} />` |
| MyPage.tsx | `useErrorHandler` → toast + 마이페이지 리다이렉트 | `<InlineError onRetry={refetch} />`  |

**+) MoodBoard.tsx 리팩토링:** MoodBoard 컴포넌트에서 직접 `useMoodBoardQuery()`를 호출하고 있었는데, 에러/로딩 분기(isPending, isError 시 보여줄 컴포넌트 UI 분기처리)를 FunnelHeader 컴포넌트 아래에서 처리하려면 쿼리 호출을 상위인 InteriorStyle로 올려야 했어요. 그래서 MoodBoard는 이제 `images` prop을 받는 순수 UI 컴포넌트가 됐고, 데이터 fetch + 에러/로딩 분기는 InteriorStyle에서 담당해요.

---

### 에러 처리 없던 쿼리에 isError 분기 추가

| 파일 | 추가된 에러 처리 |
| --- | --- |
| HouseInfo.tsx | `useHousingOptionsQuery()`에 `isError`, `isPending`, `refetch` 추가 → `<InlineError>` 적용 |
| ActivityInfo.tsx | `useActivityOptionsQuery()`의 기존 `<div>데이터를 불러올 수 없습니다.</div>` → `<InlineError>` 적용 |
| ResultPage.tsx | `useGetResultDataQuery()`에 `isError` 추가 → `<InlineError>` 적용 |

---

### 뮤테이션 onError 토스트 추가

POST 요청이 실패해도 사용자에게 아무 피드백이 없던 곳에 toast를 추가했어요.

| 파일 | 뮤테이션 | 토스트 메시지 |
| --- | --- | --- |
| useHouseInfo.ts | `housingSelection.mutate()` | "주거 정보 저장 중 오류가 발생했어요" |
| FloorPlanList.tsx | `postAddress()` | "주소 등록 중 오류가 발생했어요" |

FloorPlanList의 `postAddress`는 기존에 mutate 호출 후 성공/실패 여부와 관계없이 무조건 성공 toast를 띄웠는데, `onSuccess`/`onError` 콜백으로 분리해서 실패 시에는 실패 toast가 뜨도록 수정했어요.

| Before(HouseInfo) | After(HouseInfo) |
|:---:|:---:|
| <video src="https://github.com/user-attachments/assets/bdc55d0b-d26d-41a0-b9b9-ed638f8f1d1f" controls width="300" /> | <video src="https://github.com/user-attachments/assets/cd15603e-0f6b-4e60-8bef-ca5a7c9eac2b" controls width="300" /> |
| API 에러가 발생해도 아무런 사용자 피드백 X | API 에러 발생 시 토스트 |

`FloorPlan`의 시군구 입력 POST 요청에도 똑같이 적용해뒀어요.


---

### InlineError가 남은 공간을 채우도록 flex chain 적용

InlineError 컴포넌트의 container에 `flex: 1`이 적용되어 있어서, 부모 → 자식으로 이어지는 flex height chain이 끊기지 않아야 InlineError가 남은 공간 중앙에 제대로 위치해요.

**부모에서부터 InlineError 컴포넌트까지 해당 속성이 끊임없이 chain되어야해서 일부 페이지 css를 수정했는데 혹시 UI 깨진 부분 있다면 얘기해주세요.**

---

### +) isLoading → isPending 변경

TanStack Query v5에서 `isLoading`은 `isPending && isFetching`의 의미라 초기 로딩만 체크하려면 `isPending`이 더 정확해요. 기존 `isLoading`을 사용하는 컴포넌트에서 `isLoading` → `isPending`으로 변경했어요.


## 🔍 To Reviewer

이번 PR에서 현재 사용 중인 `useQuery`들을 `useSuspenseQuery`/`useSuspenseQueries`로 리팩토링해볼까 검토해봤는데 다음과 같은 이유로 우선 지금은 하지 않기로 했어요.

- **컴포넌트 분리 비용이 높음** — xxxPage와 xxxPageContent로 분리하는 것 외에도 현재 폴백 UI 구조를 유지하기 위해서 신경써야하는 부분(각 페이지의 컴포넌트와 폴백 UI 배치, ErrorBoundary 위치 등)이 꽤 있어서 생각보다 분리 비용이 있을 것 같아요
- 수정할 API 개수가 꽤 돼요
- **일부 API는 staleTime: Infinity로 prefetch** — suspense가 실제로 fallback을 보여줄 일이 거의 없어요.

리팩토링이 어려운건 아니지만 file changes도 많아지고 일단 후딱 테스트 환경 구축까지 끝내고싶어서 다음에 하려고 합니당

---

<details>
<summary>+) 새로운 페이지/API 구현부터는 `useSuspenseQuery`를 사용하면 좋겠어요</summary>

<br />
<br />

컴포넌트 분리 자체는 어렵지 않고 코드도 선언적이어서 가독성이 더 좋아요. useQuery를 사용하는 지금은 `isPending`, `isError`, 정상 상태를 삼항연산자로 분기처리하는데:

```typescript
// 현재 패턴
{isError ? (
  <InlineError onRetry={refetch} />
) : isPending ? (
  <Loading />
) : (
  <NormalContent />
)}
```

useSuspenseQuery를 쓰면:

```typescript
const HouseInfo = () => (
<div>
  <FunnelHeader />
  <Suspense fallback={<Loading />}>
    <ErrorBoundary fallback={<InlineError />}>
      <HouseInfoContent />
    </ErrorBoundary>
  </Suspense>
</div>
);
```

에러 바운더리와의 궁합도 좋아요

또한 이미지 상세조회 페이지(`/generate/result`)에서는 여러 GET API가 동시에 실행되며 `enabled` 플래그로 의존성 체인이 구성되어 있는데, 현재 `useQuery`를 사용 중이라 `data`가 `T | undefined`여서 방어적 조건문이 많아요 (ResultPage의 `resolvedResult` 4단계 fallback 체인, optional chaining 등). `useSuspenseQuery` 사용 시 `data`가 항상 `T`로 보장되므로(data가 항상 존재하므로) 이런 방어 코드를 줄이고 더 선언적으로 작성할 수 있을 것 같아요. 

⇒ 앞으로 새로 구현할 때는 useSuspenseQuery 적용하고, 에러/예외처리 작업 마무리 후 Result 페이지, MyPage 정도는 리팩토링하면 좋을 듯해요

</details>

_리뷰어에게 요청하는 내용을 작성해주세요._

## 📸 Screenshot

-

_작업한 내용에 대한 스크린샷을 첨부해주세요._
