### PR TITLE
[setting] swagger-typescript-api 적용

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -5,3 +5,4 @@ build
 package.json
 /.coderabbit.yaml
 *.hbs
+src/shared/apis/__generated__/

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -16,7 +16,14 @@ import vanillaExtract from '@antebudimir/eslint-plugin-vanilla-extract';
 
 export default [
   {
-    ignores: ['dist', 'storybook-static/**', 'node_modules/', '*.js', '*.d.ts'],
+    ignores: [
+      'dist',
+      'storybook-static/**',
+      'node_modules/',
+      '*.js',
+      '*.d.ts',
+      'src/shared/apis/__generated__/**',
+    ],
   },
   {
     files: ['**/*.{ts,tsx}'],

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "playwright": "^1.53.1",
     "prettier": "3.6.2",
     "storybook": "^10.1.11",
+    "swagger-typescript-api": "^13.6.10",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.34.1",
     "vite": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "build-storybook": "storybook build --stats-json",
     "test": "vitest run --project unit",
     "test:watch": "vitest --project unit",
-    "test:coverage": "vitest run --project unit --coverage"
+    "test:coverage": "vitest run --project unit --coverage",
+    "api:generate": "node scripts/gen-api.mjs"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,7 +90,7 @@ importers:
     devDependencies:
       '@antebudimir/eslint-plugin-vanilla-extract':
         specifier: ^1.16.0
-        version: 1.16.0(eslint@9.30.0)
+        version: 1.16.0(eslint@9.30.0(jiti@2.6.1))
       '@chromatic-com/storybook':
         specifier: ^5.0.0
         version: 5.0.0(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.6.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))
@@ -102,19 +102,19 @@ importers:
         version: 10.1.11(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.6.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))
       '@storybook/addon-docs':
         specifier: ^10.1.11
-        version: 10.1.11(@types/react@19.2.2)(esbuild@0.25.5)(rollup@4.44.1)(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.6.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@7.0.0(@types/node@24.0.7)(yaml@2.8.0))
+        version: 10.1.11(@types/react@19.2.2)(esbuild@0.25.5)(rollup@4.44.1)(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.6.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@7.0.0(@types/node@24.0.7)(jiti@2.6.1)(yaml@2.8.3))
       '@storybook/addon-vitest':
         specifier: ^10.1.11
         version: 10.1.11(@vitest/browser@3.2.4)(@vitest/runner@3.2.4)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.6.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vitest@3.2.4)
       '@storybook/react-vite':
         specifier: ^10.1.11
-        version: 10.1.11(esbuild@0.25.5)(msw@2.12.10(@types/node@24.0.7)(typescript@5.8.3))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(rollup@4.44.1)(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.6.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.8.3)(vite@7.0.0(@types/node@24.0.7)(yaml@2.8.0))
+        version: 10.1.11(esbuild@0.25.5)(msw@2.12.10(@types/node@24.0.7)(typescript@5.8.3))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(rollup@4.44.1)(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.6.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.8.3)(vite@7.0.0(@types/node@24.0.7)(jiti@2.6.1)(yaml@2.8.3))
       '@svgr/plugin-svgo':
         specifier: ^8.1.0
         version: 8.1.0(@svgr/core@8.1.0(typescript@5.8.3))(typescript@5.8.3)
       '@tanstack/eslint-plugin-query':
         specifier: ^5.81.2
-        version: 5.81.2(eslint@9.30.0)(typescript@5.8.3)
+        version: 5.81.2(eslint@9.30.0(jiti@2.6.1))(typescript@5.8.3)
       '@testing-library/jest-dom':
         specifier: ^6.9.1
         version: 6.9.1
@@ -135,58 +135,58 @@ importers:
         version: 19.2.1(@types/react@19.2.2)
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.35.0
-        version: 8.35.0(@typescript-eslint/parser@8.35.0(eslint@9.30.0)(typescript@5.8.3))(eslint@9.30.0)(typescript@5.8.3)
+        version: 8.35.0(@typescript-eslint/parser@8.35.0(eslint@9.30.0(jiti@2.6.1))(typescript@5.8.3))(eslint@9.30.0(jiti@2.6.1))(typescript@5.8.3)
       '@typescript-eslint/parser':
         specifier: ^8.35.0
-        version: 8.35.0(eslint@9.30.0)(typescript@5.8.3)
+        version: 8.35.0(eslint@9.30.0(jiti@2.6.1))(typescript@5.8.3)
       '@vanilla-extract/css':
         specifier: ^1.17.4
         version: 1.17.4
       '@vanilla-extract/vite-plugin':
         specifier: ^5.1.0
-        version: 5.1.0(@types/node@24.0.7)(vite@7.0.0(@types/node@24.0.7)(yaml@2.8.0))(yaml@2.8.0)
+        version: 5.1.0(@types/node@24.0.7)(jiti@2.6.1)(vite@7.0.0(@types/node@24.0.7)(jiti@2.6.1)(yaml@2.8.3))(yaml@2.8.3)
       '@vitejs/plugin-react':
         specifier: ^4.5.2
-        version: 4.6.0(vite@7.0.0(@types/node@24.0.7)(yaml@2.8.0))
+        version: 4.6.0(vite@7.0.0(@types/node@24.0.7)(jiti@2.6.1)(yaml@2.8.3))
       '@vitest/browser':
         specifier: ^3.2.4
-        version: 3.2.4(msw@2.12.10(@types/node@24.0.7)(typescript@5.8.3))(playwright@1.53.2)(vite@7.0.0(@types/node@24.0.7)(yaml@2.8.0))(vitest@3.2.4)
+        version: 3.2.4(msw@2.12.10(@types/node@24.0.7)(typescript@5.8.3))(playwright@1.53.2)(vite@7.0.0(@types/node@24.0.7)(jiti@2.6.1)(yaml@2.8.3))(vitest@3.2.4)
       '@vitest/coverage-v8':
         specifier: ^3.2.4
         version: 3.2.4(@vitest/browser@3.2.4)(vitest@3.2.4)
       eslint:
         specifier: ^9.29.0
-        version: 9.30.0
+        version: 9.30.0(jiti@2.6.1)
       eslint-config-prettier:
         specifier: ^10.1.5
-        version: 10.1.5(eslint@9.30.0)
+        version: 10.1.5(eslint@9.30.0(jiti@2.6.1))
       eslint-import-resolver-typescript:
         specifier: ^4.4.4
-        version: 4.4.4(eslint-plugin-import@2.32.0)(eslint@9.30.0)
+        version: 4.4.4(eslint-plugin-import@2.32.0)(eslint@9.30.0(jiti@2.6.1))
       eslint-plugin-import:
         specifier: ^2.32.0
-        version: 2.32.0(@typescript-eslint/parser@8.35.0(eslint@9.30.0)(typescript@5.8.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.30.0)
+        version: 2.32.0(@typescript-eslint/parser@8.35.0(eslint@9.30.0(jiti@2.6.1))(typescript@5.8.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.30.0(jiti@2.6.1))
       eslint-plugin-jsx-a11y:
         specifier: ^6.10.2
-        version: 6.10.2(eslint@9.30.0)
+        version: 6.10.2(eslint@9.30.0(jiti@2.6.1))
       eslint-plugin-prettier:
         specifier: ^5.5.1
-        version: 5.5.1(eslint-config-prettier@10.1.5(eslint@9.30.0))(eslint@9.30.0)(prettier@3.6.2)
+        version: 5.5.1(eslint-config-prettier@10.1.5(eslint@9.30.0(jiti@2.6.1)))(eslint@9.30.0(jiti@2.6.1))(prettier@3.6.2)
       eslint-plugin-react:
         specifier: ^7.37.5
-        version: 7.37.5(eslint@9.30.0)
+        version: 7.37.5(eslint@9.30.0(jiti@2.6.1))
       eslint-plugin-react-hooks:
         specifier: ^5.2.0
-        version: 5.2.0(eslint@9.30.0)
+        version: 5.2.0(eslint@9.30.0(jiti@2.6.1))
       eslint-plugin-react-refresh:
         specifier: ^0.4.20
-        version: 0.4.20(eslint@9.30.0)
+        version: 0.4.20(eslint@9.30.0(jiti@2.6.1))
       eslint-plugin-simple-import-sort:
         specifier: ^12.1.1
-        version: 12.1.1(eslint@9.30.0)
+        version: 12.1.1(eslint@9.30.0(jiti@2.6.1))
       eslint-plugin-storybook:
         specifier: ^10.1.11
-        version: 10.1.11(eslint@9.30.0)(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.6.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.8.3)
+        version: 10.1.11(eslint@9.30.0(jiti@2.6.1))(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.6.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.8.3)
       globals:
         specifier: ^16.2.0
         version: 16.2.0
@@ -211,21 +211,24 @@ importers:
       storybook:
         specifier: ^10.1.11
         version: 10.1.11(@testing-library/dom@10.4.0)(prettier@3.6.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      swagger-typescript-api:
+        specifier: ^13.6.10
+        version: 13.6.10(magicast@0.3.5)(react@19.2.0)
       typescript:
         specifier: ~5.8.3
         version: 5.8.3
       typescript-eslint:
         specifier: ^8.34.1
-        version: 8.35.0(eslint@9.30.0)(typescript@5.8.3)
+        version: 8.35.0(eslint@9.30.0(jiti@2.6.1))(typescript@5.8.3)
       vite:
         specifier: ^7.0.0
-        version: 7.0.0(@types/node@24.0.7)(yaml@2.8.0)
+        version: 7.0.0(@types/node@24.0.7)(jiti@2.6.1)(yaml@2.8.3)
       vite-plugin-svgr:
         specifier: ^4.3.0
-        version: 4.3.0(rollup@4.44.1)(typescript@5.8.3)(vite@7.0.0(@types/node@24.0.7)(yaml@2.8.0))
+        version: 4.3.0(rollup@4.44.1)(typescript@5.8.3)(vite@7.0.0(@types/node@24.0.7)(jiti@2.6.1)(yaml@2.8.3))
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.0.7)(@vitest/browser@3.2.4)(jsdom@28.1.0)(msw@2.12.10(@types/node@24.0.7)(typescript@5.8.3))(yaml@2.8.0)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.0.7)(@vitest/browser@3.2.4)(jiti@2.6.1)(jsdom@28.1.0)(msw@2.12.10(@types/node@24.0.7)(typescript@5.8.3))(yaml@2.8.3)
 
 packages:
   '@acemir/cssom@0.9.31':
@@ -255,6 +258,34 @@ packages:
     engines: { node: '>=18.18.0' }
     peerDependencies:
       eslint: '>=8.57.0'
+
+  '@apidevtools/json-schema-ref-parser@14.0.1':
+    resolution:
+      {
+        integrity: sha512-Oc96zvmxx1fqoSEdUmfmvvb59/KDOnUoJ7s2t7bISyAn0XEz57LCCw8k2Y4Pf3mwKaZLMciESALORLgfe2frCw==,
+      }
+    engines: { node: '>= 16' }
+
+  '@apidevtools/openapi-schemas@2.1.0':
+    resolution:
+      {
+        integrity: sha512-Zc1AlqrJlX3SlpupFGpiLi2EbteyP7fXmUOGup6/DnkRgjP9bgMM/ag+n91rsv0U1Gpz0H3VILA/o3bW7Ua6BQ==,
+      }
+    engines: { node: '>=10' }
+
+  '@apidevtools/swagger-methods@3.0.2':
+    resolution:
+      {
+        integrity: sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg==,
+      }
+
+  '@apidevtools/swagger-parser@12.1.0':
+    resolution:
+      {
+        integrity: sha512-e5mJoswsnAX0jG+J09xHFYQXb/bUc5S3pLpMxUuRUA2H8T2kni3yEoyz2R3Dltw5f4A6j6rPNMpWTK+iVDFlng==,
+      }
+    peerDependencies:
+      openapi-types: '>=7'
 
   '@asamuzakjp/css-color@5.0.1':
     resolution:
@@ -524,6 +555,29 @@ packages:
         integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==,
       }
     engines: { node: '>=18' }
+
+  '@biomejs/js-api@4.0.0':
+    resolution:
+      {
+        integrity: sha512-EOArR/6drRzM1/hwOIz1pZw90FL31Ud4Y7hEHGWVtMNmAwS9SrwZ8hMENGlLVXCeGW/kL46p8kX7eO6x9Nmezg==,
+      }
+    peerDependencies:
+      '@biomejs/wasm-bundler': ^2.3.0
+      '@biomejs/wasm-nodejs': ^2.3.0
+      '@biomejs/wasm-web': ^2.3.0
+    peerDependenciesMeta:
+      '@biomejs/wasm-bundler':
+        optional: true
+      '@biomejs/wasm-nodejs':
+        optional: true
+      '@biomejs/wasm-web':
+        optional: true
+
+  '@biomejs/wasm-nodejs@2.4.12':
+    resolution:
+      {
+        integrity: sha512-3SGczq2LKHJw9TYhJEmNwgBY767wSu+nRZVkp+oDiczYn2u7Xekb4smn/r3KJpaxGKkxxtTV4h6RTwBUKzf8Fw==,
+      }
 
   '@bramus/specificity@2.4.2':
     resolution:
@@ -922,6 +976,12 @@ packages:
     peerDependenciesMeta:
       '@noble/hashes':
         optional: true
+
+  '@exodus/schemasafe@1.3.0':
+    resolution:
+      {
+        integrity: sha512-5Aap/GaRupgNx/feGBwLLTVv8OQFfv3pq2lPRzPg9R+IOBnDgghTGW7l7EuVXOvg5cc/xSAlRW8rBrjIC3Nvqw==,
+      }
 
   '@firebase/ai@2.3.0':
     resolution:
@@ -2507,6 +2567,18 @@ packages:
         integrity: sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==,
       }
 
+  '@types/swagger-schema-official@2.0.25':
+    resolution:
+      {
+        integrity: sha512-T92Xav+Gf/Ik1uPW581nA+JftmjWPgskw/WBf4TJzxRG/SJ+DfNnNE+WuZ4mrXuzflQMqMkm1LSYjzYW7MB1Cg==,
+      }
+
+  '@types/trusted-types@2.0.7':
+    resolution:
+      {
+        integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==,
+      }
+
   '@types/unist@2.0.11':
     resolution:
       {
@@ -2949,10 +3021,27 @@ packages:
       }
     engines: { node: '>= 14' }
 
+  ajv-draft-04@1.0.0:
+    resolution:
+      {
+        integrity: sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==,
+      }
+    peerDependencies:
+      ajv: ^8.5.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
   ajv@6.12.6:
     resolution:
       {
         integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==,
+      }
+
+  ajv@8.18.0:
+    resolution:
+      {
+        integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==,
       }
 
   ansi-escapes@7.0.0:
@@ -3203,6 +3292,17 @@ packages:
       }
     engines: { node: '>=18' }
 
+  c12@3.3.4:
+    resolution:
+      {
+        integrity: sha512-cM0ApFQSBXuourJejzwv/AuPRvAxordTyParRVcHjjtXirtkzM0uK2L9TTn9s0cXZbG7E55jCivRQzoxYmRAlA==,
+      }
+    peerDependencies:
+      magicast: '*'
+    peerDependenciesMeta:
+      magicast:
+        optional: true
+
   cac@6.7.14:
     resolution:
       {
@@ -3230,6 +3330,12 @@ packages:
         integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==,
       }
     engines: { node: '>= 0.4' }
+
+  call-me-maybe@1.0.2:
+    resolution:
+      {
+        integrity: sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ==,
+      }
 
   callsites@3.1.0:
     resolution:
@@ -3309,6 +3415,13 @@ packages:
       }
     engines: { node: '>= 16' }
 
+  chokidar@5.0.0:
+    resolution:
+      {
+        integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==,
+      }
+    engines: { node: '>= 20.19.0' }
+
   chromatic@13.3.5:
     resolution:
       {
@@ -3323,6 +3436,18 @@ packages:
         optional: true
       '@chromatic-com/playwright':
         optional: true
+
+  citty@0.2.2:
+    resolution:
+      {
+        integrity: sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w==,
+      }
+
+  class-variance-authority@0.7.1:
+    resolution:
+      {
+        integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==,
+      }
 
   cli-cursor@5.0.0:
     resolution:
@@ -3416,6 +3541,19 @@ packages:
       {
         integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==,
       }
+
+  confbox@0.2.4:
+    resolution:
+      {
+        integrity: sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==,
+      }
+
+  consola@3.4.2:
+    resolution:
+      {
+        integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==,
+      }
+    engines: { node: ^14.18.0 || >=16.10.0 }
 
   convert-source-map@2.0.0:
     resolution:
@@ -3551,6 +3689,12 @@ packages:
       }
     engines: { node: '>= 0.4' }
 
+  dayjs@1.11.20:
+    resolution:
+      {
+        integrity: sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==,
+      }
+
   debug@3.2.7:
     resolution:
       {
@@ -3658,6 +3802,12 @@ packages:
       }
     engines: { node: '>= 0.4' }
 
+  defu@6.1.7:
+    resolution:
+      {
+        integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==,
+      }
+
   delayed-stream@1.0.0:
     resolution:
       {
@@ -3671,6 +3821,12 @@ packages:
         integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==,
       }
     engines: { node: '>=6' }
+
+  destr@2.0.5:
+    resolution:
+      {
+        integrity: sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==,
+      }
 
   detect-node-es@1.1.0:
     resolution:
@@ -3729,6 +3885,12 @@ packages:
       }
     engines: { node: '>= 4' }
 
+  dompurify@3.4.1:
+    resolution:
+      {
+        integrity: sha512-JahakDAIg1gyOm7dlgWSDjV4n7Ip2PKR55NIT6jrMfIgLFgWo81vdr1/QGqWtFNRqXP9UV71oVePtjqS2ebnPw==,
+      }
+
   domutils@3.2.2:
     resolution:
       {
@@ -3740,6 +3902,13 @@ packages:
       {
         integrity: sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==,
       }
+
+  dotenv@17.4.2:
+    resolution:
+      {
+        integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==,
+      }
+    engines: { node: '>=12' }
 
   dunder-proto@1.0.1:
     resolution:
@@ -3873,6 +4042,18 @@ packages:
         integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==,
       }
     engines: { node: '>= 0.4' }
+
+  es-toolkit@1.46.0:
+    resolution:
+      {
+        integrity: sha512-IToJ6ct9OLl5zz6WsC/1vZEwfSZ7Myil+ygl5Tf30Xjn9AEkzNB4kqp2G7VUJKF1DtTx/ra5M5KLlXvzOg51BA==,
+      }
+
+  es6-promise@3.3.1:
+    resolution:
+      {
+        integrity: sha512-SOp9Phqvqn7jtEUxPWdWfWoLmyt2VaJ6MpvP9Comy1MceMXqE6bxvaTu4iaxpYYPzhny28Lc+M87/c2cPK6lDg==,
+      }
 
   esbuild@0.25.5:
     resolution:
