### PR TITLE
[feat] 탐색 탭 도면 프리뷰 API 연동 및 홈 UI 수정

### DIFF
--- a/src/pages/home/components/explore/RoomTypeSection/RoomTypeSection.tsx
+++ b/src/pages/home/components/explore/RoomTypeSection/RoomTypeSection.tsx
@@ -32,7 +32,7 @@ const RoomTypeSection = () => {
           color="secondary"
           size="s"
           rightIcon="ArrowRight"
-          onClick={() => {}}
+          onClick={handleRoomTypeClick}
         >
           더보기
         </TextButton>
@@ -51,7 +51,7 @@ const RoomTypeSection = () => {
             </div>
           ))}
           <div className={styles.cardItem}>
-            <RoomTypeCard type="more" size="s" onClick={() => {}} />
+            <RoomTypeCard type="more" size="s" onClick={handleRoomTypeClick} />
           </div>
         </div>
       </div>

--- a/src/pages/home/components/explore/RoomTypeSection/RoomTypeSection.tsx
+++ b/src/pages/home/components/explore/RoomTypeSection/RoomTypeSection.tsx
@@ -1,5 +1,7 @@
 import { useNavigate } from 'react-router-dom';
 
+import { useHouseTemplatesQuery } from '@pages/imageSetup/v2/apis/queries/useHouseTemplatesQuery';
+
 import { ROUTES } from '@routes/paths';
 
 import { ENTRY_ROUTE, useImageFlowStore } from '@store/useImageFlowStore';
@@ -10,36 +12,10 @@ import TextButton from '@/shared/components/v2/btnText/TextButton';
 
 import * as styles from './RoomTypeSection.css';
 
-const ROOM_TYPE_MOCK = [
-  {
-    id: 'living',
-    label: '거실',
-    imageSrc: ' ',
-  },
-  {
-    id: 'bedroom',
-    label: '침실',
-    imageSrc: ' ',
-  },
-  {
-    id: 'kitchen',
-    label: '주방',
-    imageSrc: ' ',
-  },
-  {
-    id: 'study',
-    label: '서재',
-    imageSrc: ' ',
-  },
-  {
-    id: 'bathroom',
-    label: '욕실',
-    imageSrc: ' ',
-  },
-] as const;
-
 const RoomTypeSection = () => {
   const navigate = useNavigate();
+  const { data } = useHouseTemplatesQuery({ size: 4 });
+  const floorPlans = data?.floorPlans ?? [];
 
   const handleRoomTypeClick = () => {
     useImageFlowStore
@@ -63,15 +39,13 @@ const RoomTypeSection = () => {
       </div>
       <div className={styles.cardScroll}>
         <div className={styles.cardList}>
-          {ROOM_TYPE_MOCK.map((room) => (
-            // cardList가 가로 스크롤 가능한 컴포넌트(width: max-content + flex-wrap:nowrap) + RoomTypeCard는 반응형 대응 가능(width: 100%)
-            // => cardItem으로 명시적으로 너비를 설정해야 RoomTypeCard의 너비가 무한히 커지지 않음
-            <div key={room.id} className={styles.cardItem}>
+          {floorPlans.map((floorPlan) => (
+            <div key={floorPlan.id} className={styles.cardItem}>
               <RoomTypeCard
                 type="default"
                 size="s"
-                label={room.label}
-                imageSrc={room.imageSrc}
+                label={floorPlan.name ?? ''}
+                imageSrc={floorPlan.imageUrl ?? ''}
                 onClick={handleRoomTypeClick}
               />
             </div>

--- a/src/pages/home/components/explore/StyleSection/StyleSection.tsx
+++ b/src/pages/home/components/explore/StyleSection/StyleSection.tsx
@@ -41,7 +41,7 @@ const StyleSection = () => {
         <h2 className={styles.sectionTitle}>다른 스타일로 꾸며보기</h2>
         <TextButton
           color="secondary"
-          size="m"
+          size="s"
           rightIcon="ArrowRight"
           onClick={handleMoreClick}
         >

--- a/src/pages/home/components/product/SearchSection/SearchSection.css.ts
+++ b/src/pages/home/components/product/SearchSection/SearchSection.css.ts
@@ -25,9 +25,11 @@ export const stickyHeader = style({
   position: 'fixed',
   zIndex: zIndex.navigation,
   top: 0,
-  left: 0,
+  margin: '0 auto',
   background: colorVars.color.bg.primary,
   width: '100%',
+  minWidth: unitVars.unit.dimension.wMin,
+  maxWidth: unitVars.unit.dimension.wMax,
 });
 
 export const stickySearchBarWrap = style({

--- a/src/pages/home/hooks/useProductSearch.ts
+++ b/src/pages/home/hooks/useProductSearch.ts
@@ -12,7 +12,6 @@ import type { ProductListQueryVariables } from '@constants/queryKey';
  */
 interface ProductSearchCardItem {
   id: string;
-  /** `GET /api/v1/curations/products/:id` 상세 조회용 */
   detailProductId: number;
   title: string;
   brand: string;

--- a/src/shared/constants/apiEndpoints.ts
+++ b/src/shared/constants/apiEndpoints.ts
@@ -56,7 +56,7 @@ export const API_ENDPOINT = {
     MYPAGE_JJYM_LIST_V2: '/api/v2/jjyms',
   },
   PRODUCT: {
-    LIST: '/api/v1/curations/products',
+    LIST: '/api/v2/curations/products',
     DETAIL: (productId: number) => `/api/v1/curations/products/${productId}`,
     FILTERS: '/api/v1/curations/products/filters',
   },


### PR DESCRIPTION
## 📌 Summary

- close #535
- close #542

홈 탐색 탭의 "우리 집 공간으로 시작하기" 섹션을 도면 미리보기 API와 연동하고, 자잘한 UI를 수정했습니다.


## 📄 Tasks

- 홈 탐색 탭 `우리 집 공간으로 시작하기` 섹션에 도면 미리보기 API 연동
- API 응답(`floorPlans`) 기반으로 도면 카드 렌더링하도록 목업 데이터 제거
- 더보기 버튼에 navigation 연결
- `handleRoomTypeClick` 동작을 도면 카드 및 더보기 버튼에 동일하게 연결
- 상품 검색/필터바 너비 및 더보기 버튼 크기 조정
- 상품 탭 메인 API v2 업데이트


## 🔍 To Reviewer

1. 도면 프리뷰 카드 연동 시 신규 쿼리를 만들지 않고 기존 `useHouseTemplatesQuery`를 재사용했고, size="4" 조건만 활용했어요.
2. 기존에 카드에 연결되어 있던 `handleRoomTypeClick`을 더보기 버튼에도 동일하게 연결했는데, 이 UX 흐름이 맞는지 확인 부탁드립니다.
3. 자잘한 UI가 수정되었어요.
  - 탐색 탭 스타일 섹션 더보기 버튼 크기 조정 (M >> S)
  - 상품 탭 Sticky 검색/필터바 너비 조정
4. 상품 탭 메인 API가 검색 엔진이 도입된 v2로 업데이트되었어요. 엔드포인트만 변경되었습니다!



## 📸 Screenshot

<img width="250" alt="스크린샷 2026-05-07 오전 1 41 51" src="https://github.com/user-attachments/assets/c2e0fd0f-a7a7-49e9-9314-65fbd6bbd6c1" />
<img width="300" alt="스크린샷 2026-05-07 오전 1 43 48" src="https://github.com/user-attachments/assets/23fafefe-93b2-4440-b81b-816b4db648fb" />

