### PR TITLE
[feat] DragHandleBottomSheet Persistent/Dismissible 모드 분기 및 뒷배경 상호작용 구현

### DIFF
--- a/patches/vaul@1.1.2.patch
+++ b/patches/vaul@1.1.2.patch
@@ -1,0 +1,28 @@
+diff --git a/dist/index.js b/dist/index.js
+index 7f343be1fafe1cf302ee6afc7268c29490895e34..4e4a4f1d863894eb08ebcc69f4bca4ac4a60ee02 100644
+--- a/dist/index.js
++++ b/dist/index.js
+@@ -1371,7 +1371,8 @@ function Root({ open: openProp, onOpenChange, children, onDrag: onDragProp, onRe
+             }
+             setIsOpen(open);
+         },
+-        open: isOpen
++        open: isOpen,
++        modal: modal
+     }, /*#__PURE__*/ React__namespace.default.createElement(DrawerContext.Provider, {
+         value: {
+             activeSnapPoint,
+diff --git a/dist/index.mjs b/dist/index.mjs
+index 0dbbce5526681925a81804ced237a045a53c0355..b40bf4765757689a46eb9084c08709bfd02c3f84 100644
+--- a/dist/index.mjs
++++ b/dist/index.mjs
+@@ -1349,7 +1349,8 @@ function Root({ open: openProp, onOpenChange, children, onDrag: onDragProp, onRe
+             }
+             setIsOpen(open);
+         },
+-        open: isOpen
++        open: isOpen,
++        modal: modal
+     }, /*#__PURE__*/ React__default.createElement(DrawerContext.Provider, {
+         value: {
+             activeSnapPoint,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  vaul@1.1.2:
+    hash: 4d7c126bc95e7c5da45a5950038e40ad0e127dbf041cd91a85fd7d8fe64380a4
+    path: patches/vaul@1.1.2.patch
+
 importers:
   .:
     dependencies:
@@ -78,7 +83,7 @@ importers:
         version: 12.0.2
       vaul:
         specifier: ^1.1.2
-        version: 1.1.2(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 1.1.2(patch_hash=4d7c126bc95e7c5da45a5950038e40ad0e127dbf041cd91a85fd7d8fe64380a4)(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       zustand:
         specifier: ^5.0.6
         version: 5.0.6(@types/react@19.2.2)(react@19.2.0)(use-sync-external-store@1.6.0(react@19.2.0))
@@ -12454,7 +12459,7 @@ snapshots:
     dependencies:
       react: 19.2.0
 
-  vaul@1.1.2(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
+  vaul@1.1.2(patch_hash=4d7c126bc95e7c5da45a5950038e40ad0e127dbf041cd91a85fd7d8fe64380a4)(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
     dependencies:
       '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       react: 19.2.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+patchedDependencies:
+  vaul@1.1.2: patches/vaul@1.1.2.patch

--- a/src/shared/components/v2/bottomSheet/BottomSheetBase.css.ts
+++ b/src/shared/components/v2/bottomSheet/BottomSheetBase.css.ts
@@ -12,7 +12,8 @@ const mobileFrame = style({
   maxWidth: unitVars.unit.dimension.wMax,
 });
 
-// 바텀시트 포털 전체를 viewport 하단 기준으로 정렬하는 고정 레이어
+// 화면 전체를 차지하는 컨테이너, 자식(바텀시트)을 화면 하단(flex-end)에 붙이는 역할
+// 바텀시트의 위치를 잡아주는 레이아웃 프레임
 export const viewportLayer = style({
   position: 'fixed',
   zIndex: zIndex.sheet,
@@ -30,7 +31,7 @@ export const overlay = style([
     position: 'absolute',
     top: 0,
     bottom: 0,
-    backgroundColor: colorVars.color.fill.dim,
+    backgroundColor: colorVars.color.fill.dimSecondary,
     pointerEvents: 'auto',
   },
 ]);

--- a/src/shared/components/v2/bottomSheet/BottomSheetBase.css.ts
+++ b/src/shared/components/v2/bottomSheet/BottomSheetBase.css.ts
@@ -32,7 +32,7 @@ export const overlay = style([
     top: 0,
     bottom: 0,
     backgroundColor: colorVars.color.fill.dimSecondary,
-    pointerEvents: 'auto',
+    // pointerEvents는 BottomSheetBase에서 backgroundInteractable prop에 따라 inline으로 제어
   },
 ]);
 

--- a/src/shared/components/v2/bottomSheet/BottomSheetBase.tsx
+++ b/src/shared/components/v2/bottomSheet/BottomSheetBase.tsx
@@ -24,6 +24,8 @@ interface BottomSheetBaseProps {
   handleSlot?: ReactNode;
   /** true일 때 overlay/viewportLayer의 터치 이벤트를 통과시켜 뒷배경 터치 가능하게 함 */
   backgroundInteractable?: boolean;
+  /** true일 때 body overflow를 hidden으로 설정하여 뒷배경 스크롤을 막음 (기본: true) */
+  preventScroll?: boolean;
 }
 
 const BottomSheetBase = ({
@@ -42,10 +44,11 @@ const BottomSheetBase = ({
   onCloseClick,
   handleSlot,
   backgroundInteractable = false,
+  preventScroll = true,
 }: BottomSheetBaseProps) => {
-  // 뒷배경 스크롤 방지용
+  // expanded 상태에서만 스크롤을 막고, collapsed 상태(preventScroll=false)에서는 뒷배경 스크롤 허용
   useEffect(() => {
-    if (!open) return undefined;
+    if (!open || !preventScroll) return undefined;
 
     const previousOverflow = document.body.style.overflow;
     document.body.style.overflow = 'hidden';
@@ -53,7 +56,7 @@ const BottomSheetBase = ({
     return () => {
       document.body.style.overflow = previousOverflow;
     };
-  }, [open]);
+  }, [open, preventScroll]);
 
   // 접근성용 title
   const accessibleTitle =

--- a/src/shared/components/v2/bottomSheet/BottomSheetBase.tsx
+++ b/src/shared/components/v2/bottomSheet/BottomSheetBase.tsx
@@ -69,9 +69,7 @@ const BottomSheetBase = ({
             <div
               className={styles.overlay}
               style={
-                dimOpacity !== undefined
-                  ? { backgroundColor: `rgba(0, 0, 0, ${dimOpacity * 0.5})` }
-                  : undefined
+                dimOpacity !== undefined ? { opacity: dimOpacity } : undefined
               }
               onClick={onOverlayClick}
               aria-hidden="true"

--- a/src/shared/components/v2/bottomSheet/BottomSheetBase.tsx
+++ b/src/shared/components/v2/bottomSheet/BottomSheetBase.tsx
@@ -22,6 +22,8 @@ interface BottomSheetBaseProps {
   onOverlayClick?: () => void;
   onCloseClick?: () => void;
   handleSlot?: ReactNode;
+  /** true일 때 overlay/viewportLayer의 터치 이벤트를 통과시켜 뒷배경 터치 가능하게 함 */
+  backgroundInteractable?: boolean;
 }
 
 const BottomSheetBase = ({
@@ -39,6 +41,7 @@ const BottomSheetBase = ({
   onOverlayClick,
   onCloseClick,
   handleSlot,
+  backgroundInteractable = false,
 }: BottomSheetBaseProps) => {
   // 뒷배경 스크롤 방지용
   useEffect(() => {
@@ -61,21 +64,38 @@ const BottomSheetBase = ({
         : '드래그 핸들 바텀시트';
 
   return (
-    <Drawer.Root open={open} modal dismissible={false}>
+    // backgroundInteractable일 때 modal=false로 전환: modal Drawer는 Radix Dialog 포커스 트랩이 외부 요소 클릭을 차단함
+    <Drawer.Root
+      open={open}
+      modal={!backgroundInteractable}
+      dismissible={false}
+    >
       <Drawer.Portal>
         {open && (
-          <div className={styles.viewportLayer}>
+          <div
+            className={styles.viewportLayer}
+            // backgroundInteractable=true일 때 viewportLayer의 터치를 통과시켜 뒷배경과 상호작용 가능하게 함
+            style={
+              backgroundInteractable ? { pointerEvents: 'none' } : undefined
+            }
+          >
             {/* Drawer.Overlay(radix Dialog의 overlay) 사용 시 데스크탑 뒷배경 레이아웃 깨짐 현상 발생 -> 커스텀 dim overlay 적용 */}
+            {/* backgroundInteractable=true일 때 overlay도 터치를 통과시킴 */}
             <div
               className={styles.overlay}
-              style={
-                dimOpacity !== undefined ? { opacity: dimOpacity } : undefined
-              }
+              style={{
+                ...(dimOpacity !== undefined ? { opacity: dimOpacity } : {}),
+                pointerEvents: backgroundInteractable ? 'none' : 'auto',
+              }}
               onClick={onOverlayClick}
               aria-hidden="true"
             />
+            {/* backgroundInteractable이어도 바텀시트 자체는 항상 터치 가능해야 함 */}
             <Drawer.Content
               className={styles.content}
+              style={
+                backgroundInteractable ? { pointerEvents: 'auto' } : undefined
+              }
               aria-describedby={undefined}
             >
               <Drawer.Title className={styles.srOnlyTitle}>

--- a/src/shared/components/v2/bottomSheet/BottomSheetBase.tsx
+++ b/src/shared/components/v2/bottomSheet/BottomSheetBase.tsx
@@ -67,7 +67,12 @@ const BottomSheetBase = ({
         : '드래그 핸들 바텀시트';
 
   return (
-    <Drawer.Root open={open} modal={false} dismissible={false}>
+    // backgroundInteractable일 때만 modal=false
+    <Drawer.Root
+      open={open}
+      modal={!backgroundInteractable}
+      dismissible={false}
+    >
       <Drawer.Portal>
         {open && (
           <div

--- a/src/shared/components/v2/bottomSheet/BottomSheetBase.tsx
+++ b/src/shared/components/v2/bottomSheet/BottomSheetBase.tsx
@@ -67,12 +67,7 @@ const BottomSheetBase = ({
         : '드래그 핸들 바텀시트';
 
   return (
-    // backgroundInteractable일 때 modal=false로 전환: modal Drawer는 Radix Dialog 포커스 트랩이 외부 요소 클릭을 차단함
-    <Drawer.Root
-      open={open}
-      modal={!backgroundInteractable}
-      dismissible={false}
-    >
+    <Drawer.Root open={open} modal={false} dismissible={false}>
       <Drawer.Portal>
         {open && (
           <div
@@ -82,7 +77,6 @@ const BottomSheetBase = ({
               backgroundInteractable ? { pointerEvents: 'none' } : undefined
             }
           >
-            {/* Drawer.Overlay(radix Dialog의 overlay) 사용 시 데스크탑 뒷배경 레이아웃 깨짐 현상 발생 -> 커스텀 dim overlay 적용 */}
             {/* backgroundInteractable=true일 때 overlay도 터치를 통과시킴 */}
             <div
               className={styles.overlay}

--- a/src/shared/components/v2/bottomSheet/DragHandleBottomSheet.tsx
+++ b/src/shared/components/v2/bottomSheet/DragHandleBottomSheet.tsx
@@ -6,13 +6,15 @@ import * as styles from './BottomSheetBase.css';
 
 interface DragHandleBottomSheetProps {
   open: boolean;
-  // COLLAPSED_HEIGHT: string;
   contentSlot: ReactNode;
   primaryButton: ReactNode;
   secondaryButton?: ReactNode;
+  /** 최소 높이 (rem 문자열). 있으면 Persistent(최소높이 존재) 모드, 없으면 Dismissible 모드 */
+  collapsedHeight?: string;
+  /** Dismissible 모드에서 바텀시트가 사라질 때 부모에게 알리는 콜백 (부모가 open을 false로 바꿈) */
+  onDismiss?: () => void;
 }
 
-const COLLAPSED_HEIGHT = '24rem';
 const EXPANDED_HEIGHT = 'calc(100dvh - 10.4rem)';
 
 const parsePxFromRem = (rem: string): number => {
@@ -28,12 +30,15 @@ const resolveExpandedPx = (): number =>
 
 const DragHandleBottomSheet = ({
   open,
-  // COLLAPSED_HEIGHT,
   contentSlot,
   primaryButton,
   secondaryButton,
+  collapsedHeight,
+  onDismiss,
 }: DragHandleBottomSheetProps) => {
-  const [expanded, setExpanded] = useState(false);
+  const isPersistent = collapsedHeight !== undefined;
+
+  const [expanded, setExpanded] = useState(!isPersistent);
   const [isDragging, setIsDragging] = useState(false);
   const [dragHeight, setDragHeight] = useState<number | null>(null);
 
@@ -43,19 +48,25 @@ const DragHandleBottomSheet = ({
   const collapsedPxRef = useRef(0);
   const expandedPxRef = useRef(0);
 
-  const handlePointerDown = useCallback((e: React.PointerEvent) => {
-    const panel = panelRef.current;
-    if (!panel) return;
+  const handlePointerDown = useCallback(
+    (e: React.PointerEvent) => {
+      const panel = panelRef.current;
+      if (!panel) return;
 
-    dragStartYRef.current = e.clientY;
-    startHeightRef.current = panel.offsetHeight;
-    collapsedPxRef.current = parsePxFromRem(COLLAPSED_HEIGHT);
-    expandedPxRef.current = resolveExpandedPx();
+      dragStartYRef.current = e.clientY;
+      startHeightRef.current = panel.offsetHeight;
+      // Persistent: 최소 높이에서 멈춤 / Dismissible: 높이가 0까지 줄어들 수 있음
+      collapsedPxRef.current = isPersistent
+        ? parsePxFromRem(collapsedHeight)
+        : 0;
+      expandedPxRef.current = resolveExpandedPx();
 
-    setIsDragging(true);
-    setDragHeight(panel.offsetHeight);
-    (e.target as HTMLElement).setPointerCapture(e.pointerId);
-  }, []);
+      setIsDragging(true);
+      setDragHeight(panel.offsetHeight);
+      (e.target as HTMLElement).setPointerCapture(e.pointerId);
+    },
+    [isPersistent, collapsedHeight]
+  );
 
   const handlePointerMove = useCallback(
     (e: React.PointerEvent) => {
@@ -79,27 +90,55 @@ const DragHandleBottomSheet = ({
       (e.target as HTMLElement).releasePointerCapture(e.pointerId);
       setIsDragging(false);
 
-      const midPoint = (collapsedPxRef.current + expandedPxRef.current) / 2;
-      setExpanded(dragHeight > midPoint);
+      if (isPersistent) {
+        // Persistent: 절반 기준으로 expand/collapse 토글
+        const midPoint = (collapsedPxRef.current + expandedPxRef.current) / 2;
+        setExpanded(dragHeight > midPoint);
+      } else {
+        // Dismissible: 절반 이하면 dismiss, 이상이면 snap back
+        const midPoint = expandedPxRef.current / 2;
+        if (dragHeight > midPoint) {
+          setExpanded(true);
+        } else {
+          onDismiss?.();
+        }
+      }
       setDragHeight(null);
     },
-    [isDragging, dragHeight]
+    [isDragging, dragHeight, isPersistent, onDismiss]
   );
 
   const getDimOpacity = (): number => {
-    if (!isDragging || dragHeight == null) return expanded ? 1 : 0;
+    if (isPersistent) {
+      // Persistent: collapsed(0) ~ expanded(1) 사이를 선형 보간
+      if (!isDragging || dragHeight == null) return expanded ? 1 : 0;
 
-    const range = expandedPxRef.current - collapsedPxRef.current;
-    if (range <= 0) return 0;
+      const range = expandedPxRef.current - collapsedPxRef.current;
+      if (range <= 0) return 0;
 
-    const progress = (dragHeight - collapsedPxRef.current) / range;
+      const progress = (dragHeight - collapsedPxRef.current) / range;
+      return Math.max(0, Math.min(1, progress));
+    }
+
+    // Dismissible: 항상 dim 표시, 드래그 중에는 높이에 비례
+    if (!isDragging || dragHeight == null) return 1;
+
+    const progress = dragHeight / expandedPxRef.current;
     return Math.max(0, Math.min(1, progress));
   };
 
   const panelStyle: React.CSSProperties =
     isDragging && dragHeight != null
       ? { height: `${dragHeight}px` }
-      : { height: expanded ? EXPANDED_HEIGHT : COLLAPSED_HEIGHT };
+      : { height: expanded ? EXPANDED_HEIGHT : (collapsedHeight ?? '0') };
+
+  const handleOverlayClick = () => {
+    if (isPersistent) {
+      setExpanded(false);
+    } else {
+      onDismiss?.();
+    }
+  };
 
   return (
     <BottomSheetBase
@@ -112,7 +151,10 @@ const DragHandleBottomSheet = ({
       panelStyle={panelStyle}
       dimOpacity={getDimOpacity()}
       disableTransition={isDragging}
-      onOverlayClick={() => setExpanded(false)} // DragHandleBottomSheet은 dismissible={false}(vaul 자동닫기 꺼놓은 상태), DragHandle바텀시트에서 내부적으로 close 상태 관리 => 백드롭 클릭 시 collapse도 별도로 관리 필요
+      onOverlayClick={handleOverlayClick}
+      // Persistent collapsed 상태에서만 뒷배경 터치·스크롤 가능
+      backgroundInteractable={isPersistent && !expanded && !isDragging}
+      preventScroll={!isPersistent || expanded}
       handleSlot={
         <button
           type="button"


### PR DESCRIPTION
## 📌 Summary

- close #506

> 관련 있는 Issue를 태그해주세요. (e.g. > - #1)

_해당 PR에 대한 작업 내용을 요약하여 작성해주세요._

## 📄 Tasks

### 구현 내용

- **드래그형 바텀시트 두 가지 모드**
    
    **Persistent 모드 (최소 높이를 가지는 경우)** — 사용처: 상품 탭
    
    - 최소높이일 때: dim=false, 뒷배경과 상호작용 가능 (가구 선택 등)
    - 최대높이일 때: dim=true, 뒷배경 상호작용 불가, 아래 드래그/뒷배경 터치 시 최소높이로 복귀
    
    **Dismissible 모드 (최소 높이를 가지지 않는 경우)** — 사용처: 주요활동 선택
    
    - 최대높이일 때: dim=true, 뒷배경 상호작용 불가, 뒷배경 터치/아래 드래그 시 완전히 사라짐
- **X형 바텀시트(CloseBottomSheet)는 기존 구현내용과 동일**

### 바텀시트 사용 방법

**1. DragHandleBottomSheet — Persistent 모드 (최소높이 있음)**

```tsx
// collapsedHeight를 넘기면 Persistent 모드
// 항상 화면에 표시, collapse/expand 토글, 절대 사라지지 않음
<DragHandleBottomSheet
  open={open}
  collapsedHeight="24rem"
  contentSlot={<Content />}
  primaryButton={<Button>확인</Button>}
  secondaryButton={<Button>보조</Button>}  // 선택
/>
```

**2. DragHandleBottomSheet — Dismissible 모드 (최소높이 없음)**

```tsx
// collapsedHeight 없이 onDismiss만 넘기면 Dismissible 모드
// 백드롭 터치 또는 절반 이하 드래그 시 완전히 사라짐
const [open, setOpen] = useState(false);

<DragHandleBottomSheet
  open={open}
  onDismiss={() => setOpen(false)}
  contentSlot={<Content />}
  primaryButton={<Button>확인</Button>}
/>
```

**3. CloseBottomSheet — X형**

```tsx
// X 버튼 또는 백드롭 터치로 닫힘
// toss/overlay-kit 사용하면 useState 필요없음
const [open, setOpen] = useState(false);

<CloseBottomSheet
  open={open}
  onClose={() => setOpen(false)}
  titleSlot="필터 선택"
  titleAlign="left"          // 'left' | 'center' (기본: center)
  height="40rem"             // 선택: 최소 높이
  contentSlot={<Content />}
  primaryButton={<Button>확인</Button>}
  secondaryButton={<Button>보조</Button>}  // 선택
/>
```

---

## 작업 내용

### BottomSheetBase 개선

| 변경 | 설명 |
| --- | --- |
| `backgroundInteractable` prop | true일 때 뒷배경과 상호작용 가능 (상품 선택 등) |
| `preventScroll` prop | false일 때 `body.style.overflow = 'hidden'` 해제해 뒷배경 스크롤 허용 |
| dim 색상 | `colorVars.color.fill.dim` → `dimSecondary` 토큰으로 변경 |

CloseBottomSheet는 새 props를 전달하지 않으므로 기본값(backgroundInteractable=false, preventScroll=true)으로 기존 동작 유지돼요.

### DragHandleBottomSheet 모드 분기

```tsx
// collapsedHeight가 있으면 Persistent, 없으면 Dismissible
<DragHandleBottomSheet
  open={open}
  collapsedHeight="24rem" // Persistent 모드
  contentSlot={...}
  primaryButton={...}
/>

<DragHandleBottomSheet
  open={open}
  onDismiss={() => setOpen(false)} // Dismissible 모드
  contentSlot={...}
  primaryButton={...}
/>
```

| 모드 | collapsed 하한 | 드래그 해제 기준 | overlay 클릭 | BottomSheetBase props |
| --- | --- | --- | --- | --- |
| Persistent | collapsedPx (최소높이) | 절반 기준 expand/collapse | collapse | backgroundInteractable=!expanded, preventScroll=expanded |
| Dismissible | 0 (끝까지 내림 가능) | 절반 이하면 dismiss | onDismiss | backgroundInteractable=false, preventScroll=true |

### +) 바텀시트 뒷배경 터치 기능 구현을 위한 vaul 라이브러리 버그 pnpm patch

> `pnpm patch`는 저도 처음 해봤는데 신기하더라고요..!
> 

뒷배경 터치 구현 과정에서, 커스텀 overlay를 사용하기 위해 vaul `Drawer.Root`에 `modal={false}`를 전달했는데도 배경 클릭이 안 되는 문제가 있어서 원인을 확인해봤더니 **vaul 라이브러리(v1.1.2) 자체의 버그**였어요. (원래 `<Drawer.Root open={open} modal={false} dismissible={false}>`이렇게 `modal={false}` 전달하면 뒷배경 터치가 가능해야함)

**문제 흐름:**
vaul `Drawer.Root`에 `modal={false}`를 전달 
→ vaul이 내부적으로 Radix Dialog.Root에 modal prop을 **전달하지 않음 (코드에서 modal={false}를 전달해도 내부적으로는 modal prop 전달이 아예 안됨)** 
→ 따라서 Radix Dialog는 기본값 `modal=true`로 동작
→ `DismissableLayer`가 `document.body.style.pointerEvents = "none"` 설정
→ **모든 외부 요소 클릭 차단된다!**

이 버그 자체는 이미 vaul GitHub에 [PR #580](https://github.com/emilkowalski/vaul/pull/580)으로 수정이 머지되어 있지만, 아직 npm에 새 버전이 릴리즈되지 않은 상태였어요

⇒ 이럴때 **pnpm patch**를 사용하면 되더라고요! pnpm patch는 node_modules의 라이브러리 소스를 직접 수정하고, 그 변경사항을 `.patch` 파일로 저장해서 `pnpm install` 시 자동 적용하는 기능이에요. 라이브러리 버그가 있는데 새 버전이 안 나왔을 때 사용하는 공식 지원 방법.

+) 수정하는건 클로드 도움을 받아서 했어요. 


```jsx
// After: modal prop 추가 (patches/vaul@1.1.2.patch)
React.createElement(DialogPrimitive.Root, {
    defaultOpen: defaultOpen,
    onOpenChange: ...,
    open: isOpen,
    modal: modal  // ← 한 줄 추가
})
```

이 패치 덕분에 `modal={false}` 전달 시 Radix Dialog가 정상적으로 non-modal로 동작하고, `body.style.pointerEvents`를 건드리지 않아요.

+) vaul 새 버전이 나오면 패치를 제거하고 업데이트하면 돼요.

## 🔍 To Reviewer

- `backgroundInteractable`, `preventScroll`은 DragHandleBottomSheet 내부에서만 사용하고, CloseBottomSheet는 기본값으로 동작하니까 기존 필터/도면 선택 바텀시트에 영향 없어요.
- vaul patch는 `patches/vaul@1.1.2.patch`에 저장되어 있고, `pnpm install` 시 자동 적용돼요. 새 버전이 릴리즈되면 제거할 예정이에요.

_해당 PR에 수행한 작업을 작성해주세요._

## 📸 Screenshot

데스크탑, 모바일 둘 다 정상 동작하는거 확인했습니다

https://github.com/user-attachments/assets/f575ed99-fff5-49eb-8927-230934502657




_작업한 내용에 대한 스크린샷을 첨부해주세요._