@@ -4147,6 +4328,13 @@ packages:
       }
     engines: { node: '>=0.10.0' }
 
+  eta@3.5.0:
+    resolution:
+      {
+        integrity: sha512-e3x3FBvGzeCIHhF+zhK8FZA2vC5uFn6b4HJjegUbIWrDb4mJ7JjTGMJY9VGIbRVpmSwHopNiaJibhjIr+HfLug==,
+      }
+    engines: { node: '>=6.0.0' }
+
   eval@0.1.8:
     resolution:
       {
@@ -4166,6 +4354,12 @@ packages:
         integrity: sha512-/kP8CAwxzLVEeFrMm4kMmy4CCDlpipyA7MYLVrdJIkV0fYF0UaigQHRsxHiuY/GEea+bh4KSv3TIlgr+2UL6bw==,
       }
     engines: { node: '>=12.0.0' }
+
+  exsolve@1.0.8:
+    resolution:
+      {
+        integrity: sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==,
+      }
 
   extend@3.0.2:
     resolution:
@@ -4202,6 +4396,18 @@ packages:
     resolution:
       {
         integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==,
+      }
+
+  fast-safe-stringify@2.1.1:
+    resolution:
+      {
+        integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==,
+      }
+
+  fast-uri@3.1.0:
+    resolution:
+      {
+        integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==,
       }
 
   fastq@1.19.1:
@@ -4421,6 +4627,13 @@ packages:
         integrity: sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==,
       }
 
+  giget@3.2.0:
+    resolution:
+      {
+        integrity: sha512-GvHTWcykIR/fP8cj8dMpuMMkvaeJfPvYnhq0oW+chSeIr+ldX21ifU2Ms6KBoyKZQZmVaUAAhQ2EZ68KJF8a7A==,
+      }
+    hasBin: true
+
   glob-parent@5.1.2:
     resolution:
       {
@@ -4607,6 +4820,12 @@ packages:
         integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==,
       }
     engines: { node: '>= 14' }
+
+  http2-client@1.3.5:
+    resolution:
+      {
+        integrity: sha512-EC2utToWl4RKfs5zd36Mxq7nzHHBuomZboI0yYL6Y0RmBgT7Sgkq4rQ0ezFTYoIsSs7Tm9SJe+o2FcAg6GBhGA==,
+      }
 
   https-proxy-agent@7.0.6:
     resolution:
@@ -5023,6 +5242,13 @@ packages:
         integrity: sha512-JVAfqNPTvNq3sB/VHQJAFxN/sPgKnsKrCwyRt15zwNCdrMMJDdcEOdubuy+DuJYYdm0ox1J4uzEuYKkN+9yhVg==,
       }
 
+  jiti@2.6.1:
+    resolution:
+      {
+        integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==,
+      }
+    hasBin: true
+
   js-tokens@4.0.0:
     resolution:
       {
@@ -5078,6 +5304,12 @@ packages:
     resolution:
       {
         integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==,
+      }
+
+  json-schema-traverse@1.0.0:
+    resolution:
+      {
+        integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==,
       }
 
   json-stable-stringify-without-jsonify@1.0.1:
@@ -5742,6 +5974,14 @@ packages:
     engines: { node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1 }
     hasBin: true
 
+  nanoid@5.1.9:
+    resolution:
+      {
+        integrity: sha512-ZUvP7KeBLe3OZ1ypw6dI/TzYJuvHP77IM4Ry73waSQTLn8/g8rpdjfyVAh7t1/+FjBtG4lCP42MEbDxOsRpBMw==,
+      }
+    engines: { node: ^18 || >=20 }
+    hasBin: true
+
   napi-postinstall@0.3.0:
     resolution:
       {
@@ -5762,6 +6002,31 @@ packages:
         integrity: sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==,
       }
 
+  node-fetch-h2@2.3.0:
+    resolution:
+      {
+        integrity: sha512-ofRW94Ab0T4AOh5Fk8t0h8OBWrmjb0SSB20xh1H8YnPV9EJ+f5AMoYSUQ2zgJ4Iq2HAK0I2l5/Nequ8YzFS3Hg==,
+      }
+    engines: { node: 4.x || >=6.0.0 }
+
+  node-fetch@2.7.0:
+    resolution:
+      {
+        integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==,
+      }
+    engines: { node: 4.x || >=6.0.0 }
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+
+  node-readfiles@0.2.0:
+    resolution:
+      {
+        integrity: sha512-SU00ZarexNlE4Rjdm83vglt5Y9yiQ+XI1XpflWlb7q7UTN1JUItm69xMeiQCTxtTfnzt+83T8Cx+vI2ED++VDA==,
+      }
+
   node-releases@2.0.19:
     resolution:
       {
@@ -5772,6 +6037,37 @@ packages:
     resolution:
       {
         integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==,
+      }
+
+  oas-kit-common@1.0.8:
+    resolution:
+      {
+        integrity: sha512-pJTS2+T0oGIwgjGpw7sIRU8RQMcUoKCDWFLdBqKB2BNmGpbBMH2sdqAaOXUg8OzonZHU0L7vfJu1mJFEiYDWOQ==,
+      }
+
+  oas-linter@3.2.2:
+    resolution:
+      {
+        integrity: sha512-KEGjPDVoU5K6swgo9hJVA/qYGlwfbFx+Kg2QB/kd7rzV5N8N5Mg6PlsoCMohVnQmo+pzJap/F610qTodKzecGQ==,
+      }
+
+  oas-resolver@2.5.6:
+    resolution:
+      {
+        integrity: sha512-Yx5PWQNZomfEhPPOphFbZKi9W93CocQj18NlD2Pa4GWZzdZpSJvYwoiuurRI7m3SpcChrnO08hkuQDL3FGsVFQ==,
+      }
+    hasBin: true
+
+  oas-schema-walker@1.1.5:
+    resolution:
+      {
+        integrity: sha512-2yucenq1a9YPmeNExoUa9Qwrt9RFkjqaMAA1X+U7sbb0AqBeTIdMHky9SQQ6iN94bO5NW0W4TRYXerG+BdAvAQ==,
+      }
+
+  oas-validator@5.0.8:
+    resolution:
+      {
+        integrity: sha512-cu20/HE5N5HKqVygs3dt94eYJfBi0TsZvPVXDhbXQHiEityDN+RROTleefoKRKKJ9dFAF2JBkDHgvWj0sjKGmw==,
       }
 
   object-assign@4.1.1:
@@ -5830,6 +6126,12 @@ packages:
       }
     engines: { node: '>= 0.4' }
 
+  ohash@2.0.11:
+    resolution:
+      {
+        integrity: sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==,
+      }
+
   onetime@7.0.0:
     resolution:
       {
@@ -5855,6 +6157,12 @@ packages:
         integrity: sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==,
       }
     engines: { node: '>=18' }
+
+  openapi-types@12.1.3:
+    resolution:
+      {
+        integrity: sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==,
+      }
 
   optionator@0.9.4:
     resolution:
@@ -5991,6 +6299,12 @@ packages:
       }
     engines: { node: '>= 14.16' }
 
+  perfect-debounce@2.1.0:
+    resolution:
+      {
+        integrity: sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g==,
+      }
+
   picocolors@1.1.1:
     resolution:
       {
@@ -6030,6 +6344,12 @@ packages:
     resolution:
       {
         integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==,
+      }
+
+  pkg-types@2.3.0:
+    resolution:
+      {
+        integrity: sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==,
       }
 
   platform@1.3.6:
@@ -6133,6 +6453,12 @@ packages:
     resolution:
       {
         integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==,
+      }
+
+  rc9@3.0.1:
+    resolution:
+      {
+        integrity: sha512-gMDyleLWVE+i6Sgtc0QbbY6pEKqYs97NGi6isHQPqYlLemPoO8dxQ3uGi0f4NiP98c+jMW6cG1Kx9dDwfvqARQ==,
       }
 
   react-docgen-typescript@2.4.0:
@@ -6293,6 +6619,13 @@ packages:
       }
     engines: { node: '>=0.10.0' }
 
+  readdirp@5.0.0:
+    resolution:
+      {
+        integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==,
+      }
+    engines: { node: '>= 20.19.0' }
+
   recast@0.23.11:
     resolution:
       {
@@ -6313,6 +6646,12 @@ packages:
         integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==,
       }
     engines: { node: '>= 0.4' }
+
+  reftools@1.1.9:
+    resolution:
+      {
+        integrity: sha512-OVede/NQE13xBQ+ob5CKd5KyeJYU2YInb1bmV4nRoOfquZPkAkxuOXicSe1PvqIuZZ4kD13sPKBbR7UFDmli6w==,
+      }
 
   regexp.prototype.flags@1.5.4:
     resolution:
@@ -6541,6 +6880,42 @@ packages:
         integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==,
       }
     engines: { node: '>=8' }
+
+  should-equal@2.0.0:
+    resolution:
+      {
+        integrity: sha512-ZP36TMrK9euEuWQYBig9W55WPC7uo37qzAEmbjHz4gfyuXrEUgF8cUvQVO+w+d3OMfPvSRQJ22lSm8MQJ43LTA==,
+      }
+
+  should-format@3.0.3:
+    resolution:
+      {
+        integrity: sha512-hZ58adtulAk0gKtua7QxevgUaXTTXxIi8t41L3zo9AHvjXO1/7sdLECuHeIN2SRtYXpNkmhoUP2pdeWgricQ+Q==,
+      }
+
+  should-type-adaptors@1.1.0:
+    resolution:
+      {
+        integrity: sha512-JA4hdoLnN+kebEp2Vs8eBe9g7uy0zbRo+RMcU0EsNy+R+k049Ki+N5tT5Jagst2g7EAja+euFuoXFCa8vIklfA==,
+      }
+
+  should-type@1.4.0:
+    resolution:
+      {
+        integrity: sha512-MdAsTu3n25yDbIe1NeN69G4n6mUnJGtSJHygX3+oN0ZbO3DTiATnf7XnYJdGT42JCXurTb1JI0qOBR65shvhPQ==,
+      }
+
+  should-util@1.0.1:
+    resolution:
+      {
+        integrity: sha512-oXF8tfxx5cDk8r2kYqlkUJzZpDBqVY/II2WhvU0n9Y3XYvAYRmeaf1PvvIvTgPnv4KJ+ES5M0PyDq5Jp+Ygy2g==,
+      }
+
+  should@13.2.3:
+    resolution:
+      {
+        integrity: sha512-ggLesLtu2xp+ZxI+ysJTmNjh2U0TsC+rQ/pfED9bUZZ4DKefP27D+7YJVVTvKsmjLpIi9jAa7itwDGkDDmt1GQ==,
+      }
 
   side-channel-list@1.0.0:
     resolution:
@@ -6844,6 +7219,27 @@ packages:
     engines: { node: '>=14.0.0' }
     hasBin: true
 
+  swagger-schema-official@2.0.0-bab6bed:
+    resolution:
+      {
+        integrity: sha512-rCC0NWGKr/IJhtRuPq/t37qvZHI/mH4I4sxflVM+qgVe5Z2uOCivzWaVbuioJaB61kvm5UvB7b49E+oBY0M8jA==,
+      }
+
+  swagger-typescript-api@13.6.10:
+    resolution:
+      {
+        integrity: sha512-X+DenKK2txtI0LdNcpmWddcZWiWaf6erIZ+m9Wz7vk/yMFmPJ9EljSuX+dnJQ9YuzjV1imaRCDKsHA4CG2wUZA==,
+      }
+    engines: { node: '>=20' }
+    hasBin: true
+
+  swagger2openapi@7.0.8:
+    resolution:
+      {
+        integrity: sha512-upi/0ZGkYgEcLeGieoz8gT74oWHA0E7JivX7aN9mAf+Tc7BQoRBvnIGHoPDw+f9TXTW4s6kGYCZJtauP6OYp7g==,
+      }
+    hasBin: true
+
   swiper@12.0.2:
     resolution:
       {
@@ -6870,6 +7266,12 @@ packages:
         integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==,
       }
     engines: { node: '>=20' }
+
+  tailwind-merge@3.5.0:
+    resolution:
+      {
+        integrity: sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==,
+      }
 
   test-exclude@7.0.1:
     resolution:
@@ -6957,6 +7359,12 @@ packages:
         integrity: sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==,
       }
     engines: { node: '>=16' }
+
+  tr46@0.0.3:
+    resolution:
+      {
+        integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==,
+      }
 
   tr46@6.0.0:
     resolution:
@@ -7068,6 +7476,14 @@ packages:
     resolution:
       {
         integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==,
+      }
+    engines: { node: '>=14.17' }
+    hasBin: true
+
+  typescript@6.0.3:
+    resolution:
+      {
+        integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==,
       }
     engines: { node: '>=14.17' }
     hasBin: true
@@ -7376,6 +7792,12 @@ packages:
         integrity: sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw==,
       }
 
+  webidl-conversions@3.0.1:
+    resolution:
+      {
+        integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==,
+      }
+
   webidl-conversions@8.0.1:
     resolution:
       {
@@ -7416,6 +7838,12 @@ packages:
         integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==,
       }
     engines: { node: ^20.19.0 || ^22.12.0 || >=24.0.0 }
+
+  whatwg-url@5.0.0:
+    resolution:
+      {
+        integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==,
+      }
 
   which-boxed-primitive@1.1.1:
     resolution:
@@ -7544,10 +7972,25 @@ packages:
         integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==,
       }
 
+  yaml@1.10.3:
+    resolution:
+      {
+        integrity: sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==,
+      }
+    engines: { node: '>= 6' }
+
   yaml@2.8.0:
     resolution:
       {
         integrity: sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==,
+      }
+    engines: { node: '>= 14.6' }
+    hasBin: true
+
+  yaml@2.8.3:
+    resolution:
+      {
+        integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==,
       }
     engines: { node: '>= 14.6' }
     hasBin: true
@@ -7579,6 +8022,20 @@ packages:
         integrity: sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==,
       }
     engines: { node: '>=18' }
+
+  yummies@7.18.0:
+    resolution:
+      {
+        integrity: sha512-fgldINrxPi20XJjIa1LOniyqHROm5HwDmmq0VZtQml4u3cMerm8H7H2BM8kMhHilgd8l7rg3mN4xt2apc2l/xA==,
+      }
+    peerDependencies:
+      mobx: ^6.12.4
+      react: ^18 || ^19
+    peerDependenciesMeta:
+      mobx:
+        optional: true
+      react:
+        optional: true
 
   zustand@5.0.6:
     resolution:
@@ -7617,11 +8074,30 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.10
       '@jridgewell/trace-mapping': 0.3.27
 
-  '@antebudimir/eslint-plugin-vanilla-extract@1.16.0(eslint@9.30.0)':
+  '@antebudimir/eslint-plugin-vanilla-extract@1.16.0(eslint@9.30.0(jiti@2.6.1))':
     dependencies:
       '@babel/parser': 7.28.6
       '@babel/types': 7.28.6
-      eslint: 9.30.0
+      eslint: 9.30.0(jiti@2.6.1)
+
+  '@apidevtools/json-schema-ref-parser@14.0.1':
+    dependencies:
+      '@types/json-schema': 7.0.15
+      js-yaml: 4.1.0
+
+  '@apidevtools/openapi-schemas@2.1.0': {}
+
+  '@apidevtools/swagger-methods@3.0.2': {}
+
+  '@apidevtools/swagger-parser@12.1.0(openapi-types@12.1.3)':
+    dependencies:
+      '@apidevtools/json-schema-ref-parser': 14.0.1
+      '@apidevtools/openapi-schemas': 2.1.0
+      '@apidevtools/swagger-methods': 3.0.2
+      ajv: 8.18.0
+      ajv-draft-04: 1.0.0(ajv@8.18.0)
+      call-me-maybe: 1.0.2
+      openapi-types: 12.1.3
 
   '@asamuzakjp/css-color@5.0.1':
     dependencies:
@@ -7854,6 +8330,12 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
+  '@biomejs/js-api@4.0.0(@biomejs/wasm-nodejs@2.4.12)':
+    optionalDependencies:
+      '@biomejs/wasm-nodejs': 2.4.12
+
+  '@biomejs/wasm-nodejs@2.4.12': {}
+
   '@bramus/specificity@2.4.2':
     dependencies:
       css-tree: 3.1.0
@@ -7985,9 +8467,9 @@ snapshots:
   '@esbuild/win32-x64@0.25.5':
     optional: true
 
-  '@eslint-community/eslint-utils@4.7.0(eslint@9.30.0)':
+  '@eslint-community/eslint-utils@4.7.0(eslint@9.30.0(jiti@2.6.1))':
     dependencies:
-      eslint: 9.30.0
+      eslint: 9.30.0(jiti@2.6.1)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.1': {}
@@ -8034,6 +8516,8 @@ snapshots:
       levn: 0.4.1
 
   '@exodus/bytes@1.14.1': {}
+
+  '@exodus/schemasafe@1.3.0': {}
 
   '@firebase/ai@2.3.0(@firebase/app-types@0.9.3)(@firebase/app@0.14.3)':
     dependencies:
@@ -8423,11 +8907,11 @@ snapshots:
 
   '@istanbuljs/schema@0.1.3': {}
 
-  '@joshwooding/vite-plugin-react-docgen-typescript@0.6.3(typescript@5.8.3)(vite@7.0.0(@types/node@24.0.7)(yaml@2.8.0))':
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.6.3(typescript@5.8.3)(vite@7.0.0(@types/node@24.0.7)(jiti@2.6.1)(yaml@2.8.3))':
     dependencies:
       glob: 11.1.0
       react-docgen-typescript: 2.4.0(typescript@5.8.3)
-      vite: 7.0.0(@types/node@24.0.7)(yaml@2.8.0)
+      vite: 7.0.0(@types/node@24.0.7)(jiti@2.6.1)(yaml@2.8.3)
     optionalDependencies:
       typescript: 5.8.3
 
@@ -8790,10 +9274,10 @@ snapshots:
       axe-core: 4.10.3
       storybook: 10.1.11(@testing-library/dom@10.4.0)(prettier@3.6.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
 
-  '@storybook/addon-docs@10.1.11(@types/react@19.2.2)(esbuild@0.25.5)(rollup@4.44.1)(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.6.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@7.0.0(@types/node@24.0.7)(yaml@2.8.0))':
+  '@storybook/addon-docs@10.1.11(@types/react@19.2.2)(esbuild@0.25.5)(rollup@4.44.1)(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.6.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@7.0.0(@types/node@24.0.7)(jiti@2.6.1)(yaml@2.8.3))':
     dependencies:
       '@mdx-js/react': 3.1.0(@types/react@19.2.2)(react@19.2.0)
-      '@storybook/csf-plugin': 10.1.11(esbuild@0.25.5)(rollup@4.44.1)(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.6.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@7.0.0(@types/node@24.0.7)(yaml@2.8.0))
+      '@storybook/csf-plugin': 10.1.11(esbuild@0.25.5)(rollup@4.44.1)(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.6.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@7.0.0(@types/node@24.0.7)(jiti@2.6.1)(yaml@2.8.3))
       '@storybook/icons': 2.0.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@storybook/react-dom-shim': 10.1.11(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.6.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))
       react: 19.2.0
@@ -8813,34 +9297,34 @@ snapshots:
       '@storybook/icons': 2.0.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       storybook: 10.1.11(@testing-library/dom@10.4.0)(prettier@3.6.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
     optionalDependencies:
-      '@vitest/browser': 3.2.4(msw@2.12.10(@types/node@24.0.7)(typescript@5.8.3))(playwright@1.53.2)(vite@7.0.0(@types/node@24.0.7)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(msw@2.12.10(@types/node@24.0.7)(typescript@5.8.3))(playwright@1.53.2)(vite@7.0.0(@types/node@24.0.7)(jiti@2.6.1)(yaml@2.8.3))(vitest@3.2.4)
       '@vitest/runner': 3.2.4
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.0.7)(@vitest/browser@3.2.4)(jsdom@28.1.0)(msw@2.12.10(@types/node@24.0.7)(typescript@5.8.3))(yaml@2.8.0)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.0.7)(@vitest/browser@3.2.4)(jiti@2.6.1)(jsdom@28.1.0)(msw@2.12.10(@types/node@24.0.7)(typescript@5.8.3))(yaml@2.8.3)
     transitivePeerDependencies:
       - react
       - react-dom
 
-  '@storybook/builder-vite@10.1.11(esbuild@0.25.5)(msw@2.12.10(@types/node@24.0.7)(typescript@5.8.3))(rollup@4.44.1)(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.6.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@7.0.0(@types/node@24.0.7)(yaml@2.8.0))':
+  '@storybook/builder-vite@10.1.11(esbuild@0.25.5)(msw@2.12.10(@types/node@24.0.7)(typescript@5.8.3))(rollup@4.44.1)(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.6.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@7.0.0(@types/node@24.0.7)(jiti@2.6.1)(yaml@2.8.3))':
     dependencies:
-      '@storybook/csf-plugin': 10.1.11(esbuild@0.25.5)(rollup@4.44.1)(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.6.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@7.0.0(@types/node@24.0.7)(yaml@2.8.0))
-      '@vitest/mocker': 3.2.4(msw@2.12.10(@types/node@24.0.7)(typescript@5.8.3))(vite@7.0.0(@types/node@24.0.7)(yaml@2.8.0))
+      '@storybook/csf-plugin': 10.1.11(esbuild@0.25.5)(rollup@4.44.1)(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.6.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@7.0.0(@types/node@24.0.7)(jiti@2.6.1)(yaml@2.8.3))
+      '@vitest/mocker': 3.2.4(msw@2.12.10(@types/node@24.0.7)(typescript@5.8.3))(vite@7.0.0(@types/node@24.0.7)(jiti@2.6.1)(yaml@2.8.3))
       storybook: 10.1.11(@testing-library/dom@10.4.0)(prettier@3.6.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       ts-dedent: 2.2.0
-      vite: 7.0.0(@types/node@24.0.7)(yaml@2.8.0)
+      vite: 7.0.0(@types/node@24.0.7)(jiti@2.6.1)(yaml@2.8.3)
     transitivePeerDependencies:
       - esbuild
       - msw
       - rollup
       - webpack
 
-  '@storybook/csf-plugin@10.1.11(esbuild@0.25.5)(rollup@4.44.1)(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.6.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@7.0.0(@types/node@24.0.7)(yaml@2.8.0))':
+  '@storybook/csf-plugin@10.1.11(esbuild@0.25.5)(rollup@4.44.1)(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.6.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@7.0.0(@types/node@24.0.7)(jiti@2.6.1)(yaml@2.8.3))':
     dependencies:
       storybook: 10.1.11(@testing-library/dom@10.4.0)(prettier@3.6.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       unplugin: 2.3.11
     optionalDependencies:
       esbuild: 0.25.5
       rollup: 4.44.1
-      vite: 7.0.0(@types/node@24.0.7)(yaml@2.8.0)
+      vite: 7.0.0(@types/node@24.0.7)(jiti@2.6.1)(yaml@2.8.3)
 
   '@storybook/global@5.0.0': {}
 
@@ -8855,11 +9339,11 @@ snapshots:
       react-dom: 19.2.0(react@19.2.0)
       storybook: 10.1.11(@testing-library/dom@10.4.0)(prettier@3.6.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
 
-  '@storybook/react-vite@10.1.11(esbuild@0.25.5)(msw@2.12.10(@types/node@24.0.7)(typescript@5.8.3))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(rollup@4.44.1)(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.6.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.8.3)(vite@7.0.0(@types/node@24.0.7)(yaml@2.8.0))':
+  '@storybook/react-vite@10.1.11(esbuild@0.25.5)(msw@2.12.10(@types/node@24.0.7)(typescript@5.8.3))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(rollup@4.44.1)(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.6.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.8.3)(vite@7.0.0(@types/node@24.0.7)(jiti@2.6.1)(yaml@2.8.3))':
     dependencies:
-      '@joshwooding/vite-plugin-react-docgen-typescript': 0.6.3(typescript@5.8.3)(vite@7.0.0(@types/node@24.0.7)(yaml@2.8.0))
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.6.3(typescript@5.8.3)(vite@7.0.0(@types/node@24.0.7)(jiti@2.6.1)(yaml@2.8.3))
       '@rollup/pluginutils': 5.2.0(rollup@4.44.1)
-      '@storybook/builder-vite': 10.1.11(esbuild@0.25.5)(msw@2.12.10(@types/node@24.0.7)(typescript@5.8.3))(rollup@4.44.1)(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.6.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@7.0.0(@types/node@24.0.7)(yaml@2.8.0))
+      '@storybook/builder-vite': 10.1.11(esbuild@0.25.5)(msw@2.12.10(@types/node@24.0.7)(typescript@5.8.3))(rollup@4.44.1)(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.6.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@7.0.0(@types/node@24.0.7)(jiti@2.6.1)(yaml@2.8.3))
       '@storybook/react': 10.1.11(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.6.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.8.3)
       empathic: 2.0.0
       magic-string: 0.30.17
@@ -8869,7 +9353,7 @@ snapshots:
       resolve: 1.22.10
       storybook: 10.1.11(@testing-library/dom@10.4.0)(prettier@3.6.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       tsconfig-paths: 4.2.0
-      vite: 7.0.0(@types/node@24.0.7)(yaml@2.8.0)
+      vite: 7.0.0(@types/node@24.0.7)(jiti@2.6.1)(yaml@2.8.3)
     transitivePeerDependencies:
       - esbuild
       - msw
@@ -8970,10 +9454,10 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  '@tanstack/eslint-plugin-query@5.81.2(eslint@9.30.0)(typescript@5.8.3)':
+  '@tanstack/eslint-plugin-query@5.81.2(eslint@9.30.0(jiti@2.6.1))(typescript@5.8.3)':
     dependencies:
-      '@typescript-eslint/utils': 8.35.0(eslint@9.30.0)(typescript@5.8.3)
-      eslint: 9.30.0
+      '@typescript-eslint/utils': 8.35.0(eslint@9.30.0(jiti@2.6.1))(typescript@5.8.3)
+      eslint: 9.30.0(jiti@2.6.1)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -9107,19 +9591,24 @@ snapshots:
 
   '@types/statuses@2.0.6': {}
 
+  '@types/swagger-schema-official@2.0.25': {}
+
+  '@types/trusted-types@2.0.7':
+    optional: true
+
   '@types/unist@2.0.11': {}
 
   '@types/unist@3.0.3': {}
 
-  '@typescript-eslint/eslint-plugin@8.35.0(@typescript-eslint/parser@8.35.0(eslint@9.30.0)(typescript@5.8.3))(eslint@9.30.0)(typescript@5.8.3)':
+  '@typescript-eslint/eslint-plugin@8.35.0(@typescript-eslint/parser@8.35.0(eslint@9.30.0(jiti@2.6.1))(typescript@5.8.3))(eslint@9.30.0(jiti@2.6.1))(typescript@5.8.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 8.35.0(eslint@9.30.0)(typescript@5.8.3)
+      '@typescript-eslint/parser': 8.35.0(eslint@9.30.0(jiti@2.6.1))(typescript@5.8.3)
       '@typescript-eslint/scope-manager': 8.35.0
-      '@typescript-eslint/type-utils': 8.35.0(eslint@9.30.0)(typescript@5.8.3)
-      '@typescript-eslint/utils': 8.35.0(eslint@9.30.0)(typescript@5.8.3)
+      '@typescript-eslint/type-utils': 8.35.0(eslint@9.30.0(jiti@2.6.1))(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.35.0(eslint@9.30.0(jiti@2.6.1))(typescript@5.8.3)
       '@typescript-eslint/visitor-keys': 8.35.0
-      eslint: 9.30.0
+      eslint: 9.30.0(jiti@2.6.1)
       graphemer: 1.4.0
       ignore: 7.0.5
       natural-compare: 1.4.0
@@ -9128,14 +9617,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.35.0(eslint@9.30.0)(typescript@5.8.3)':
+  '@typescript-eslint/parser@8.35.0(eslint@9.30.0(jiti@2.6.1))(typescript@5.8.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.35.0
       '@typescript-eslint/types': 8.35.0
       '@typescript-eslint/typescript-estree': 8.35.0(typescript@5.8.3)
       '@typescript-eslint/visitor-keys': 8.35.0
       debug: 4.4.1
-      eslint: 9.30.0
+      eslint: 9.30.0(jiti@2.6.1)
       typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
@@ -9158,12 +9647,12 @@ snapshots:
     dependencies:
       typescript: 5.8.3
 
-  '@typescript-eslint/type-utils@8.35.0(eslint@9.30.0)(typescript@5.8.3)':
+  '@typescript-eslint/type-utils@8.35.0(eslint@9.30.0(jiti@2.6.1))(typescript@5.8.3)':
     dependencies:
       '@typescript-eslint/typescript-estree': 8.35.0(typescript@5.8.3)
-      '@typescript-eslint/utils': 8.35.0(eslint@9.30.0)(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.35.0(eslint@9.30.0(jiti@2.6.1))(typescript@5.8.3)
       debug: 4.4.1
-      eslint: 9.30.0
+      eslint: 9.30.0(jiti@2.6.1)
       ts-api-utils: 2.1.0(typescript@5.8.3)
       typescript: 5.8.3
     transitivePeerDependencies:
@@ -9187,13 +9676,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.35.0(eslint@9.30.0)(typescript@5.8.3)':
+  '@typescript-eslint/utils@8.35.0(eslint@9.30.0(jiti@2.6.1))(typescript@5.8.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.7.0(eslint@9.30.0)
+      '@eslint-community/eslint-utils': 4.7.0(eslint@9.30.0(jiti@2.6.1))
       '@typescript-eslint/scope-manager': 8.35.0
       '@typescript-eslint/types': 8.35.0
       '@typescript-eslint/typescript-estree': 8.35.0(typescript@5.8.3)
-      eslint: 9.30.0
+      eslint: 9.30.0(jiti@2.6.1)
       typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
@@ -9285,12 +9774,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vanilla-extract/compiler@0.3.0(@types/node@24.0.7)(yaml@2.8.0)':
+  '@vanilla-extract/compiler@0.3.0(@types/node@24.0.7)(jiti@2.6.1)(yaml@2.8.3)':
     dependencies:
       '@vanilla-extract/css': 1.17.4
       '@vanilla-extract/integration': 8.0.4
-      vite: 6.3.5(@types/node@24.0.7)(yaml@2.8.0)
-      vite-node: 3.2.4(@types/node@24.0.7)(yaml@2.8.0)
+      vite: 6.3.5(@types/node@24.0.7)(jiti@2.6.1)(yaml@2.8.3)
+      vite-node: 3.2.4(@types/node@24.0.7)(jiti@2.6.1)(yaml@2.8.3)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -9345,11 +9834,11 @@ snapshots:
     dependencies:
       '@vanilla-extract/css': 1.17.4
 
-  '@vanilla-extract/vite-plugin@5.1.0(@types/node@24.0.7)(vite@7.0.0(@types/node@24.0.7)(yaml@2.8.0))(yaml@2.8.0)':
+  '@vanilla-extract/vite-plugin@5.1.0(@types/node@24.0.7)(jiti@2.6.1)(vite@7.0.0(@types/node@24.0.7)(jiti@2.6.1)(yaml@2.8.3))(yaml@2.8.3)':
     dependencies:
-      '@vanilla-extract/compiler': 0.3.0(@types/node@24.0.7)(yaml@2.8.0)
+      '@vanilla-extract/compiler': 0.3.0(@types/node@24.0.7)(jiti@2.6.1)(yaml@2.8.3)
       '@vanilla-extract/integration': 8.0.4
-      vite: 7.0.0(@types/node@24.0.7)(yaml@2.8.0)
+      vite: 7.0.0(@types/node@24.0.7)(jiti@2.6.1)(yaml@2.8.3)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -9365,7 +9854,7 @@ snapshots:
       - tsx
       - yaml
 
-  '@vitejs/plugin-react@4.6.0(vite@7.0.0(@types/node@24.0.7)(yaml@2.8.0))':
+  '@vitejs/plugin-react@4.6.0(vite@7.0.0(@types/node@24.0.7)(jiti@2.6.1)(yaml@2.8.3))':
     dependencies:
       '@babel/core': 7.27.7
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.27.7)
@@ -9373,20 +9862,20 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.19
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 7.0.0(@types/node@24.0.7)(yaml@2.8.0)
+      vite: 7.0.0(@types/node@24.0.7)(jiti@2.6.1)(yaml@2.8.3)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/browser@3.2.4(msw@2.12.10(@types/node@24.0.7)(typescript@5.8.3))(playwright@1.53.2)(vite@7.0.0(@types/node@24.0.7)(yaml@2.8.0))(vitest@3.2.4)':
+  '@vitest/browser@3.2.4(msw@2.12.10(@types/node@24.0.7)(typescript@5.8.3))(playwright@1.53.2)(vite@7.0.0(@types/node@24.0.7)(jiti@2.6.1)(yaml@2.8.3))(vitest@3.2.4)':
     dependencies:
       '@testing-library/dom': 10.4.0
       '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.0)
-      '@vitest/mocker': 3.2.4(msw@2.12.10(@types/node@24.0.7)(typescript@5.8.3))(vite@7.0.0(@types/node@24.0.7)(yaml@2.8.0))
+      '@vitest/mocker': 3.2.4(msw@2.12.10(@types/node@24.0.7)(typescript@5.8.3))(vite@7.0.0(@types/node@24.0.7)(jiti@2.6.1)(yaml@2.8.3))
       '@vitest/utils': 3.2.4
       magic-string: 0.30.17
       sirv: 3.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.0.7)(@vitest/browser@3.2.4)(jsdom@28.1.0)(msw@2.12.10(@types/node@24.0.7)(typescript@5.8.3))(yaml@2.8.0)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.0.7)(@vitest/browser@3.2.4)(jiti@2.6.1)(jsdom@28.1.0)(msw@2.12.10(@types/node@24.0.7)(typescript@5.8.3))(yaml@2.8.3)
       ws: 8.18.3
     optionalDependencies:
       playwright: 1.53.2
@@ -9411,9 +9900,9 @@ snapshots:
       std-env: 3.9.0
       test-exclude: 7.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.0.7)(@vitest/browser@3.2.4)(jsdom@28.1.0)(msw@2.12.10(@types/node@24.0.7)(typescript@5.8.3))(yaml@2.8.0)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.0.7)(@vitest/browser@3.2.4)(jiti@2.6.1)(jsdom@28.1.0)(msw@2.12.10(@types/node@24.0.7)(typescript@5.8.3))(yaml@2.8.3)
     optionalDependencies:
-      '@vitest/browser': 3.2.4(msw@2.12.10(@types/node@24.0.7)(typescript@5.8.3))(playwright@1.53.2)(vite@7.0.0(@types/node@24.0.7)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(msw@2.12.10(@types/node@24.0.7)(typescript@5.8.3))(playwright@1.53.2)(vite@7.0.0(@types/node@24.0.7)(jiti@2.6.1)(yaml@2.8.3))(vitest@3.2.4)
     transitivePeerDependencies:
       - supports-color
 
@@ -9425,14 +9914,14 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(msw@2.12.10(@types/node@24.0.7)(typescript@5.8.3))(vite@7.0.0(@types/node@24.0.7)(yaml@2.8.0))':
+  '@vitest/mocker@3.2.4(msw@2.12.10(@types/node@24.0.7)(typescript@5.8.3))(vite@7.0.0(@types/node@24.0.7)(jiti@2.6.1)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
       msw: 2.12.10(@types/node@24.0.7)(typescript@5.8.3)
-      vite: 7.0.0(@types/node@24.0.7)(yaml@2.8.0)
+      vite: 7.0.0(@types/node@24.0.7)(jiti@2.6.1)(yaml@2.8.3)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -9468,12 +9957,23 @@ snapshots:
 
   agent-base@7.1.4: {}
 
+  ajv-draft-04@1.0.0(ajv@8.18.0):
+    optionalDependencies:
+      ajv: 8.18.0
+
   ajv@6.12.6:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
+
+  ajv@8.18.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.0
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
 
   ansi-escapes@7.0.0:
     dependencies:
@@ -9638,6 +10138,23 @@ snapshots:
     dependencies:
       run-applescript: 7.1.0
 
+  c12@3.3.4(magicast@0.3.5):
+    dependencies:
+      chokidar: 5.0.0
+      confbox: 0.2.4
+      defu: 6.1.7
+      dotenv: 17.4.2
+      exsolve: 1.0.8
+      giget: 3.2.0
+      jiti: 2.6.1
+      ohash: 2.0.11
+      pathe: 2.0.3
+      perfect-debounce: 2.1.0
+      pkg-types: 2.3.0
+      rc9: 3.0.1
+    optionalDependencies:
+      magicast: 0.3.5
+
   cac@6.7.14: {}
 
   call-bind-apply-helpers@1.0.2:
@@ -9656,6 +10173,8 @@ snapshots:
     dependencies:
       call-bind-apply-helpers: 1.0.2
       get-intrinsic: 1.3.0
+
+  call-me-maybe@1.0.2: {}
 
   callsites@3.1.0: {}
 
@@ -9690,7 +10209,17 @@ snapshots:
 
   check-error@2.1.1: {}
 
+  chokidar@5.0.0:
+    dependencies:
+      readdirp: 5.0.0
+
   chromatic@13.3.5: {}
+
+  citty@0.2.2: {}
+
+  class-variance-authority@0.7.1:
+    dependencies:
+      clsx: 2.1.1
 
   cli-cursor@5.0.0:
     dependencies:
@@ -9732,6 +10261,10 @@ snapshots:
   concat-map@0.0.1: {}
 
   confbox@0.1.8: {}
+
+  confbox@0.2.4: {}
+
+  consola@3.4.2: {}
 
   convert-source-map@2.0.0: {}
 
@@ -9821,6 +10354,8 @@ snapshots:
       es-errors: 1.3.0
       is-data-view: 1.0.2
 
+  dayjs@1.11.20: {}
+
   debug@3.2.7:
     dependencies:
       ms: 2.1.3
@@ -9866,9 +10401,13 @@ snapshots:
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
 
+  defu@6.1.7: {}
+
   delayed-stream@1.0.0: {}
 
   dequal@2.0.3: {}
+
+  destr@2.0.5: {}
 
   detect-node-es@1.1.0: {}
 
@@ -9900,6 +10439,10 @@ snapshots:
     dependencies:
       domelementtype: 2.3.0
 
+  dompurify@3.4.1:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
+
   domutils@3.2.2:
     dependencies:
       dom-serializer: 2.0.0
@@ -9910,6 +10453,8 @@ snapshots:
     dependencies:
       no-case: 3.0.4
       tslib: 2.8.1
+
+  dotenv@17.4.2: {}
 
   dunder-proto@1.0.1:
     dependencies:
@@ -10042,6 +10587,10 @@ snapshots:
       is-date-object: 1.1.0
       is-symbol: 1.1.1
 
+  es-toolkit@1.46.0: {}
+
+  es6-promise@3.3.1: {}
+
   esbuild@0.25.5:
     optionalDependencies:
       '@esbuild/aix-ppc64': 0.25.5
@@ -10076,9 +10625,9 @@ snapshots:
 
   escape-string-regexp@5.0.0: {}
 
-  eslint-config-prettier@10.1.5(eslint@9.30.0):
+  eslint-config-prettier@10.1.5(eslint@9.30.0(jiti@2.6.1)):
     dependencies:
-      eslint: 9.30.0
+      eslint: 9.30.0(jiti@2.6.1)
 
   eslint-import-context@0.1.9(unrs-resolver@1.11.0):
     dependencies:
@@ -10095,10 +10644,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@4.4.4(eslint-plugin-import@2.32.0)(eslint@9.30.0):
+  eslint-import-resolver-typescript@4.4.4(eslint-plugin-import@2.32.0)(eslint@9.30.0(jiti@2.6.1)):
     dependencies:
       debug: 4.4.1
-      eslint: 9.30.0
+      eslint: 9.30.0(jiti@2.6.1)
       eslint-import-context: 0.1.9(unrs-resolver@1.11.0)
       get-tsconfig: 4.10.1
       is-bun-module: 2.0.0
@@ -10106,22 +10655,22 @@ snapshots:
       tinyglobby: 0.2.14
       unrs-resolver: 1.11.0
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.35.0(eslint@9.30.0)(typescript@5.8.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.30.0)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.35.0(eslint@9.30.0(jiti@2.6.1))(typescript@5.8.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.30.0(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.35.0(eslint@9.30.0)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.4.4)(eslint@9.30.0):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.35.0(eslint@9.30.0(jiti@2.6.1))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.4.4)(eslint@9.30.0(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 8.35.0(eslint@9.30.0)(typescript@5.8.3)
-      eslint: 9.30.0
+      '@typescript-eslint/parser': 8.35.0(eslint@9.30.0(jiti@2.6.1))(typescript@5.8.3)
+      eslint: 9.30.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 4.4.4(eslint-plugin-import@2.32.0)(eslint@9.30.0)
+      eslint-import-resolver-typescript: 4.4.4(eslint-plugin-import@2.32.0)(eslint@9.30.0(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.35.0(eslint@9.30.0)(typescript@5.8.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.30.0):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.35.0(eslint@9.30.0(jiti@2.6.1))(typescript@5.8.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.30.0(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -10130,9 +10679,9 @@ snapshots:
       array.prototype.flatmap: 1.3.3
       debug: 3.2.7
       doctrine: 2.1.0
-      eslint: 9.30.0
+      eslint: 9.30.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.35.0(eslint@9.30.0)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.4.4)(eslint@9.30.0)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.35.0(eslint@9.30.0(jiti@2.6.1))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.4.4)(eslint@9.30.0(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -10144,13 +10693,13 @@ snapshots:
       string.prototype.trimend: 1.0.9
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 8.35.0(eslint@9.30.0)(typescript@5.8.3)
+      '@typescript-eslint/parser': 8.35.0(eslint@9.30.0(jiti@2.6.1))(typescript@5.8.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-jsx-a11y@6.10.2(eslint@9.30.0):
+  eslint-plugin-jsx-a11y@6.10.2(eslint@9.30.0(jiti@2.6.1)):
     dependencies:
       aria-query: 5.3.2
       array-includes: 3.1.9
@@ -10160,7 +10709,7 @@ snapshots:
       axobject-query: 4.1.0
       damerau-levenshtein: 1.0.8
       emoji-regex: 9.2.2
-      eslint: 9.30.0
+      eslint: 9.30.0(jiti@2.6.1)
       hasown: 2.0.2
       jsx-ast-utils: 3.3.5
       language-tags: 1.0.9
@@ -10169,24 +10718,24 @@ snapshots:
       safe-regex-test: 1.1.0
       string.prototype.includes: 2.0.1
 
-  eslint-plugin-prettier@5.5.1(eslint-config-prettier@10.1.5(eslint@9.30.0))(eslint@9.30.0)(prettier@3.6.2):
+  eslint-plugin-prettier@5.5.1(eslint-config-prettier@10.1.5(eslint@9.30.0(jiti@2.6.1)))(eslint@9.30.0(jiti@2.6.1))(prettier@3.6.2):
     dependencies:
-      eslint: 9.30.0
+      eslint: 9.30.0(jiti@2.6.1)
       prettier: 3.6.2
       prettier-linter-helpers: 1.0.0
       synckit: 0.11.8
     optionalDependencies:
-      eslint-config-prettier: 10.1.5(eslint@9.30.0)
+      eslint-config-prettier: 10.1.5(eslint@9.30.0(jiti@2.6.1))
 
-  eslint-plugin-react-hooks@5.2.0(eslint@9.30.0):
+  eslint-plugin-react-hooks@5.2.0(eslint@9.30.0(jiti@2.6.1)):
     dependencies:
-      eslint: 9.30.0
+      eslint: 9.30.0(jiti@2.6.1)
 
-  eslint-plugin-react-refresh@0.4.20(eslint@9.30.0):
+  eslint-plugin-react-refresh@0.4.20(eslint@9.30.0(jiti@2.6.1)):
     dependencies:
-      eslint: 9.30.0
+      eslint: 9.30.0(jiti@2.6.1)
 
-  eslint-plugin-react@7.37.5(eslint@9.30.0):
+  eslint-plugin-react@7.37.5(eslint@9.30.0(jiti@2.6.1)):
     dependencies:
       array-includes: 3.1.9
       array.prototype.findlast: 1.2.5
@@ -10194,7 +10743,7 @@ snapshots:
       array.prototype.tosorted: 1.1.4
       doctrine: 2.1.0
       es-iterator-helpers: 1.2.1
-      eslint: 9.30.0
+      eslint: 9.30.0(jiti@2.6.1)
       estraverse: 5.3.0
       hasown: 2.0.2
       jsx-ast-utils: 3.3.5
@@ -10208,14 +10757,14 @@ snapshots:
       string.prototype.matchall: 4.0.12
       string.prototype.repeat: 1.0.0
 
-  eslint-plugin-simple-import-sort@12.1.1(eslint@9.30.0):
+  eslint-plugin-simple-import-sort@12.1.1(eslint@9.30.0(jiti@2.6.1)):
     dependencies:
-      eslint: 9.30.0
+      eslint: 9.30.0(jiti@2.6.1)
 
-  eslint-plugin-storybook@10.1.11(eslint@9.30.0)(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.6.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.8.3):
+  eslint-plugin-storybook@10.1.11(eslint@9.30.0(jiti@2.6.1))(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.6.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.8.3):
     dependencies:
-      '@typescript-eslint/utils': 8.35.0(eslint@9.30.0)(typescript@5.8.3)
-      eslint: 9.30.0
+      '@typescript-eslint/utils': 8.35.0(eslint@9.30.0(jiti@2.6.1))(typescript@5.8.3)
+      eslint: 9.30.0(jiti@2.6.1)
       storybook: 10.1.11(@testing-library/dom@10.4.0)(prettier@3.6.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
     transitivePeerDependencies:
       - supports-color
@@ -10230,9 +10779,9 @@ snapshots:
 
   eslint-visitor-keys@4.2.1: {}
 
-  eslint@9.30.0:
+  eslint@9.30.0(jiti@2.6.1):
     dependencies:
-      '@eslint-community/eslint-utils': 4.7.0(eslint@9.30.0)
+      '@eslint-community/eslint-utils': 4.7.0(eslint@9.30.0(jiti@2.6.1))
       '@eslint-community/regexpp': 4.12.1
       '@eslint/config-array': 0.21.0
       '@eslint/config-helpers': 0.3.0
@@ -10267,6 +10816,8 @@ snapshots:
       minimatch: 3.1.2
       natural-compare: 1.4.0
       optionator: 0.9.4
+    optionalDependencies:
+      jiti: 2.6.1
     transitivePeerDependencies:
       - supports-color
 
@@ -10298,6 +10849,8 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  eta@3.5.0: {}
+
   eval@0.1.8:
     dependencies:
       '@types/node': 24.0.7
@@ -10306,6 +10859,8 @@ snapshots:
   eventemitter3@5.0.1: {}
 
   expect-type@1.2.1: {}
+
+  exsolve@1.0.8: {}
 
   extend@3.0.2: {}
 
@@ -10324,6 +10879,10 @@ snapshots:
   fast-json-stable-stringify@2.1.0: {}
 
   fast-levenshtein@2.0.6: {}
+
+  fast-safe-stringify@2.1.1: {}
+
+  fast-uri@3.1.0: {}
 
   fastq@1.19.1:
     dependencies:
@@ -10477,6 +11036,8 @@ snapshots:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
+  giget@3.2.0: {}
+
   glob-parent@5.1.2:
     dependencies:
       is-glob: 4.0.3
@@ -10591,6 +11152,8 @@ snapshots:
       debug: 4.4.1
     transitivePeerDependencies:
       - supports-color
+
+  http2-client@1.3.5: {}
 
   https-proxy-agent@7.0.6:
     dependencies:
@@ -10822,6 +11385,8 @@ snapshots:
 
   javascript-stringify@2.1.0: {}
 
+  jiti@2.6.1: {}
+
   js-tokens@4.0.0: {}
 
   js-tokens@9.0.1: {}
@@ -10864,6 +11429,8 @@ snapshots:
   json-parse-even-better-errors@2.3.1: {}
 
   json-schema-traverse@0.4.1: {}
+
+  json-schema-traverse@1.0.0: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
@@ -11439,6 +12006,8 @@ snapshots:
 
   nanoid@3.3.11: {}
 
+  nanoid@5.1.9: {}
+
   napi-postinstall@0.3.0: {}
 
   natural-compare@1.4.0: {}
@@ -11448,11 +12017,54 @@ snapshots:
       lower-case: 2.0.2
       tslib: 2.8.1
 
+  node-fetch-h2@2.3.0:
+    dependencies:
+      http2-client: 1.3.5
+
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
+
+  node-readfiles@0.2.0:
+    dependencies:
+      es6-promise: 3.3.1
+
   node-releases@2.0.19: {}
 
   nth-check@2.1.1:
     dependencies:
       boolbase: 1.0.0
+
+  oas-kit-common@1.0.8:
+    dependencies:
+      fast-safe-stringify: 2.1.1
+
+  oas-linter@3.2.2:
+    dependencies:
+      '@exodus/schemasafe': 1.3.0
+      should: 13.2.3
+      yaml: 1.10.3
+
+  oas-resolver@2.5.6:
+    dependencies:
+      node-fetch-h2: 2.3.0
+      oas-kit-common: 1.0.8
+      reftools: 1.1.9
+      yaml: 1.10.3
+      yargs: 17.7.2
+
+  oas-schema-walker@1.1.5: {}
+
+  oas-validator@5.0.8:
+    dependencies:
+      call-me-maybe: 1.0.2
+      oas-kit-common: 1.0.8
+      oas-linter: 3.2.2
+      oas-resolver: 2.5.6
+      oas-schema-walker: 1.1.5
+      reftools: 1.1.9
+      should: 13.2.3
+      yaml: 1.10.3
 
   object-assign@4.1.1: {}
 
@@ -11496,6 +12108,8 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
 
+  ohash@2.0.11: {}
+
   onetime@7.0.0:
     dependencies:
       mimic-function: 5.0.1
@@ -11517,6 +12131,8 @@ snapshots:
       define-lazy-prop: 3.0.0
       is-inside-container: 1.0.0
       wsl-utils: 0.1.0
+
+  openapi-types@12.1.3: {}
 
   optionator@0.9.4:
     dependencies:
@@ -11599,6 +12215,8 @@ snapshots:
 
   pathval@2.0.1: {}
 
+  perfect-debounce@2.1.0: {}
+
   picocolors@1.1.1: {}
 
   picomatch@2.3.1: {}
@@ -11613,6 +12231,12 @@ snapshots:
     dependencies:
       confbox: 0.1.8
       mlly: 1.7.4
+      pathe: 2.0.3
+
+  pkg-types@2.3.0:
+    dependencies:
+      confbox: 0.2.4
+      exsolve: 1.0.8
       pathe: 2.0.3
 
   platform@1.3.6: {}
@@ -11675,6 +12299,11 @@ snapshots:
   punycode@2.3.1: {}
 
   queue-microtask@1.2.3: {}
+
+  rc9@3.0.1:
+    dependencies:
+      defu: 6.1.7
+      destr: 2.0.5
 
   react-docgen-typescript@2.4.0(typescript@5.8.3):
     dependencies:
@@ -11801,6 +12430,8 @@ snapshots:
 
   react@19.2.0: {}
 
+  readdirp@5.0.0: {}
+
   recast@0.23.11:
     dependencies:
       ast-types: 0.16.1
@@ -11824,6 +12455,8 @@ snapshots:
       get-intrinsic: 1.3.0
       get-proto: 1.0.1
       which-builtin-type: 1.2.1
+
+  reftools@1.1.9: {}
 
   regexp.prototype.flags@1.5.4:
     dependencies:
@@ -11995,6 +12628,32 @@ snapshots:
       shebang-regex: 3.0.0
 
   shebang-regex@3.0.0: {}
+
+  should-equal@2.0.0:
+    dependencies:
+      should-type: 1.4.0
+
+  should-format@3.0.3:
+    dependencies:
+      should-type: 1.4.0
+      should-type-adaptors: 1.1.0
+
+  should-type-adaptors@1.1.0:
+    dependencies:
+      should-type: 1.4.0
+      should-util: 1.0.1
+
+  should-type@1.4.0: {}
+
+  should-util@1.0.1: {}
+
+  should@13.2.3:
+    dependencies:
+      should-equal: 2.0.0
+      should-format: 3.0.3
+      should-type: 1.4.0
+      should-type-adaptors: 1.1.0
+      should-util: 1.0.1
 
   side-channel-list@1.0.0:
     dependencies:
@@ -12218,6 +12877,51 @@ snapshots:
       csso: 5.0.5
       picocolors: 1.1.1
 
+  swagger-schema-official@2.0.0-bab6bed: {}
+
+  swagger-typescript-api@13.6.10(magicast@0.3.5)(react@19.2.0):
+    dependencies:
+      '@apidevtools/swagger-parser': 12.1.0(openapi-types@12.1.3)
+      '@biomejs/js-api': 4.0.0(@biomejs/wasm-nodejs@2.4.12)
+      '@biomejs/wasm-nodejs': 2.4.12
+      '@types/swagger-schema-official': 2.0.25
+      c12: 3.3.4(magicast@0.3.5)
+      citty: 0.2.2
+      consola: 3.4.2
+      es-toolkit: 1.46.0
+      eta: 3.5.0
+      nanoid: 5.1.9
+      openapi-types: 12.1.3
+      swagger-schema-official: 2.0.0-bab6bed
+      swagger2openapi: 7.0.8
+      type-fest: 5.4.4
+      typescript: 6.0.3
+      yaml: 2.8.3
+      yummies: 7.18.0(react@19.2.0)
+    transitivePeerDependencies:
+      - '@biomejs/wasm-bundler'
+      - '@biomejs/wasm-web'
+      - encoding
+      - magicast
+      - mobx
+      - react
+
+  swagger2openapi@7.0.8:
+    dependencies:
+      call-me-maybe: 1.0.2
+      node-fetch: 2.7.0
+      node-fetch-h2: 2.3.0
+      node-readfiles: 0.2.0
+      oas-kit-common: 1.0.8
+      oas-resolver: 2.5.6
+      oas-schema-walker: 1.1.5
+      oas-validator: 5.0.8
+      reftools: 1.1.9
+      yaml: 1.10.3
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - encoding
+
   swiper@12.0.2: {}
 
   symbol-tree@3.2.4: {}
@@ -12227,6 +12931,8 @@ snapshots:
       '@pkgr/core': 0.2.7
 
   tagged-tag@1.0.0: {}
+
+  tailwind-merge@3.5.0: {}
 
   test-exclude@7.0.1:
     dependencies:
@@ -12266,6 +12972,8 @@ snapshots:
   tough-cookie@6.0.0:
     dependencies:
       tldts: 7.0.23
+
+  tr46@0.0.3: {}
 
   tr46@6.0.0:
     dependencies:
@@ -12337,17 +13045,19 @@ snapshots:
       possible-typed-array-names: 1.1.0
       reflect.getprototypeof: 1.0.10
 
-  typescript-eslint@8.35.0(eslint@9.30.0)(typescript@5.8.3):
+  typescript-eslint@8.35.0(eslint@9.30.0(jiti@2.6.1))(typescript@5.8.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.35.0(@typescript-eslint/parser@8.35.0(eslint@9.30.0)(typescript@5.8.3))(eslint@9.30.0)(typescript@5.8.3)
-      '@typescript-eslint/parser': 8.35.0(eslint@9.30.0)(typescript@5.8.3)
-      '@typescript-eslint/utils': 8.35.0(eslint@9.30.0)(typescript@5.8.3)
-      eslint: 9.30.0
+      '@typescript-eslint/eslint-plugin': 8.35.0(@typescript-eslint/parser@8.35.0(eslint@9.30.0(jiti@2.6.1))(typescript@5.8.3))(eslint@9.30.0(jiti@2.6.1))(typescript@5.8.3)
+      '@typescript-eslint/parser': 8.35.0(eslint@9.30.0(jiti@2.6.1))(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.35.0(eslint@9.30.0(jiti@2.6.1))(typescript@5.8.3)
+      eslint: 9.30.0(jiti@2.6.1)
       typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
 
   typescript@5.8.3: {}
+
+  typescript@6.0.3: {}
 
   ufo@1.6.1: {}
 
@@ -12478,13 +13188,13 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite-node@3.2.4(@types/node@24.0.7)(yaml@2.8.0):
+  vite-node@3.2.4(@types/node@24.0.7)(jiti@2.6.1)(yaml@2.8.3):
     dependencies:
       cac: 6.7.14
       debug: 4.4.1
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.0.0(@types/node@24.0.7)(yaml@2.8.0)
+      vite: 7.0.0(@types/node@24.0.7)(jiti@2.6.1)(yaml@2.8.3)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -12499,18 +13209,18 @@ snapshots:
       - tsx
       - yaml
 
-  vite-plugin-svgr@4.3.0(rollup@4.44.1)(typescript@5.8.3)(vite@7.0.0(@types/node@24.0.7)(yaml@2.8.0)):
+  vite-plugin-svgr@4.3.0(rollup@4.44.1)(typescript@5.8.3)(vite@7.0.0(@types/node@24.0.7)(jiti@2.6.1)(yaml@2.8.3)):
     dependencies:
       '@rollup/pluginutils': 5.2.0(rollup@4.44.1)
       '@svgr/core': 8.1.0(typescript@5.8.3)
       '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@5.8.3))
-      vite: 7.0.0(@types/node@24.0.7)(yaml@2.8.0)
+      vite: 7.0.0(@types/node@24.0.7)(jiti@2.6.1)(yaml@2.8.3)
     transitivePeerDependencies:
       - rollup
       - supports-color
       - typescript
 
-  vite@6.3.5(@types/node@24.0.7)(yaml@2.8.0):
+  vite@6.3.5(@types/node@24.0.7)(jiti@2.6.1)(yaml@2.8.3):
     dependencies:
       esbuild: 0.25.5
       fdir: 6.4.6(picomatch@4.0.2)
@@ -12521,9 +13231,10 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.0.7
       fsevents: 2.3.3
-      yaml: 2.8.0
+      jiti: 2.6.1
+      yaml: 2.8.3
 
-  vite@7.0.0(@types/node@24.0.7)(yaml@2.8.0):
+  vite@7.0.0(@types/node@24.0.7)(jiti@2.6.1)(yaml@2.8.3):
     dependencies:
       esbuild: 0.25.5
       fdir: 6.4.6(picomatch@4.0.2)
@@ -12534,13 +13245,14 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.0.7
       fsevents: 2.3.3
-      yaml: 2.8.0
+      jiti: 2.6.1
+      yaml: 2.8.3
 
-  vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.0.7)(@vitest/browser@3.2.4)(jsdom@28.1.0)(msw@2.12.10(@types/node@24.0.7)(typescript@5.8.3))(yaml@2.8.0):
+  vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.0.7)(@vitest/browser@3.2.4)(jiti@2.6.1)(jsdom@28.1.0)(msw@2.12.10(@types/node@24.0.7)(typescript@5.8.3))(yaml@2.8.3):
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(msw@2.12.10(@types/node@24.0.7)(typescript@5.8.3))(vite@7.0.0(@types/node@24.0.7)(yaml@2.8.0))
+      '@vitest/mocker': 3.2.4(msw@2.12.10(@types/node@24.0.7)(typescript@5.8.3))(vite@7.0.0(@types/node@24.0.7)(jiti@2.6.1)(yaml@2.8.3))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -12558,13 +13270,13 @@ snapshots:
       tinyglobby: 0.2.14
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.0.0(@types/node@24.0.7)(yaml@2.8.0)
-      vite-node: 3.2.4(@types/node@24.0.7)(yaml@2.8.0)
+      vite: 7.0.0(@types/node@24.0.7)(jiti@2.6.1)(yaml@2.8.3)
+      vite-node: 3.2.4(@types/node@24.0.7)(jiti@2.6.1)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/debug': 4.1.12
       '@types/node': 24.0.7
-      '@vitest/browser': 3.2.4(msw@2.12.10(@types/node@24.0.7)(typescript@5.8.3))(playwright@1.53.2)(vite@7.0.0(@types/node@24.0.7)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(msw@2.12.10(@types/node@24.0.7)(typescript@5.8.3))(playwright@1.53.2)(vite@7.0.0(@types/node@24.0.7)(jiti@2.6.1)(yaml@2.8.3))(vitest@3.2.4)
       jsdom: 28.1.0
     transitivePeerDependencies:
       - jiti
@@ -12585,6 +13297,8 @@ snapshots:
       xml-name-validator: 5.0.0
 
   web-vitals@4.2.4: {}
+
+  webidl-conversions@3.0.1: {}
 
   webidl-conversions@8.0.1: {}
 
@@ -12607,6 +13321,11 @@ snapshots:
       webidl-conversions: 8.0.1
     transitivePeerDependencies:
       - '@noble/hashes'
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
 
   which-boxed-primitive@1.1.1:
     dependencies:
@@ -12698,7 +13417,11 @@ snapshots:
 
   yallist@3.1.1: {}
 
+  yaml@1.10.3: {}
+
   yaml@2.8.0: {}
+
+  yaml@2.8.3: {}
 
   yargs-parser@21.1.1: {}
 
@@ -12715,6 +13438,17 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   yoctocolors-cjs@2.1.3: {}
+
+  yummies@7.18.0(react@19.2.0):
+    dependencies:
+      class-variance-authority: 0.7.1
+      clsx: 2.1.1
+      dayjs: 1.11.20
+      dompurify: 3.4.1
+      nanoid: 5.1.9
+      tailwind-merge: 3.5.0
+    optionalDependencies:
+      react: 19.2.0
 
   zustand@5.0.6(@types/react@19.2.2)(react@19.2.0)(use-sync-external-store@1.6.0(react@19.2.0)):
     optionalDependencies:

--- a/scripts/gen-api.mjs
+++ b/scripts/gen-api.mjs
@@ -1,0 +1,38 @@
+// swagger-typescript-api 실행 래퍼
+// .env에서 SWAGGER_URL을 읽어 타입을 생성합니다.
+// SWAGGER_URL을 커밋된 코드에 노출시키지 않기 위한 브릿지 스크립트입니다.
+
+import { spawnSync } from 'node:child_process';
+import process from 'node:process';
+
+process.loadEnvFile('.env');
+
+const url = process.env.SWAGGER_URL;
+if (!url) {
+  console.error(
+    '.env에 SWAGGER_URL이 정의되어 있지 않습니다. Swagger 문서 URL을 추가한 후 다시 실행해주세요.'
+  );
+  process.exit(1);
+}
+
+const result = spawnSync(
+  'pnpm',
+  [
+    'exec',
+    'swagger-typescript-api',
+    'generate',
+    '-p',
+    url,
+    '-o',
+    'src/shared/apis/__generated__',
+    '--no-client',
+    '--modular',
+    '-d',
+    '--extract-request-body',
+    '--extract-response-body',
+    '--extract-response-error',
+  ],
+  { stdio: 'inherit' }
+);
+
+process.exit(result.status ?? 1);

--- a/src/shared/apis/__generated__/data-contracts.ts
+++ b/src/shared/apis/__generated__/data-contracts.ts
@@ -1,0 +1,2170 @@
+/* eslint-disable */
+/* tslint:disable */
+// @ts-nocheck
+/*
+ * ---------------------------------------------------------------
+ * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
+ * ##                                                           ##
+ * ## AUTHOR: acacode                                           ##
+ * ## SOURCE: https://github.com/acacode/swagger-typescript-api ##
+ * ---------------------------------------------------------------
+ */
+
+export interface ApiResponseString {
+  /** @format int32 */
+  code?: number;
+  msg?: string;
+  data?: string;
+}
+
+export interface GenerateImageV4Request {
+  /** @format int64 */
+  floorPlanId: number;
+  floorPlanView: string;
+  isMirror: boolean;
+  /**
+   * @maxItems 5
+   * @minItems 1
+   */
+  moodBoardIds: number[];
+  activity: string;
+  /**
+   * @maxItems 6
+   * @minItems 0
+   */
+  furnitureIds: number[];
+}
+
+export interface ApiResponseBannerGenerateImageResponse {
+  /** @format int32 */
+  code?: number;
+  msg?: string;
+  data?: BannerGenerateImageResponse;
+}
+
+export interface BannerGenerateImageResponse {
+  /** @format int64 */
+  imageId?: number;
+}
+
+export interface FloorPlanInfo {
+  /** @format int64 */
+  floorPlanId: number;
+  isMirror: boolean;
+}
+
+export interface GenerateImageRequest {
+  /** @format int64 */
+  houseId: number;
+  equilibrium: string;
+  floorPlan: FloorPlanInfo;
+  /**
+   * @maxItems 5
+   * @minItems 1
+   */
+  moodBoardIds: number[];
+  activity: string;
+  /**
+   * @maxItems 6
+   * @minItems 0
+   */
+  selectiveIds?: number[];
+}
+
+export interface ApiResponseImageInfoListResponse {
+  /** @format int32 */
+  code?: number;
+  msg?: string;
+  data?: ImageInfoListResponse;
+}
+
+export interface ImageInfoListResponse {
+  imageInfoResponses?: ImageInfoResponse[];
+}
+
+export interface ImageInfoResponse {
+  /** @format int64 */
+  imageId?: number;
+  imageUrl?: string;
+  isMirror?: boolean;
+  equilibrium?: string;
+  houseForm?: string;
+  tagName?: string;
+  name?: string;
+}
+
+export interface SocialSignUpV2Request {
+  signupToken: string;
+  /** @pattern ^[가-힣a-zA-Z0-9]+$ */
+  nickname: string;
+  /** @pattern MALE|FEMALE|NONBINARY */
+  gender: string;
+  birthday: string;
+}
+
+export interface PromptFurnitureListDTO {
+  furnitureTagIds?: number[];
+}
+
+export interface PromptRequestDTO {
+  /** @format int64 */
+  floorPlanId?: number;
+  /** @format int64 */
+  tagId?: number;
+  equilibrium?: "UNDER_5" | "BETWEEN_6_10" | "BETWEEN_11_15" | "OVER_16";
+  promptFurnitureListDTO?: PromptFurnitureListDTO;
+}
+
+export interface ApiResponseImageInfoResponse {
+  /** @format int32 */
+  code?: number;
+  msg?: string;
+  data?: ImageInfoResponse;
+}
+
+export interface ApiResponseJjymToggleResponse {
+  /** @format int32 */
+  code?: number;
+  msg?: string;
+  data?: JjymToggleResponse;
+}
+
+export interface JjymToggleResponse {
+  favorited?: boolean;
+}
+
+export interface SocialSignUpRequest {
+  signupToken: string;
+  /** @pattern ^[가-힣a-zA-Z]+$ */
+  name: string;
+  /** @pattern MALE|FEMALE|NONBINARY */
+  gender: string;
+  birthday: string;
+}
+
+export interface HouseSelectRequest {
+  houseType: string;
+  roomType: string;
+  areaType: string;
+  isValid: boolean;
+}
+
+export interface ApiResponseHouseIdResponse {
+  /** @format int32 */
+  code?: number;
+  msg?: string;
+  data?: HouseIdResponse;
+}
+
+export interface HouseIdResponse {
+  /** @format int64 */
+  houseId?: number;
+}
+
+export interface IsLikeRequest {
+  isLike?: boolean;
+}
+
+export interface ApiResponseVoid {
+  /** @format int32 */
+  code?: number;
+  msg?: string;
+  data?: object;
+}
+
+export interface OtherStyleGenerateImageRequest {
+  /** @format int64 */
+  bannerId: number;
+  /** @format int64 */
+  floorPlanId: number;
+  floorPlanView: string;
+  isMirror: boolean;
+}
+
+export interface ApiResponseOtherStyleGenerateImageResponse {
+  /** @format int32 */
+  code?: number;
+  msg?: string;
+  data?: OtherStyleGenerateImageResponse;
+}
+
+export interface OtherStyleGenerateImageResponse {
+  /** @format int64 */
+  imageId?: number;
+}
+
+export interface BannerGenerateImageRequest {
+  /** @format int64 */
+  bannerId: number;
+  /** @format int64 */
+  answerId: number;
+  /** @format int64 */
+  floorPlanId: number;
+  floorPlanView: string;
+  isMirror: boolean;
+}
+
+export interface AdminTagRequestDTO {
+  /** @format int32 */
+  priority?: number;
+  tagName?: string;
+  tag_name_kr?: string;
+  tag_prompt?: string;
+}
+
+export interface AdminStyleCreateRequest {
+  bannerImageUrl: string;
+  bannerTitle: string;
+  styleDescription: string;
+  stylePrompt: string;
+  mappedRawProductIds: number[];
+}
+
+export interface AdminBannerMappedRawProductResponse {
+  /** @format int64 */
+  id?: number;
+  source?: string;
+  category?:
+    | "MINI_ELECTRONICS"
+    | "FURNITURE"
+    | "LIGHTING"
+    | "LIVING_GOODS"
+    | "HOME_FABRIC"
+    | "ACCESSORY";
+  /** @format int64 */
+  productId?: number;
+  productName?: string;
+  productImageUrl?: string;
+  brand?: string;
+}
+
+export interface AdminStyleResponse {
+  /** @format int64 */
+  id?: number;
+  bannerImageUrl?: string;
+  bannerTitle?: string;
+  styleDescription?: string;
+  stylePrompt?: string;
+  mappedRawProducts?: AdminBannerMappedRawProductResponse[];
+  /** @format date-time */
+  createdAt?: string;
+  /** @format date-time */
+  updatedAt?: string;
+}
+
+export interface ApiResponseAdminStyleResponse {
+  /** @format int32 */
+  code?: number;
+  msg?: string;
+  data?: AdminStyleResponse;
+}
+
+export interface AdminBannerImageUploadRequest {
+  /** @pattern ^(?i)(jpg|jpeg|png|gif|webp)$ */
+  imageExtension: string;
+}
+
+export interface AdminBannerImageUploadResponse {
+  uploadUrl?: string;
+  publicUrl?: string;
+}
+
+export interface ApiResponseAdminBannerImageUploadResponse {
+  /** @format int32 */
+  code?: number;
+  msg?: string;
+  data?: AdminBannerImageUploadResponse;
+}
+
+export interface AdminMoodBoardCreateRequestDTO {
+  imageExtension?: string;
+  originalFilename?: string;
+  /** @format int64 */
+  tagId?: number;
+}
+
+export interface AdminMoodBoardCreateResponseDTO {
+  presignedUrl?: string;
+  /** @format int64 */
+  tasteId?: number;
+}
+
+export interface ApiResponseAdminMoodBoardCreateResponseDTO {
+  /** @format int32 */
+  code?: number;
+  msg?: string;
+  data?: AdminMoodBoardCreateResponseDTO;
+}
+
+export interface AdminLandingCreateRequest {
+  bannerImageUrl: string;
+  bannerTitle: string;
+}
+
+export interface AdminLandingResponse {
+  /** @format int64 */
+  id?: number;
+  bannerImageUrl?: string;
+  bannerTitle?: string;
+  /** @format date-time */
+  createdAt?: string;
+  /** @format date-time */
+  updatedAt?: string;
+}
+
+export interface ApiResponseAdminLandingResponse {
+  /** @format int32 */
+  code?: number;
+  msg?: string;
+  data?: AdminLandingResponse;
+}
+
+export interface AdminFurnitureRequestDTO {
+  /** 추가되는 가구의 한글명 입니다 */
+  furnitureNameKr?: string;
+  /** 추가되는 가구의 영어명 입니다 */
+  furnitureNameEng?: string;
+  /**
+   * 추가되는 가구의 가구 타입 입니다
+   * @format int64
+   */
+  furnitureType?: number;
+}
+
+export interface AdminFurnitureTypeRequest {
+  /** 추가할 가구 타입 한글명 */
+  furnitureTypeNameKr?: string;
+  /** 추가할 가구 타입 영어명 */
+  furnitureTypeNameEng?: string;
+}
+
+export interface AdminFurniturePromptRequestDTO {
+  /** 가구의 한글명 입니다 */
+  furnitureNameKr?: string;
+  /** 가구에 대한 프롬프트 입니다 */
+  prompt?: string;
+  /**
+   * 가구의 스타일 태그 입니다
+   * @format int64
+   */
+  tagId?: number;
+  /** 가구의 검색 키워드입니다 */
+  searchKeyword?: string;
+  /**
+   * 가구의 우선순위입니다
+   * @format int32
+   */
+  priority?: number;
+  imageExtension?: string;
+  originalFilename?: string;
+}
+
+export interface AdminFurniturePromptCreateResponseDTO {
+  presignedUrl?: string;
+  /** @format int64 */
+  furnitureTagId?: number;
+}
+
+export interface ApiResponseAdminFurniturePromptCreateResponseDTO {
+  /** @format int32 */
+  code?: number;
+  msg?: string;
+  data?: AdminFurniturePromptCreateResponseDTO;
+}
+
+export interface AdminFloorPlanCreateRequest {
+  name: string;
+  forms: ("OFFICETEL" | "VILLA" | "APARTMENT" | "ETC")[];
+  structures: (
+    | "OPEN_ONE_ROOM"
+    | "SEPARATED_ONE_ROOM"
+    | "DUPLEX"
+    | "TWO_ROOM"
+    | "THREE_ROOM_OVER"
+  )[];
+  equilibriums: ("UNDER_5" | "BETWEEN_6_10" | "BETWEEN_11_15" | "OVER_16")[];
+  floorPlanPrompt: string;
+  images: AdminFloorPlanImageRequest[];
+}
+
+export interface AdminFloorPlanImageRequest {
+  url: string;
+  filename: string;
+  originalFilename: string;
+  fileExtension: string;
+  /**
+   * @format int32
+   * @min 1
+   */
+  sortOrder: number;
+  view?: string;
+}
+
+export interface AdminFloorPlanImageResponse {
+  url?: string;
+  filename?: string;
+  originalFilename?: string;
+  fileExtension?: string;
+  /** @format int32 */
+  sortOrder?: number;
+  view?: string;
+}
+
+export interface AdminFloorPlanResponse {
+  /** @format int64 */
+  id?: number;
+  name?: string;
+  forms?: ("OFFICETEL" | "VILLA" | "APARTMENT" | "ETC")[];
+  structures?: (
+    | "OPEN_ONE_ROOM"
+    | "SEPARATED_ONE_ROOM"
+    | "DUPLEX"
+    | "TWO_ROOM"
+    | "THREE_ROOM_OVER"
+  )[];
+  equilibriums?: ("UNDER_5" | "BETWEEN_6_10" | "BETWEEN_11_15" | "OVER_16")[];
+  floorPlanPrompt?: string;
+  representativeImageUrl?: string;
+  images?: AdminFloorPlanImageResponse[];
+}
+
+export interface ApiResponseAdminFloorPlanResponse {
+  /** @format int32 */
+  code?: number;
+  msg?: string;
+  data?: AdminFloorPlanResponse;
+}
+
+export interface AdminFloorPlanImageUploadRequest {
+  imageExtension: string;
+}
+
+export interface AdminFloorPlanImageUploadResponse {
+  uploadUrl?: string;
+  publicUrl?: string;
+}
+
+export interface ApiResponseAdminFloorPlanImageUploadResponse {
+  /** @format int32 */
+  code?: number;
+  msg?: string;
+  data?: AdminFloorPlanImageUploadResponse;
+}
+
+export interface ApiResponseSoozipRawProductSaveResponse {
+  /** @format int32 */
+  code?: number;
+  msg?: string;
+  data?: SoozipRawProductSaveResponse;
+}
+
+export interface SoozipRawProductSaveResponse {
+  source?: string;
+  category?:
+    | "MINI_ELECTRONICS"
+    | "FURNITURE"
+    | "LIGHTING"
+    | "LIVING_GOODS"
+    | "HOME_FABRIC"
+    | "ACCESSORY";
+  /** @format int32 */
+  productCount?: number;
+  /** @format int32 */
+  insertedCount?: number;
+  /** @format int32 */
+  updatedCount?: number;
+  /** @format int32 */
+  skippedCount?: number;
+}
+
+export interface AdminCurationRawProductCreateRequest {
+  /** @pattern ^[a-zA-Z0-9][a-zA-Z0-9_-]{0,49}$ */
+  source: string;
+  category:
+    | "MINI_ELECTRONICS"
+    | "FURNITURE"
+    | "LIGHTING"
+    | "LIVING_GOODS"
+    | "HOME_FABRIC"
+    | "ACCESSORY";
+  /** @format int64 */
+  productId: number;
+  productImageUrl: string;
+  productSiteUrl: string;
+  productName: string;
+  productMallName?: string;
+  brand?: string;
+  /** @format int64 */
+  listPrice?: number;
+  /**
+   * @format int32
+   * @min 0
+   * @max 100
+   */
+  discountRate?: number;
+  /** @format int64 */
+  discountPrice?: number;
+  /** @format int64 */
+  baseShippingFee?: number;
+  /** @format int64 */
+  freeShippingCondition?: number;
+  isExposed?: boolean;
+  /** @format date-time */
+  fetchedAt?: string;
+}
+
+export interface AdminCurationRawProductColorResponse {
+  /** @format int64 */
+  id?: number;
+  rawColorName?: string;
+  clientColorName?: string;
+}
+
+export interface AdminCurationRawProductFurnitureTagResponse {
+  /** @format int64 */
+  mappingId?: number;
+  /** @format int64 */
+  furnitureTagId?: number;
+  /** @format int64 */
+  furnitureId?: number;
+  furnitureNameKr?: string;
+  /** @format int64 */
+  furnitureTypeId?: number;
+  furnitureTypeNameKr?: string;
+  /** @format int64 */
+  tagId?: number;
+  tagNameKr?: string;
+  /** @format int32 */
+  priority?: number;
+  searchKeyword?: string;
+}
+
+export interface AdminCurationRawProductResponse {
+  /** @format int64 */
+  id?: number;
+  source?: string;
+  category?:
+    | "MINI_ELECTRONICS"
+    | "FURNITURE"
+    | "LIGHTING"
+    | "LIVING_GOODS"
+    | "HOME_FABRIC"
+    | "ACCESSORY";
+  /** @format int64 */
+  productId?: number;
+  productImageUrl?: string;
+  productSiteUrl?: string;
+  productName?: string;
+  productMallName?: string;
+  brand?: string;
+  /** @format int64 */
+  listPrice?: number;
+  /** @format int32 */
+  discountRate?: number;
+  /** @format int64 */
+  discountPrice?: number;
+  /** @format int64 */
+  baseShippingFee?: number;
+  /** @format int64 */
+  freeShippingCondition?: number;
+  /** @format date-time */
+  fetchedAt?: string;
+  isExposed?: boolean;
+  colors?: AdminCurationRawProductColorResponse[];
+  furnitureTags?: AdminCurationRawProductFurnitureTagResponse[];
+}
+
+export interface ApiResponseAdminCurationRawProductResponse {
+  /** @format int32 */
+  code?: number;
+  msg?: string;
+  data?: AdminCurationRawProductResponse;
+}
+
+export interface AdminCurationRawProductFurnitureTagCreateRequest {
+  /** @format int64 */
+  furnitureTagId: number;
+}
+
+export interface ApiResponseAdminCurationRawProductFurnitureTagResponse {
+  /** @format int32 */
+  code?: number;
+  msg?: string;
+  data?: AdminCurationRawProductFurnitureTagResponse;
+}
+
+export interface AdminBannerCreateRequest {
+  bannerImageUrl: string;
+  bannerTitle: string;
+  styleDescription: string;
+  styleQuestion: string;
+  stylePrompt: string;
+  /**
+   * @maxItems 4
+   * @minItems 0
+   */
+  styleAnswerChips: AdminBannerStyleAnswerChipRequest[];
+  mappedRawProductIds: number[];
+}
+
+export interface AdminBannerStyleAnswerChipRequest {
+  /**
+   * @format int32
+   * @min 1
+   * @max 4
+   */
+  order: number;
+  label: string;
+  selectedPrompt: string;
+  /** @format int64 */
+  curationRawProductId: number;
+}
+
+export interface AdminBannerResponse {
+  /** @format int64 */
+  id?: number;
+  bannerImageUrl?: string;
+  bannerTitle?: string;
+  styleDescription?: string;
+  styleQuestion?: string;
+  stylePrompt?: string;
+  styleAnswerChips?: AdminBannerStyleAnswerChipResponse[];
+  mappedRawProducts?: AdminBannerMappedRawProductResponse[];
+  /** @format date-time */
+  createdAt?: string;
+  /** @format date-time */
+  updatedAt?: string;
+}
+
+export interface AdminBannerStyleAnswerChipResponse {
+  /** @format int64 */
+  id?: number;
+  /** @format int32 */
+  order?: number;
+  label?: string;
+  selectedPrompt?: string;
+  /** @format int64 */
+  curationRawProductId?: number;
+  curationRawProductName?: string;
+  curationRawProductImageUrl?: string;
+}
+
+export interface ApiResponseAdminBannerResponse {
+  /** @format int32 */
+  code?: number;
+  msg?: string;
+  data?: AdminBannerResponse;
+}
+
+export interface AddressRequest {
+  sigungu: string;
+  roadName: string;
+}
+
+export interface CreateUserV2Request {
+  /**
+   * @minLength 2
+   * @maxLength 20
+   * @pattern ^[가-힣a-zA-Z0-9]+$
+   */
+  nickname: string;
+  /** @pattern MALE|FEMALE|NONBINARY */
+  gender: string;
+  birthday: string;
+}
+
+export interface CreateUserRequest {
+  /** @pattern ^[가-힣a-zA-Z]+$ */
+  name: string;
+  /** @pattern MALE|FEMALE|NONBINARY */
+  gender: string;
+  birthday: string;
+}
+
+export interface AdminTagUpdateRequestDTO {
+  /** @format int64 */
+  tagId: number;
+  /** @format int32 */
+  newPriority?: number;
+  /** @pattern ^[a-zA-Z0-9\s\-_.()&/]*$ */
+  newTagNameEng?: string;
+  newTagPrompt?: string;
+  newTagNameKr?: string;
+}
+
+export interface AdminStyleUpdateRequest {
+  bannerImageUrl?: string;
+  bannerTitle?: string;
+  styleDescription?: string;
+  stylePrompt?: string;
+  mappedRawProductIds?: number[];
+}
+
+export interface AdminLandingUpdateRequest {
+  bannerImageUrl?: string;
+  bannerTitle?: string;
+}
+
+export interface AdminFurnitureUpdateRequestDTO {
+  /** 업데이트할 가구의 한글 이름(식별자) */
+  furnitureNameKr?: string;
+  /**
+   * 업데이트할 가구의 태그 ID(식별자)
+   * @format int64
+   */
+  tagId?: number;
+  /** 새로운 가구 영어 이름 */
+  newFurnitureNameEng?: string;
+  /** 새로운 프롬프트 */
+  newPrompt?: string;
+  /** 새로운 검색 키워드 */
+  newSearchKeyword?: string;
+  /**
+   * 새로운 우선순위
+   * @format int32
+   */
+  newPriority?: number;
+  /** 이미지 업데이트 시 사용할 확장자 (예: jpg, png) */
+  imageExtension?: string;
+  /** 이미지 업데이트 시 표시용 원본 파일명 */
+  originalFilename?: string;
+}
+
+export interface AdminFurnitureUpdateResponseDTO {
+  presignedUrl?: string;
+  /** @format int64 */
+  furnitureTagId?: number;
+}
+
+export interface ApiResponseAdminFurnitureUpdateResponseDTO {
+  /** @format int32 */
+  code?: number;
+  msg?: string;
+  data?: AdminFurnitureUpdateResponseDTO;
+}
+
+export interface AdminUpdateFurnitureTypeRequest {
+  /**
+   * 수정할 가구 타입 식별자
+   * @format int64
+   */
+  id?: number;
+  /** 새로운 가구 타입 한글명 */
+  furnitureTypeNameKr?: string;
+  /** 새로운 가구 타입 영어명 */
+  furnitureTypeNameEng?: string;
+}
+
+export interface AdminFloorPlanUpdateRequest {
+  name?: string;
+  forms?: ("OFFICETEL" | "VILLA" | "APARTMENT" | "ETC")[];
+  structures?: (
+    | "OPEN_ONE_ROOM"
+    | "SEPARATED_ONE_ROOM"
+    | "DUPLEX"
+    | "TWO_ROOM"
+    | "THREE_ROOM_OVER"
+  )[];
+  equilibriums?: ("UNDER_5" | "BETWEEN_6_10" | "BETWEEN_11_15" | "OVER_16")[];
+  floorPlanPrompt: string;
+  images?: AdminFloorPlanImageRequest[];
+}
+
+export interface AdminCurationRawProductUpdateRequest {
+  /** @pattern ^[a-zA-Z0-9][a-zA-Z0-9_-]{0,49}$ */
+  source?: string;
+  category?:
+    | "MINI_ELECTRONICS"
+    | "FURNITURE"
+    | "LIGHTING"
+    | "LIVING_GOODS"
+    | "HOME_FABRIC"
+    | "ACCESSORY";
+  /** @format int64 */
+  productId?: number;
+  productImageUrl?: string;
+  productSiteUrl?: string;
+  productName?: string;
+  productMallName?: string;
+  brand?: string;
+  /** @format int64 */
+  listPrice?: number;
+  /**
+   * @format int32
+   * @min 0
+   * @max 100
+   */
+  discountRate?: number;
+  /** @format int64 */
+  discountPrice?: number;
+  /** @format int64 */
+  baseShippingFee?: number;
+  /** @format int64 */
+  freeShippingCondition?: number;
+  isExposed?: boolean;
+  /** @format date-time */
+  fetchedAt?: string;
+}
+
+export interface AdminCurationRawProductFurnitureTagUpdateRequest {
+  /** @format int64 */
+  furnitureTagId: number;
+}
+
+export interface AdminCurationRawProductExposureUpdateRequest {
+  rawProductIds: number[];
+  isExposed: boolean;
+}
+
+export interface AdminBannerUpdateRequest {
+  bannerImageUrl?: string;
+  bannerTitle?: string;
+  styleDescription?: string;
+  styleQuestion?: string;
+  stylePrompt?: string;
+  /**
+   * @maxItems 4
+   * @minItems 0
+   */
+  styleAnswerChips?: AdminBannerStyleAnswerChipRequest[];
+  mappedRawProductIds?: number[];
+}
+
+export interface ApiResponseKakaoLoginResponse {
+  /** @format int32 */
+  code?: number;
+  msg?: string;
+  data?: KakaoLoginResponse;
+}
+
+export interface KakaoLoginResponse {
+  isNewUser?: boolean;
+  signupToken?: string;
+  prefill?: Prefill;
+}
+
+export interface Prefill {
+  email?: string;
+  nickname?: string;
+}
+
+export interface ApiResponseRecentFloorPlanResponse {
+  /** @format int32 */
+  code?: number;
+  msg?: string;
+  data?: RecentFloorPlanResponse;
+}
+
+export interface RecentFloorPlanResponse {
+  hasRecentImage?: boolean;
+  floorPlan?: object;
+}
+
+export interface ApiResponseMyPageGeneratedImageV2Response {
+  /** @format int32 */
+  code?: number;
+  msg?: string;
+  data?: MyPageGeneratedImageV2Response;
+}
+
+export interface DateGroupResponse {
+  /** @format date */
+  date?: string;
+  items?: ItemResponse[];
+}
+
+export interface ItemResponse {
+  /** @format int64 */
+  imageId?: number;
+  viewType?: "LIST" | "RECOMMEND";
+  generatedImageUrl?: string;
+  /** @format date-time */
+  generatedAt?: string;
+  bannerTitle?: string | null;
+  productSummaryText?: string | null;
+  usedProducts?: UsedProductResponse[];
+}
+
+export interface MyPageGeneratedImageV2Response {
+  groups?: DateGroupResponse[];
+}
+
+export interface UsedProductResponse {
+  /** @format int64 */
+  rawProductId?: number;
+  productImageUrl?: string;
+  colors?: string[];
+  productName?: string;
+  /** @format int64 */
+  listPrice?: number;
+  /** @format int32 */
+  discountRate?: number;
+  /** @format int64 */
+  discountPrice?: number;
+  productSiteUrl?: string;
+  isJjym?: boolean;
+}
+
+export interface ApiResponseJjymV2ListResponse {
+  /** @format int32 */
+  code?: number;
+  msg?: string;
+  data?: JjymV2ListResponse;
+}
+
+export interface JjymV2ItemResponse {
+  /** @format int64 */
+  rawProductId?: number;
+  isJjym?: boolean;
+  productImageUrl?: string;
+  productSiteUrl?: string;
+  colors?: string[];
+  brandName?: string;
+  productName?: string;
+  /** @format int64 */
+  listPrice?: number;
+  /** @format int32 */
+  discountRate?: number;
+  /** @format int64 */
+  discountPrice?: number;
+  /** @format int64 */
+  jjymCount?: number;
+}
+
+export interface JjymV2ListResponse {
+  items?: JjymV2ItemResponse[];
+}
+
+export interface ApiResponseExploreHouseTemplateListResponse {
+  /** @format int32 */
+  code?: number;
+  msg?: string;
+  data?: ExploreHouseTemplateListResponse;
+}
+
+export interface ExploreHouseTemplateItemResponse {
+  /** @format int64 */
+  id?: number;
+  name?: string;
+  imageUrl?: string;
+  isLatest?: boolean;
+}
+
+export interface ExploreHouseTemplateListResponse {
+  isExact?: boolean;
+  floorPlans?: ExploreHouseTemplateItemResponse[];
+}
+
+export interface ApiResponseExploreHouseTemplateDetailResponse {
+  /** @format int32 */
+  code?: number;
+  msg?: string;
+  data?: ExploreHouseTemplateDetailResponse;
+}
+
+export interface ExploreHouseTemplateDetailItemResponse {
+  imageUrl?: string;
+  view?: string;
+}
+
+export interface ExploreHouseTemplateDetailResponse {
+  /** @format int64 */
+  floorPlanId?: number;
+  floorPlanName?: string;
+  equilibrium?: string;
+  floorPlans?: ExploreHouseTemplateDetailItemResponse[];
+}
+
+export interface ApiResponseDashboardCategoriesResponse {
+  /** @format int32 */
+  code?: number;
+  msg?: string;
+  data?: DashboardCategoriesResponse;
+}
+
+export interface DashboardCategoriesResponse {
+  categories?: FurnitureCategoryGroup[];
+}
+
+export interface FurnitureCategoryGroup {
+  /** @format int64 */
+  categoryId?: number;
+  nameKr?: string;
+  nameEng?: string;
+  furnitures?: FurnitureItem[];
+}
+
+export interface FurnitureItem {
+  /** @format int64 */
+  id?: number;
+  code?: string;
+  label?: string;
+  /** @format int32 */
+  priority?: number;
+}
+
+export interface ActivityFurnitureMappingsResponse {
+  activities?: ActivityWithFurnitureResponse[];
+}
+
+export interface ActivityWithFurnitureResponse {
+  code?: string;
+  label?: string;
+  furnitures?: FurnitureItem[];
+}
+
+export interface ApiResponseActivityFurnitureMappingsResponse {
+  /** @format int32 */
+  code?: number;
+  msg?: string;
+  data?: ActivityFurnitureMappingsResponse;
+}
+
+export interface ApiResponseGetCarouselV2ListResponseDTO {
+  /** @format int32 */
+  code?: number;
+  msg?: string;
+  data?: GetCarouselV2ListResponseDTO;
+}
+
+export interface GetCarouselResponseDTO {
+  /** @format int64 */
+  carouselId?: number;
+  url?: string;
+}
+
+export interface GetCarouselV2ListResponseDTO {
+  carousels?: GetCarouselResponseDTO[];
+}
+
+export interface ApiResponseOtherStyleListResponse {
+  /** @format int32 */
+  code?: number;
+  msg?: string;
+  data?: OtherStyleListResponse;
+}
+
+export interface OtherStyleListResponse {
+  otherStyles?: OtherStyleResponse[];
+}
+
+export interface OtherStyleResponse {
+  /** @format int64 */
+  id?: number;
+  name?: string;
+  imageUrl?: string;
+}
+
+export interface ApiResponseOtherStyleDetailResponse {
+  /** @format int32 */
+  code?: number;
+  msg?: string;
+  data?: OtherStyleDetailResponse;
+}
+
+export interface OtherStyleDetailProductResponse {
+  /** @format int64 */
+  id?: number;
+  name?: string;
+  imageUrl?: string;
+  /** @format int64 */
+  originalPrice?: number;
+  /** @format int32 */
+  discountRate?: number;
+  /** @format int64 */
+  finalPrice?: number;
+  linkUrl?: string;
+  colors?: ProductColorResponse[];
+  isLiked?: boolean;
+}
+
+export interface OtherStyleDetailResponse {
+  styleName?: string;
+  styleImageUrl?: string;
+  styleDescription?: string;
+  products?: OtherStyleDetailProductResponse[];
+}
+
+export interface ProductColorResponse {
+  name?: string;
+  value?: string;
+}
+
+export interface ApiResponseMyPageInfoResponse {
+  /** @format int32 */
+  code?: number;
+  msg?: string;
+  data?: MyPageInfoResponse;
+}
+
+export interface MyPageInfoResponse {
+  /** @format int64 */
+  userId?: number;
+  name?: string;
+  /** @format int64 */
+  CreditCount?: number;
+}
+
+export interface ApiResponseUserImageHistoryListResponse {
+  /** @format int32 */
+  code?: number;
+  msg?: string;
+  data?: UserImageHistoryListResponse;
+}
+
+export interface UserImageHistoryDTO {
+  /** @format int64 */
+  houseId?: number;
+  /** @format int64 */
+  imageId?: number;
+  generatedImageUrl?: string;
+  tasteTag?: string;
+  equilibrium?: string;
+  houseForm?: string;
+  isMirror?: boolean;
+}
+
+export interface UserImageHistoryListResponse {
+  histories?: UserImageHistoryDTO[];
+}
+
+export interface ApiResponseImageHistoriesResultPageResponse {
+  /** @format int32 */
+  code?: number;
+  msg?: string;
+  data?: ImageHistoriesResultPageResponse;
+}
+
+export interface ImageHistoriesResultPageResponse {
+  histories?: ImageHistoryResultPageResponse[];
+}
+
+export interface ImageHistoryResultPageResponse {
+  /** @format int64 */
+  imageId?: number;
+  equilibrium?: string;
+  houseForm?: string;
+  tasteTag?: string;
+  name?: string;
+  generatedImageUrl?: string;
+  /** 좋아요 여부 */
+  isLike?: boolean | null;
+  /**
+   * 선호도 요인 식별자
+   * @format int64
+   */
+  factorId?: number | null;
+  /** 선호도 요인 */
+  factorText?: string | null;
+}
+
+export interface ApiResponseMoodBoardListResponse {
+  /** @format int32 */
+  code?: number;
+  msg?: string;
+  data?: MoodBoardListResponse;
+}
+
+export interface MoodBoardListResponse {
+  moodBoardResponseList?: MoodBoardResponse[];
+}
+
+export interface MoodBoardResponse {
+  /** @format int64 */
+  id?: number;
+  imageUrl?: string;
+  fileExtension?: string;
+}
+
+export interface ApiResponseLandingListResponse {
+  /** @format int32 */
+  code?: number;
+  msg?: string;
+  data?: LandingListResponse;
+}
+
+export interface LandingListResponse {
+  landings?: LandingResponse[];
+}
+
+export interface LandingResponse {
+  /** @format int64 */
+  id?: number;
+  name?: string;
+  imageUrl?: string;
+}
+
+export interface ApiResponseJjymListResponse {
+  /** @format int32 */
+  code?: number;
+  msg?: string;
+  data?: JjymListResponse;
+}
+
+export interface JjymItemResponse {
+  /** @format int64 */
+  id?: number;
+  furnitureProductImageUrl?: string;
+  furnitureProductSiteUrl?: string;
+  furnitureProductName?: string;
+  /** @format int64 */
+  furnitureProductId?: number;
+}
+
+export interface JjymListResponse {
+  items?: JjymItemResponse[];
+}
+
+export interface ApiResponseHouseOptionsResponse {
+  /** @format int32 */
+  code?: number;
+  msg?: string;
+  data?: HouseOptionsResponse;
+}
+
+export interface HouseOptionDTO {
+  code?: string;
+  label?: string;
+}
+
+export interface HouseOptionsResponse {
+  houseTypes?: HouseOptionDTO[];
+  roomTypes?: HouseOptionDTO[];
+  areaTypes?: HouseOptionDTO[];
+}
+
+export interface ApiResponseFloorPlanListResponse {
+  /** @format int32 */
+  code?: number;
+  msg?: string;
+  data?: FloorPlanListResponse;
+}
+
+export interface FloorPlanListResponse {
+  floorPlanList?: FloorPlanResponse[];
+}
+
+export interface FloorPlanResponse {
+  /** @format int64 */
+  id?: number;
+  form?: "OFFICETEL" | "VILLA" | "APARTMENT" | "ETC";
+  structure?:
+    | "OPEN_ONE_ROOM"
+    | "SEPARATED_ONE_ROOM"
+    | "DUPLEX"
+    | "TWO_ROOM"
+    | "THREE_ROOM_OVER";
+  floorPlanImage?: string;
+}
+
+export interface ApiResponseFurnitureProductsInfoResponseForPlan {
+  /** @format int32 */
+  code?: number;
+  msg?: string;
+  data?: FurnitureProductsInfoResponseForPlan;
+}
+
+export interface FurnitureProductInfo {
+  baseFurnitureImageUrl?: string;
+  furnitureProductImageUrl?: string;
+  furnitureProductSiteUrl?: string;
+  furnitureProductName?: string;
+  furnitureProductMallName?: string;
+  furnitureProductId?: string;
+  /** @format double */
+  similarity?: number;
+}
+
+export interface FurnitureProductsInfoResponseForPlan {
+  userName?: string;
+  products?: FurnitureProductInfo[];
+}
+
+export interface ApiResponseFurnitureProductsInfoResponse {
+  /** @format int32 */
+  code?: number;
+  msg?: string;
+  data?: FurnitureProductsInfoResponse;
+}
+
+export interface FurnitureProductsInfoResponse {
+  userName?: string;
+  products?: FurnitureProductInfo[];
+}
+
+export interface ApiResponseFurnitureCategoriesResponse {
+  /** @format int32 */
+  code?: number;
+  msg?: string;
+  data?: FurnitureCategoriesResponse;
+}
+
+export interface FurnitureCategoriesResponse {
+  categories?: FurnitureCategoryResponse[];
+}
+
+export interface FurnitureCategoryResponse {
+  /** @format int64 */
+  id?: number;
+  categoryName?: string;
+}
+
+export interface ApiResponseSimilarItemsResponse {
+  /** @format int32 */
+  code?: number;
+  msg?: string;
+  data?: SimilarItemsResponse;
+}
+
+export interface SimilarItemResponse {
+  /** @format int64 */
+  id?: number;
+  brand?: string;
+  name?: string;
+  imageUrl?: string;
+  /** @format int64 */
+  originalPrice?: number;
+  /** @format int32 */
+  discountRate?: number;
+  /** @format int64 */
+  finalPrice?: number;
+  linkUrl?: string;
+  colors?: ProductColorResponse[];
+  isLiked?: boolean;
+}
+
+export interface SimilarItemsResponse {
+  products?: SimilarItemResponse[];
+}
+
+export interface ApiResponseRelatedImagesResponse {
+  /** @format int32 */
+  code?: number;
+  msg?: string;
+  data?: RelatedImagesResponse;
+}
+
+export interface RelatedImageResponse {
+  /** @format int64 */
+  id?: number;
+  imageUrl?: string;
+  resultType?: string;
+}
+
+export interface RelatedImagesResponse {
+  name?: string;
+  images?: RelatedImageResponse[];
+}
+
+export interface ApiResponseGenerateImageResultResponse {
+  /** @format int32 */
+  code?: number;
+  msg?: string;
+  data?: GenerateImageResultResponse;
+}
+
+export interface GenerateImageResultProductResponse {
+  /** @format int64 */
+  id?: number;
+  name?: string;
+  imageUrl?: string;
+  /** @format int64 */
+  originalPrice?: number;
+  /** @format int32 */
+  discountRate?: number;
+  /** @format int64 */
+  finalPrice?: number;
+  linkUrl?: string;
+  colors?: ProductColorResponse[];
+  isLiked?: boolean;
+}
+
+export interface GenerateImageResultResponse {
+  /** @format int64 */
+  imageId?: number;
+  imageUrl?: string;
+  isMirror?: boolean;
+  products?: GenerateImageResultProductResponse[];
+}
+
+export interface ApiResponseFactorsResponse {
+  /** @format int32 */
+  code?: number;
+  msg?: string;
+  data?: FactorsResponse;
+}
+
+export interface FactorItem {
+  /** @format int64 */
+  id?: number;
+  text?: string;
+}
+
+export interface FactorsResponse {
+  factors?: FactorItem[];
+}
+
+export interface ActivityItem {
+  code?: string;
+  label?: string;
+}
+
+export interface ApiResponseFurnitureAndActivityResponse {
+  /** @format int32 */
+  code?: number;
+  msg?: string;
+  data?: FurnitureAndActivityResponse;
+}
+
+export interface FurnitureAndActivityResponse {
+  activities?: ActivityItem[];
+  categories?: FurnitureCategoryGroup[];
+}
+
+export interface ApiResponseCurationProductListResponse {
+  /** @format int32 */
+  code?: number;
+  msg?: string;
+  data?: CurationProductListResponse;
+}
+
+export interface CurationProductAppliedFilterResponse {
+  category?: string;
+  id?: string;
+  label?: string;
+  value?: string;
+}
+
+export interface CurationProductListResponse {
+  products?: CurationProductResponse[];
+  meta?: CurationProductMetaResponse;
+}
+
+export interface CurationProductMetaResponse {
+  /** @format int64 */
+  nextCursor?: number;
+  hasNext?: boolean;
+  appliedFilters?: CurationProductAppliedFilterResponse[];
+}
+
+export interface CurationProductResponse {
+  /** @format int64 */
+  id?: number;
+  /** @format int64 */
+  productId?: number;
+  categoryName?: string;
+  source?: string;
+  brand?: string;
+  name?: string;
+  imageUrl?: string;
+  /** @format int64 */
+  originalPrice?: number;
+  /** @format int32 */
+  discountRate?: number;
+  /** @format int64 */
+  finalPrice?: number;
+  mallName?: string;
+  linkUrl?: string;
+}
+
+export interface ApiResponseCurationProductDetailResponse {
+  /** @format int32 */
+  code?: number;
+  msg?: string;
+  data?: CurationProductDetailResponse;
+}
+
+export interface CurationProductDetailResponse {
+  product?: ProductDetail;
+}
+
+export interface ProductColorDetail {
+  name?: string;
+  value?: string;
+}
+
+export interface ProductDetail {
+  /** @format int64 */
+  id?: number;
+  /** @format int64 */
+  productId?: number;
+  categoryName?: string;
+  source?: string;
+  brand?: string;
+  name?: string;
+  imageUrl?: string;
+  /** @format int64 */
+  originalPrice?: number;
+  /** @format int32 */
+  discountRate?: number;
+  /** @format int64 */
+  finalPrice?: number;
+  mallName?: string;
+  linkUrl?: string;
+  colors?: ProductColorDetail[];
+  isLiked?: boolean;
+}
+
+export interface ApiResponseCurationProductFilterResponse {
+  /** @format int32 */
+  code?: number;
+  msg?: string;
+  data?: CurationProductFilterResponse;
+}
+
+export interface ColorFilterResponse {
+  /** @format int64 */
+  id?: number;
+  label?: string;
+  value?: string;
+}
+
+export interface CurationProductFilterResponse {
+  furnitureTypes?: FurnitureTypeFilterResponse[];
+  priceRanges?: PriceRangeFilterResponse[];
+  colors?: ColorFilterResponse[];
+}
+
+export interface FurnitureTypeFilterResponse {
+  /** @format int64 */
+  id?: number;
+  nameKr?: string;
+  nameEng?: string;
+}
+
+export interface PriceRangeFilterResponse {
+  id?: string;
+  label?: string;
+  /** @format int64 */
+  min?: number;
+  /** @format int64 */
+  max?: number;
+}
+
+export interface ApiResponseBoolean {
+  /** @format int32 */
+  code?: number;
+  msg?: string;
+  data?: boolean;
+}
+
+export interface ApiResponseGetCarouselListResponseDTO {
+  /** @format int32 */
+  code?: number;
+  msg?: string;
+  data?: GetCarouselListResponseDTO;
+}
+
+export interface GetCarouselListResponseDTO {
+  carouselResponseDTOS?: GetCarouselResponseDTO[];
+}
+
+export interface ApiResponseBannerExploreListResponse {
+  /** @format int32 */
+  code?: number;
+  msg?: string;
+  data?: BannerExploreListResponse;
+}
+
+export interface BannerExploreListResponse {
+  banners?: BannerExploreResponse[];
+}
+
+export interface BannerExploreResponse {
+  /** @format int64 */
+  id?: number;
+  name?: string;
+  imageUrl?: string;
+}
+
+export interface ApiResponseBannerDetailResponse {
+  /** @format int32 */
+  code?: number;
+  msg?: string;
+  data?: BannerDetailResponse;
+}
+
+export interface BannerDetailAnswerResponse {
+  /** @format int64 */
+  id?: number;
+  text?: string;
+}
+
+export interface BannerDetailResponse {
+  bannerName?: string;
+  bannerImageUrl?: string;
+  question?: string;
+  answers?: BannerDetailAnswerResponse[];
+}
+
+export interface AdminTagGetAllResponseDTO {
+  tagGetResponseDTOS?: AdminTagGetResponseDTO[];
+}
+
+export interface AdminTagGetResponseDTO {
+  /** @format int64 */
+  id?: number;
+  /** @format int32 */
+  priority?: number;
+  tagName?: string;
+  tag_name_kr?: string;
+  tag_prompt?: string;
+}
+
+export interface ApiResponseAdminTagGetAllResponseDTO {
+  /** @format int32 */
+  code?: number;
+  msg?: string;
+  data?: AdminTagGetAllResponseDTO;
+}
+
+export interface AdminStyleListResponse {
+  styles?: AdminStyleResponse[];
+}
+
+export interface ApiResponseAdminStyleListResponse {
+  /** @format int32 */
+  code?: number;
+  msg?: string;
+  data?: AdminStyleListResponse;
+}
+
+export interface AdminBannerRawProductSearchResponse {
+  rawProducts?: AdminBannerMappedRawProductResponse[];
+}
+
+export interface ApiResponseAdminBannerRawProductSearchResponse {
+  /** @format int32 */
+  code?: number;
+  msg?: string;
+  data?: AdminBannerRawProductSearchResponse;
+}
+
+export interface AdminMoodBoardGetAllResponseDTO {
+  dtos?: AdminMoodBoardGetResponseDTO[];
+}
+
+export interface AdminMoodBoardGetResponseDTO {
+  filename?: string;
+  originalFilename?: string;
+  url?: string;
+}
+
+export interface ApiResponseAdminMoodBoardGetAllResponseDTO {
+  /** @format int32 */
+  code?: number;
+  msg?: string;
+  data?: AdminMoodBoardGetAllResponseDTO;
+}
+
+export interface AdminLandingListResponse {
+  landings?: AdminLandingResponse[];
+}
+
+export interface ApiResponseAdminLandingListResponse {
+  /** @format int32 */
+  code?: number;
+  msg?: string;
+  data?: AdminLandingListResponse;
+}
+
+export interface AdminFurnitureGetDTO {
+  furnitures?: FurnitureInfo[];
+}
+
+export interface ApiResponseAdminFurnitureGetDTO {
+  /** @format int32 */
+  code?: number;
+  msg?: string;
+  data?: AdminFurnitureGetDTO;
+}
+
+export interface FurnitureInfo {
+  /**
+   * 가구 ID
+   * @format int64
+   */
+  furnitureId?: number;
+  /** 가구 한글 이름 */
+  furnitureNameKr?: string;
+  /** 연결된 태그 정보 리스트 */
+  tags?: TagInfo[];
+}
+
+/** 연결된 태그 정보 리스트 */
+export interface TagInfo {
+  /**
+   * 가구-태그 매핑 ID (FurnitureTag ID)
+   * @format int64
+   */
+  furnitureTagId?: number;
+  /**
+   * 태그 ID
+   * @format int64
+   */
+  tagId?: number;
+  /** 태그 이름 */
+  tagName?: string;
+  /** 가구 대표 이미지 URL */
+  imageUrl?: string;
+  /** 검색 키워드 */
+  searchKeyword?: string;
+  /**
+   * 우선순위
+   * @format int32
+   */
+  priority?: number;
+}
+
+export interface AdminFurnitureTypeListResponse {
+  /** 전체 가구 타입 */
+  furnitureTypeList?: AdminFurnitureTypeResponse[];
+}
+
+/** 전체 가구 타입 */
+export interface AdminFurnitureTypeResponse {
+  /**
+   * 가구 타입 식별자
+   * @format int64
+   */
+  furnitureTypeId?: number;
+  /** 가구 타입 한글명 */
+  furnitureTypeNameKr?: string;
+  /** 가구 타입 영어명 */
+  furnitureTypeNameEng?: string;
+}
+
+export interface ApiResponseAdminFurnitureTypeListResponse {
+  /** @format int32 */
+  code?: number;
+  msg?: string;
+  data?: AdminFurnitureTypeListResponse;
+}
+
+export interface AdminFurnitureTagOptionListResponse {
+  /** 선택한 가구 타입에 연결된 가구 태그 목록 */
+  furnitureTags?: AdminFurnitureTagOptionResponse[];
+}
+
+/** 선택한 가구 타입에 연결된 가구 태그 목록 */
+export interface AdminFurnitureTagOptionResponse {
+  /**
+   * 가구 태그 식별자
+   * @format int64
+   */
+  furnitureTagId?: number;
+  /**
+   * 가구 식별자
+   * @format int64
+   */
+  furnitureId?: number;
+  /** 가구 한글 이름 */
+  furnitureNameKr?: string;
+  /**
+   * 가구 타입 식별자
+   * @format int64
+   */
+  furnitureTypeId?: number;
+  /** 가구 타입 한글 이름 */
+  furnitureTypeNameKr?: string;
+  /**
+   * 스타일 태그 식별자
+   * @format int64
+   */
+  tagId?: number;
+  /** 스타일 태그 한글 이름 */
+  tagNameKr?: string;
+  /** 검색 키워드 */
+  searchKeyword?: string;
+  /**
+   * 우선순위
+   * @format int32
+   */
+  priority?: number;
+}
+
+export interface ApiResponseAdminFurnitureTagOptionListResponse {
+  /** @format int32 */
+  code?: number;
+  msg?: string;
+  data?: AdminFurnitureTagOptionListResponse;
+}
+
+export interface AdminFurnitureTagGetDTO {
+  /** tag 식별자 입니다 */
+  tagId?: number[];
+  /** tag의 한글 이름 입니다 */
+  tagNameKr?: string[];
+}
+
+export interface ApiResponseAdminFurnitureTagGetDTO {
+  /** @format int32 */
+  code?: number;
+  msg?: string;
+  data?: AdminFurnitureTagGetDTO;
+}
+
+export interface AdminFurnitureDetailsResponseDTO {
+  prompt?: string;
+}
+
+export interface ApiResponseAdminFurnitureDetailsResponseDTO {
+  /** @format int32 */
+  code?: number;
+  msg?: string;
+  data?: AdminFurnitureDetailsResponseDTO;
+}
+
+export interface AdminFloorPlanListResponse {
+  floorPlans?: AdminFloorPlanResponse[];
+}
+
+export interface ApiResponseAdminFloorPlanListResponse {
+  /** @format int32 */
+  code?: number;
+  msg?: string;
+  data?: AdminFloorPlanListResponse;
+}
+
+export interface AdminCurationRawProductListResponse {
+  products?: AdminCurationRawProductResponse[];
+  /** @format int32 */
+  page?: number;
+  /** @format int32 */
+  size?: number;
+  /** @format int64 */
+  totalElements?: number;
+  /** @format int32 */
+  totalPages?: number;
+  hasNext?: boolean;
+  hasPrevious?: boolean;
+}
+
+export interface ApiResponseAdminCurationRawProductListResponse {
+  /** @format int32 */
+  code?: number;
+  msg?: string;
+  data?: AdminCurationRawProductListResponse;
+}
+
+export interface AdminBannerListResponse {
+  banners?: AdminBannerResponse[];
+}
+
+export interface ApiResponseAdminBannerListResponse {
+  /** @format int32 */
+  code?: number;
+  msg?: string;
+  data?: AdminBannerListResponse;
+}
+
+export interface AdminTagDeleteRequestDTO {
+  /** @format int64 */
+  tagId: number;
+}
+
+export interface AdminFurnitureDeleteDTO {
+  /** 업데이트할 가구의 한글 이름(식별자) */
+  furnitureNameKr?: string;
+}
+
+export interface AdminDeleteFurnitureTypeRequest {
+  /**
+   * 삭제할 가구 타입 식별자
+   * @format int64
+   */
+  furnitureTypeId?: number;
+}
+
+export interface AdminFurnitureTagDeleteDTO {
+  /** 업데이트할 가구의 한글 이름(식별자) */
+  furnitureNameKr?: string;
+  /**
+   * 업데이트할 가구의 태그 ID(식별자)
+   * @format int64
+   */
+  tagId?: number;
+}
+
+export type ReissueData = ApiResponseString;
+
+export type LogoutData = ApiResponseString;
+
+export type GenerateImageV4ByGeminiData =
+  ApiResponseBannerGenerateImageResponse;
+
+export type Generate2ImageByFastApiData = ApiResponseImageInfoListResponse;
+
+export type Generate2ImageByFastApiGeminiData =
+  ApiResponseImageInfoListResponse;
+
+export type SignUpData = ApiResponseString;
+
+export type UpdateUserData = ApiResponseString;
+
+export type GenerateData = ApiResponseString;
+
+export type GenerateImageByFastApiData = ApiResponseImageInfoResponse;
+
+export type GenerateImageByFastApiGeminiData = ApiResponseImageInfoResponse;
+
+export type ToggleRawProductJjymData = ApiResponseJjymToggleResponse;
+
+export type LikeCarouselV2Data = ApiResponseString;
+
+export type HateCarouselV2Data = ApiResponseString;
+
+export type SignUp1Data = ApiResponseString;
+
+export type UpdateUser1Data = ApiResponseString;
+
+export type ToggleJjymData = ApiResponseJjymToggleResponse;
+
+export type Generate1Data = ApiResponseString;
+
+export type HousingSelectionsData = ApiResponseHouseIdResponse;
+
+export type GenerateImagePreferenceData = ApiResponseVoid;
+
+export type DeleteGenerateImagePreferenceData = ApiResponseVoid;
+
+export type ToggleFactorLogData = ApiResponseVoid;
+
+export type GetImageFallbackData = ApiResponseImageInfoResponse;
+
+export type GenerateImageData = ApiResponseImageInfoResponse;
+
+export type GenerateOtherStyleImageByGeminiData =
+  ApiResponseOtherStyleGenerateImageResponse;
+
+export type GenerateImageByGeminiData = ApiResponseImageInfoResponse;
+
+export type GenerateBannerImageByGeminiData =
+  ApiResponseBannerGenerateImageResponse;
+
+export type CreateFurnitureRecommendBtnClickLogData = ApiResponseVoid;
+
+export type CreatePaymentBtnClickLogData = ApiResponseVoid;
+
+export type LikeCarouselData = ApiResponseString;
+
+export type HateCarouselData = ApiResponseString;
+
+export type CreateTagData = ApiResponseString;
+
+export type DeleteTagData = ApiResponseString;
+
+export type UpdateTagData = ApiResponseString;
+
+export type GetStylesData = ApiResponseAdminStyleListResponse;
+
+export type CreateStyleData = ApiResponseAdminStyleResponse;
+
+export type CreateStyleImageUploadUrlData =
+  ApiResponseAdminBannerImageUploadResponse;
+
+export type CreateMoodBoardData = ApiResponseAdminMoodBoardCreateResponseDTO;
+
+export type DeleteMoodBoardData = ApiResponseString;
+
+export type GetLandings1Data = ApiResponseAdminLandingListResponse;
+
+export type CreateLandingData = ApiResponseAdminLandingResponse;
+
+export type CreateLandingImageUploadUrlData =
+  ApiResponseAdminBannerImageUploadResponse;
+
+export type AdminFurnitureData = ApiResponseString;
+
+export type DeleteFurnitureData = ApiResponseString;
+
+export type UpdateFurnitureData = ApiResponseAdminFurnitureUpdateResponseDTO;
+
+export type AdminFurnitureTypeData = ApiResponseString;
+
+export type DeleteFurnitureTypeData = ApiResponseString;
+
+export type UpdateFurnitureTypeData = ApiResponseString;
+
+export type GetFurniturePromptData =
+  ApiResponseAdminFurnitureDetailsResponseDTO;
+
+export type AdminFurniturePromptData =
+  ApiResponseAdminFurniturePromptCreateResponseDTO;
+
+export type GetFloorPlansData = ApiResponseAdminFloorPlanListResponse;
+
+export type CreateFloorPlanData = ApiResponseAdminFloorPlanResponse;
+
+export type CreateFloorPlanImageUploadUrlData =
+  ApiResponseAdminFloorPlanImageUploadResponse;
+
+export type SaveSoozipRawProductsData = ApiResponseSoozipRawProductSaveResponse;
+
+export type GetRawProductsData = ApiResponseAdminCurationRawProductListResponse;
+
+export type CreateRawProductData = ApiResponseAdminCurationRawProductResponse;
+
+export type CreateRawProductFurnitureTagMappingData =
+  ApiResponseAdminCurationRawProductFurnitureTagResponse;
+
+export type GetBannersData = ApiResponseAdminBannerListResponse;
+
+export type CreateBannerData = ApiResponseAdminBannerResponse;
+
+export type CreateBannerImageUploadUrlData =
+  ApiResponseAdminBannerImageUploadResponse;
+
+export type CreateAddressData = ApiResponseVoid;
+
+export type GetStyleData = ApiResponseAdminStyleResponse;
+
+export type DeleteStyleData = ApiResponseString;
+
+export type UpdateStyleData = ApiResponseAdminStyleResponse;
+
+export type GetLandingData = ApiResponseAdminLandingResponse;
+
+export type DeleteLandingData = ApiResponseString;
+
+export type UpdateLandingData = ApiResponseAdminLandingResponse;
+
+export type GetFloorPlanData = ApiResponseAdminFloorPlanResponse;
+
+export type DeleteFloorPlanData = ApiResponseString;
+
+export type UpdateFloorPlanData = ApiResponseAdminFloorPlanResponse;
+
+export type GetRawProductData = ApiResponseAdminCurationRawProductResponse;
+
+export type DeleteRawProductData = ApiResponseString;
+
+export type UpdateRawProductData = ApiResponseAdminCurationRawProductResponse;
+
+export type DeleteRawProductFurnitureTagMappingData = ApiResponseString;
+
+export type UpdateRawProductFurnitureTagMappingData =
+  ApiResponseAdminCurationRawProductFurnitureTagResponse;
+
+export type UpdateRawProductExposureData = ApiResponseString;
+
+export type GetBannerData = ApiResponseAdminBannerResponse;
+
+export type DeleteBannerData = ApiResponseString;
+
+export type UpdateBannerData = ApiResponseAdminBannerResponse;
+
+export type KakaoOAuthCallbackData = any;
+
+export type KakaoLoginData = ApiResponseKakaoLoginResponse;
+
+export type GetRecentFloorPlanData = ApiResponseRecentFloorPlanResponse;
+
+export type RotateNicknameData = ApiResponseString;
+
+export type GetUserImageHistoryListV2Data =
+  ApiResponseMyPageGeneratedImageV2Response;
+
+export type GetMyRawProductJjymsData = ApiResponseJjymV2ListResponse;
+
+export type GetExploreHouseTemplatesData =
+  ApiResponseExploreHouseTemplateListResponse;
+
+export type GetExploreHouseTemplateDetailData =
+  ApiResponseExploreHouseTemplateDetailResponse;
+
+export type GetDashboardCategoriesData = ApiResponseDashboardCategoriesResponse;
+
+export type GetActivityFurnitureMappingsData =
+  ApiResponseActivityFurnitureMappingsResponse;
+
+export type GetCarouselsV2Data = ApiResponseGetCarouselV2ListResponseDTO;
+
+export type GetOtherStylesData = ApiResponseOtherStyleListResponse;
+
+export type GetOtherStyleDetailData = ApiResponseOtherStyleDetailResponse;
+
+export type GetMyPageInfoData = ApiResponseMyPageInfoResponse;
+
+export type GetUserImageHistoryListData =
+  ApiResponseUserImageHistoryListResponse;
+
+export type GetImageHistoryResultPageData =
+  ApiResponseImageHistoriesResultPageResponse;
+
+export type MoodboardImagesData = ApiResponseMoodBoardListResponse;
+
+export type GetLandingsData = ApiResponseLandingListResponse;
+
+export type GetMyJjymsData = ApiResponseJjymListResponse;
+
+export type HousingOptionsData = ApiResponseHouseOptionsResponse;
+
+export type GetHouseTemplatesData = ApiResponseFloorPlanListResponse;
+
+export type GetFurnitureProductInfoFromNaverApiForPlanData =
+  ApiResponseFurnitureProductsInfoResponseForPlan;
+
+export type GetFurnitureProductInfoFromNaverApiForPlanV2Data =
+  ApiResponseFurnitureProductsInfoResponseForPlan;
+
+export type GetFurnitureProductInfoFromNaverApiData =
+  ApiResponseFurnitureProductsInfoResponse;
+
+export type GetFurnitureCategoriesData = ApiResponseFurnitureCategoriesResponse;
+
+export type GetSimilarItemsData = ApiResponseSimilarItemsResponse;
+
+export type GetRelatedImagesData = ApiResponseRelatedImagesResponse;
+
+export type GetListResultItemsData = ApiResponseGenerateImageResultResponse;
+
+export type GetFactorsData = ApiResponseFactorsResponse;
+
+export type GetEnvData = Record<string, string>;
+
+export type GetFurnitureAndActivityData =
+  ApiResponseFurnitureAndActivityResponse;
+
+export type GetProductsData = ApiResponseCurationProductListResponse;
+
+export type GetProductDetailData = ApiResponseCurationProductDetailResponse;
+
+export type GetFiltersData = ApiResponseCurationProductFilterResponse;
+
+export type CheckHasGeneratedImageData = ApiResponseBoolean;
+
+export type GetCarouselsData = ApiResponseGetCarouselListResponseDTO;
+
+export type GetExploreBannersData = ApiResponseBannerExploreListResponse;
+
+export type GetExploreBannerDetailData = ApiResponseBannerDetailResponse;
+
+export type AdminOnlyTestData = ApiResponseString;
+
+export type GetTagsData = ApiResponseAdminTagGetAllResponseDTO;
+
+export type SearchRawProductsData =
+  ApiResponseAdminBannerRawProductSearchResponse;
+
+export type GetAllData = ApiResponseAdminMoodBoardGetAllResponseDTO;
+
+export type GetFurnituresData = ApiResponseAdminFurnitureGetDTO;
+
+export type GetFurnitureTypesData = ApiResponseAdminFurnitureTypeListResponse;
+
+export type GetFurnitureTagsByTypeData =
+  ApiResponseAdminFurnitureTagOptionListResponse;
+
+export type GetFurnitureTagsData = ApiResponseAdminFurnitureTagGetDTO;
+
+export type SearchRawProducts1Data =
+  ApiResponseAdminBannerRawProductSearchResponse;
+
+export type CreateAccessData = ApiResponseString;
+
+export type AccessTestData = ApiResponseString;
+
+export type DeleteUserData = ApiResponseString;
+
+export type DeleteFurnitureTagData = ApiResponseString;


### PR DESCRIPTION
## 📌 Summary

- close #519 

> 관련 있는 Issue를 태그해주세요. (e.g. > - #1)

_해당 PR에 대한 작업 내용을 요약하여 작성해주세요._

## 📄 Tasks

### 1. swagger-typescript-api

- OpenAPI(Swagger) 스펙으로부터 TypeScript 타입을 자동 생성해주는 도구
- API 요청/응답 타입은 물론 axios 기반의 API 클라이언트 코드(실제 API 요청 메서드)까지 생성 가능하지만, HOUME은 이미 axios 인스턴스 / 인터셉터 / `request<T>()` 래퍼 / 공통 에러 처리가 일관된 방식으로 구성되어 있어, **타입만 생성하고 API 요청 메서드는 생성하지 않는 방향**으로 설정했어요.

### 2. SWAGGER_URL은 .env로 분리

- Swagger 문서 URL은 **내부 리소스**
- 현재 dev 서버의 Swagger 엔드포인트가 열려있어 URL이 노출된다고 해서 추가로 노출되는 정보는 제한적이지만, public repository에 URL을 커밋하면 봇 스캔/취약점 탐색 대상이 되기 쉬워진다고 해요
- 보안 측면에서 굳이 Swagger URL을 노출시킬 필요가 없을 듯해 `.env`에 `SWAGGER_URL`을 정의하고, 이를 읽어서 `swagger-typescript-api`를 실행하는 **브릿지 스크립트** `scripts/gen-api.mjs`를 두는 방식으로 URL을 숨겼어요.

```js
// scripts/gen-api.mjs
process.loadEnvFile('.env');
const url = process.env.SWAGGER_URL;
// ... spawn swagger-typescript-api with url
```

업데이트된 `.env` 파일은 별도로 전달드릴게요!

### 3. 사용한 스크립트

`package.json`에 다음 스크립트를 추가

```json
"api:generate": "swagger-typescript-api generate -p <스웨거 주소> -o src/shared/apis/__generated__ --no-client --modular -d --extract-request-body --extract-response-body --extract-response-error"
```

| 옵션 | 의미 |
| --- | --- |
| `-p <URL>` | Swagger 문서 URL (`.env`의 `SWAGGER_URL`에서 주입) |
| `-o src/shared/apis/__generated__` | 요청/응답 타입이 저장될 폴더 위치 |
| `--no-client` | API 요청 메서드는 생성하지 않음, 요청/응답 타입만 생성 |
| `--modular` | 모듈별 파일 분리 (단, `--no-client`와 함께 사용시 분리될 파일이 없으므로 하우미 기준으로는 별 동작 X) |
| `-d` | default 응답을 성공 응답으로 취급 |
| `--extract-request-body` | 요청 body를 별도 interface로 추출 |
| `--extract-response-body` | 응답 body를 별도 interface로 추출 |
| `--extract-response-error` | 에러 응답을 별도 interface로 추출 |

### 4. 스펙 최신화

- 백엔드 Swagger 스펙이 변경될 때마다 아래 명령어를 실행하면 data-contracts.ts가 최신화됨
    
    `pnpm api:generate`
    

### 5. 주의사항

- 파일 위치: `src/shared/apis/__generated__/data-contracts.ts`
- 폴더 이름 앞뒤 언더스코어 2개(`__generated__`)는 **"자동 생성물, 직접 수정 금지"** 시그널이에요. 하우미를 포함해 앞으로 프로젝트를 진행할 때 폴더 이름 앞뒤에 _ _ 가 들어가있다면 ‘자동 생성물이니까 내부 코드를 직접 수정하지 마세요’라는 의미라고 알아두시면 돼요.
    
    `data-contracts.ts`는 **직접 수정 금지** — 스펙이 바뀌면 `pnpm api:generate`로 재생성하기
    
- `.prettierignore` / `eslint.config.js` 에서 ignore 처리되어 있어 lint-staged / 포매터가 건드리지 않음

### 사용 예시

```ts
import type {
  BannerGenerateImageResponse,
  GenerateImageV4Request,
} from '@apis/__generated__/data-contracts';
import { HTTPMethod, request } from '@apis/config/request';
import { API_ENDPOINT } from '@constants/apiEndpoints';

export const postGenerateImage = (
  body: GenerateImageV4Request,
): Promise<BannerGenerateImageResponse> =>
  request<BannerGenerateImageResponse>({
    method: HTTPMethod.POST,
    url: API_ENDPOINT.GENERATE.IMAGE_V4,
    body,
  });
```

⇒ 그냥 swagger에서 해당 API의 요청/응답 타입 찾아서 바로 import하면 됨!

_해당 PR에 수행한 작업을 작성해주세요._

## 🔍 To Reviewer

- 스웨거 주소는 

_리뷰어에게 요청하는 내용을 작성해주세요._

## 📸 Screenshot

-

_작업한 내용에 대한 스크린샷을 첨부해주세요._
