### PR TITLE
[fix] 도면 선택 단계 진입 경로별 바텀시트 자동 오픈 분기 정리 / 도면 선택 바텀시트 동작 일부 수정

### DIFF
--- a/src/pages/generate/v2/pages/loading/LoadingPage.tsx
+++ b/src/pages/generate/v2/pages/loading/LoadingPage.tsx
@@ -105,7 +105,7 @@ const LoadingPage = () => {
     // - useImageFlowStore의 entryRoute/resultType은 ResultPage에서 사용하므로 유지
     const onMutationSettled = () => {
       useFunnelStore.getState().reset();
-      useImageFlowStore.setState({ preset: null });
+      useImageFlowStore.getState().clearPreset();
     };
 
     const mutateOptions = {

--- a/src/pages/generate/v2/pages/loading/hooks/useGenerateImageRequest.ts
+++ b/src/pages/generate/v2/pages/loading/hooks/useGenerateImageRequest.ts
@@ -81,8 +81,8 @@ export const useGenerateImageRequest = (): GenerateImageRequestResult => {
     // 모든 이미지 생성 API 요청 필수 값: floorPlan (필드 단위 타입 검증)
     if (!isFloorPlanValid(floorPlan)) return { kind: 'invalid' };
 
-    // 풀퍼널 (preset 없음)
-    if (preset === null) {
+    // 풀퍼널 (preset 없음 또는 FLOOR_PLAN 경로의 floorPlan preset 잔존 — useFloorPlanSelect가 정상 소비하면 null이지만 안전망)
+    if (preset === null || preset.type === 'floorPlan') {
       const activity = activityInfo?.activity;
       const furnitureIds = activityInfo?.furnitureIds;
 

--- a/src/pages/home/components/explore/RoomTypeSection/RoomTypeSection.tsx
+++ b/src/pages/home/components/explore/RoomTypeSection/RoomTypeSection.tsx
@@ -26,7 +26,8 @@ const RoomTypeSection = () => {
   };
 
   // 홈에서 도면 카드 클릭: floorPlanId를 preset으로 전달 → 퍼널 진입 즉시 해당 도면 시트 자동 오픈
-  const handleFloorPlanClick = (floorPlanId: number) => {
+  const handleFloorPlanClick = (floorPlanId: number | undefined) => {
+    if (floorPlanId === undefined) return;
     useImageFlowStore.getState().setFlow({
       entryRoute: ENTRY_ROUTE.FLOOR_PLAN,
       preset: { type: 'floorPlan', floorPlanId },
@@ -56,10 +57,7 @@ const RoomTypeSection = () => {
                 size="s"
                 label={floorPlan.name ?? ''}
                 imageSrc={floorPlan.imageUrl ?? ''}
-                onClick={() =>
-                  floorPlan.id !== undefined &&
-                  handleFloorPlanClick(floorPlan.id)
-                }
+                onClick={() => handleFloorPlanClick(floorPlan.id)}
               />
             </div>
           ))}

--- a/src/pages/home/components/explore/RoomTypeSection/RoomTypeSection.tsx
+++ b/src/pages/home/components/explore/RoomTypeSection/RoomTypeSection.tsx
@@ -17,10 +17,20 @@ const RoomTypeSection = () => {
   const { data } = useHouseTemplatesQuery({ size: 4 });
   const floorPlans = data?.floorPlans ?? [];
 
-  const handleRoomTypeClick = () => {
+  // "더보기" / "more" 카드: floorPlanId 없이 진입, 사용자가 그리드에서 도면을 직접 선택
+  const handleMoreClick = () => {
     useImageFlowStore
       .getState()
       .setFlow({ entryRoute: ENTRY_ROUTE.FLOOR_PLAN });
+    navigate(ROUTES.IMAGE_SETUP);
+  };
+
+  // 홈에서 도면 카드 클릭: floorPlanId를 preset으로 전달 → 퍼널 진입 즉시 해당 도면 시트 자동 오픈
+  const handleFloorPlanClick = (floorPlanId: number) => {
+    useImageFlowStore.getState().setFlow({
+      entryRoute: ENTRY_ROUTE.FLOOR_PLAN,
+      preset: { type: 'floorPlan', floorPlanId },
+    });
     navigate(ROUTES.IMAGE_SETUP);
   };
 
@@ -32,7 +42,7 @@ const RoomTypeSection = () => {
           color="secondary"
           size="s"
           rightIcon="ArrowRight"
-          onClick={handleRoomTypeClick}
+          onClick={handleMoreClick}
         >
           더보기
         </TextButton>
@@ -46,12 +56,15 @@ const RoomTypeSection = () => {
                 size="s"
                 label={floorPlan.name ?? ''}
                 imageSrc={floorPlan.imageUrl ?? ''}
-                onClick={handleRoomTypeClick}
+                onClick={() =>
+                  floorPlan.id !== undefined &&
+                  handleFloorPlanClick(floorPlan.id)
+                }
               />
             </div>
           ))}
           <div className={styles.cardItem}>
-            <RoomTypeCard type="more" size="s" onClick={handleRoomTypeClick} />
+            <RoomTypeCard type="more" size="s" onClick={handleMoreClick} />
           </div>
         </div>
       </div>

--- a/src/pages/imageSetup/components/layout/FunnelLayout.tsx
+++ b/src/pages/imageSetup/components/layout/FunnelLayout.tsx
@@ -16,6 +16,7 @@ import {
   logSelectHouseInfoClickModalExit,
   logSelectHouseInfoViewModal,
 } from '../../utils/analytics';
+import { useFloorPlanStore } from '../../v2/stores/useFloorPlanStore';
 
 type FunnelStepKey = 'FloorPlanSelect' | 'InteriorStyle' | 'ActivityInfo';
 
@@ -69,16 +70,30 @@ const FunnelLayout = ({ children, currentStep }: FunnelLayoutProps) => {
     onBlocked: ({ proceed, reset }) => {
       logSelectHouseInfoViewModal();
 
+      // vaul Drawer의 modal=true가 이탈방지 Popup의 pointer-events를 차단하므로,
+      // popup이 떠 있는 동안에는 시트들을 일시 close하고, 계속 입력 시 원상 복구
+      // 선택/필터 상태는 useFloorPlanStore가 보존하므로 시트만 다시 열면 사용자 작업이 그대로 이어짐
+      const { isFilterSheetOpen, isFloorPlanSheetOpen, isRecentSheetOpen } =
+        useFloorPlanStore.getState();
+      const sheetsSnapshot = {
+        isFilterSheetOpen,
+        isFloorPlanSheetOpen,
+        isRecentSheetOpen,
+      };
+      useFloorPlanStore.getState().pauseSheets();
+
       // unmount: overlay-kit이 제공, 모달 컴포넌트 제거
       overlay.open(({ unmount }) => {
         // '계속하기' / backdrop 클릭 -> blocker의 'blocked' 상태 해제, 현재 step에 머무름
         const stay = () => {
           logSelectHouseInfoClickModalContinue();
+          useFloorPlanStore.getState().restoreSheets(sheetsSnapshot);
           reset();
           unmount();
         };
 
         // '나가기' -> 막혔던 navigation(뒤로가기 등)을 그대로 진행
+        // 페이지 자체를 떠나므로 시트 복원 불필요 (cleanup에서 store reset됨)
         const exit = () => {
           logSelectHouseInfoClickModalExit();
           unmount();

--- a/src/pages/imageSetup/v2/hooks/useFloorPlanSelect.ts
+++ b/src/pages/imageSetup/v2/hooks/useFloorPlanSelect.ts
@@ -1,4 +1,6 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
+
+import { useImageFlowStore } from '@store/useImageFlowStore';
 
 import { useToast } from '@components/toast/useToast';
 
@@ -41,11 +43,10 @@ export const useFloorPlanSelect = (
     ? (recentFloorPlanData.floorPlan ?? null)
     : null;
 
-  // 시트 표시 우선순위:
-  // 1순위: useFunnelStore에 저장된 도면이 있는 경우 시트 복원
-  //   (case: 경로 3 홈 도면 클릭 / 로그인 게이트에서 복귀)
-  // 2순위: 최근 생성 공간이 있는 경우 RecentSheet 표시 + 토스트
-  // 3순위: useFloorPlanStore 저장 도면도 없고 최근 생성 공간도 없으면 바텀시트 X
+  // 시트 자동 오픈 우선순위 (마운트 시 1회 평가):
+  // 1순위: useFunnelStore.floorPlan 있음 → FloorPlanSheet 복원 (로그인 게이트 복귀)
+  // 2순위: useImageFlowStore.preset.type === 'floorPlan' → FloorPlanSheet 오픈, 이후 바로 preset 소비 (LoadingPage에 preset이 불필요하므로 바로 null 처리)
+  // 그 외: 자동 오픈 없음
   useEffect(() => {
     const savedFloorPlan = useFunnelStore.getState().floorPlan;
     if (savedFloorPlan) {
@@ -57,11 +58,29 @@ export const useFloorPlanSelect = (
       return;
     }
 
-    if (recentFloorPlan) {
-      store.openRecentSheet();
-      notify({ text: '저장된 내 공간을 불러왔어요.' });
+    const preset = useImageFlowStore.getState().preset;
+    if (preset?.type === 'floorPlan') {
+      store.selectNewFloorPlan(preset.floorPlanId);
+      store.openFloorPlanSheet();
+      // FLOOR_PLAN 경로는 풀퍼널이므로 LoadingPage가 preset을 사용하지 않음 → 시트 오픈 후 즉시 클리어
+      useImageFlowStore.setState({ preset: null });
     }
-    // 마운트 시 1회만 실행 (recentFloorPlan은 처음 fetch 완료 후 한 번만 반영하면 됨)
+    // 마운트 시 1회만 평가
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // RecentSheet 자동 오픈: FloorPlanSheet가 자동 오픈되지 않은 모든 경로에서 표시
+  // (로그인 복귀 / 홈 도면 클릭으로 FloorPlanSheet 이미 열린 경우는 if(isFloorPlanSheetOpen) return; 으로 저장된 내 공간 바텀시트 스킵)
+  // recentFloorPlan fetch 완료 후 1회 처리
+  const recentHandledRef = useRef(false);
+  useEffect(() => {
+    if (recentHandledRef.current) return;
+    if (!recentFloorPlan) return;
+    if (store.isFloorPlanSheetOpen) return;
+
+    recentHandledRef.current = true;
+    store.openRecentSheet();
+    notify({ text: '저장된 내 공간을 불러왔어요.' });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [recentFloorPlan]);
 

--- a/src/pages/imageSetup/v2/hooks/useFloorPlanSelect.ts
+++ b/src/pages/imageSetup/v2/hooks/useFloorPlanSelect.ts
@@ -70,13 +70,14 @@ export const useFloorPlanSelect = (
   }, []);
 
   // RecentSheet 자동 오픈: FloorPlanSheet가 자동 오픈되지 않은 모든 경로에서 표시
-  // (로그인 복귀 / 홈 도면 클릭으로 FloorPlanSheet 이미 열린 경우는 if(isFloorPlanSheetOpen) return; 으로 저장된 내 공간 바텀시트 스킵)
-  // recentFloorPlan fetch 완료 후 1회 처리
+  // recentFloorPlan이 캐시된 상태로 진입하면 위 useEffect와 같은 mount commit에서 함께 실행되는데,
+  // 그때 `store` 변수는 첫 렌더의 snapshot이라 위 effect의 openFloorPlanSheet()가 반영되지 않음.
+  // -> useFloorPlanStore.getState()로 zustand에서 동기적으로 최신값을 읽어 race condition 방지!
   const recentHandledRef = useRef(false);
   useEffect(() => {
     if (recentHandledRef.current) return;
     if (!recentFloorPlan) return;
-    if (store.isFloorPlanSheetOpen) return;
+    if (useFloorPlanStore.getState().isFloorPlanSheetOpen) return;
 
     recentHandledRef.current = true;
     store.openRecentSheet();

--- a/src/pages/imageSetup/v2/hooks/useFloorPlanSelect.ts
+++ b/src/pages/imageSetup/v2/hooks/useFloorPlanSelect.ts
@@ -63,7 +63,7 @@ export const useFloorPlanSelect = (
       store.selectNewFloorPlan(preset.floorPlanId);
       store.openFloorPlanSheet();
       // FLOOR_PLAN 경로는 풀퍼널이므로 LoadingPage가 preset을 사용하지 않음 → 시트 오픈 후 즉시 클리어
-      useImageFlowStore.setState({ preset: null });
+      useImageFlowStore.getState().clearPreset();
     }
     // 마운트 시 1회만 평가
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/pages/imageSetup/v2/stores/useFloorPlanStore.ts
+++ b/src/pages/imageSetup/v2/stores/useFloorPlanStore.ts
@@ -59,6 +59,14 @@ interface FloorPlanStoreState {
   // 최근 선택한 도면이 있을 경우 RecentSheet open
   openRecentSheet: () => void;
   closeRecentSheet: () => void;
+  // 페이지 이탈 가드 popup이 떠 있는 동안 시트 visibility만 임시로 false (선택/필터 상태 보존)
+  pauseSheets: () => void;
+  // pauseSheets로 숨겼던 시트를 snapshot 기반으로 다시 보이게 복원
+  restoreSheets: (snapshot: {
+    isFilterSheetOpen: boolean;
+    isFloorPlanSheetOpen: boolean;
+    isRecentSheetOpen: boolean;
+  }) => void;
   // 페이지 이탈 시 모든 상태 초기화
   reset: () => void;
 }
@@ -128,6 +136,20 @@ export const useFloorPlanStore = create<FloorPlanStoreState>((set) => ({
   // TODO: 최근 생성 공간 API 연동 시, 도면 데이터를 파라미터로 받아 스토어에 저장하거나 별도 방식으로 전달 검토
   openRecentSheet: () => set({ isRecentSheetOpen: true }),
   closeRecentSheet: () => set({ isRecentSheetOpen: false }),
+
+  // 이탈 가드 popup 표시 동안만 시트 visibility를 false로 (선택/필터 상태는 보존)
+  pauseSheets: () =>
+    set({
+      isFilterSheetOpen: false,
+      isFloorPlanSheetOpen: false,
+      isRecentSheetOpen: false,
+    }),
+  restoreSheets: (snapshot) =>
+    set({
+      isFilterSheetOpen: snapshot.isFilterSheetOpen,
+      isFloorPlanSheetOpen: snapshot.isFloorPlanSheetOpen,
+      isRecentSheetOpen: snapshot.isRecentSheetOpen,
+    }),
 
   reset: () =>
     set({

--- a/src/store/useImageFlowStore.ts
+++ b/src/store/useImageFlowStore.ts
@@ -22,6 +22,7 @@ export type ResultType = (typeof RESULT_TYPE)[keyof typeof RESULT_TYPE];
 // 퍼널 진입 시점에 setFlow()로 저장 → 최종 이미지 생성 API 호출 시 사용
 export type PresetData =
   | { type: 'banner'; bannerId: number; answerId: number } // 경로2
+  | { type: 'floorPlan'; floorPlanId: number } // 경로3: 홈에서 도면 선택
   | { type: 'style'; styleId: number } // 경로4
   | { type: 'product'; productIds: number[] }; // 경로5
 

--- a/src/store/useImageFlowStore.ts
+++ b/src/store/useImageFlowStore.ts
@@ -33,6 +33,8 @@ interface ImageFlowState {
   // 퍼널 진입 시 호출, 진입경로 + 프리셋 세팅 및 resultType 자동 매핑
   // TODO: API 명세 나오면 entryRoute와 preset 조합을 타입으로 강제 (ex: STYLE_RESTYLE + banner preset 방지)
   setFlow: (params: { entryRoute: EntryRoute; preset?: PresetData }) => void;
+  // preset만 선택적으로 비움 (entryRoute/resultType은 ResultPage에서 사용하므로 유지해야 하는 케이스에 사용)
+  clearPreset: () => void;
   // 퍼널 완료/이탈 시 호출
   reset: () => void;
 }
@@ -58,6 +60,7 @@ export const useImageFlowStore = create<ImageFlowState>()(
           resultType: RESULT_TYPE_MAP[entryRoute], // 결과 페이지 타입 자동 매핑
           preset: preset ?? null,
         }),
+      clearPreset: () => set({ preset: null }),
       reset: () => set({ entryRoute: null, resultType: null, preset: null }),
     }),
     {


### PR DESCRIPTION
## 📌 Summary

- close #552 

> 관련 있는 Issue를 태그해주세요. (e.g. > - #1)

_해당 PR에 대한 작업 내용을 요약하여 작성해주세요._

## 📄 Tasks

### 도면 선택 단계 진입 경로별 바텀시트 자동 오픈 분기 정리

**문제**
- 어떤 경로로 진입하든 퍼널 진입 시 RecentSheet가 자동으로 떠서 홈에서 선택한 도면이 무시됨
- 홈 `도면 카드` 클릭 시 floorPlanId가 퍼널로 전달되지 않았음 (floorPlanId 전달 로직 부재)

**해결**
- PresetData에 { type: 'floorPlan'; floorPlanId } 케이스 추가
- RoomTypeSection에서 도면 카드와 '더보기' 카드의 클릭 핸들러 분리, 도면 카드 클릭 시 floorPlanId를 preset으로 전달
- useFloorPlanSelect 시트 자동 오픈 우선순위 재작성:
  - 1순위: useFunnelStore.floorPlan 있음 → FloorPlanSheet 복원 (로그인 게이트 복귀)
  - 2순위: preset.type === 'floorPlan' → FloorPlanSheet 자동 오픈 후 preset 바로 소비 (바로 `preset=null`로 변경)
  - 그 외: FloorPlanSheet 자동 오픈 안 된 경우에만 RecentSheet 표시
- useGenerateImageRequest에서 preset.type === 'floorPlan'인 케이스를 풀퍼널 분기 검증 조건문에 추가 (퍼널 진입 시 preset.type === 'floorPlan'인 경우 preset.type을 바로 consume하므로, useGenerateImageRequest에서 preset이 floorPlan인 경우는 정상적인 플로우에서는 없는 케이스 / 안전망용)

**변경 파일**
- src/store/useImageFlowStore.ts
- src/pages/home/components/explore/RoomTypeSection/RoomTypeSection.tsx
- src/pages/imageSetup/v2/hooks/useFloorPlanSelect.ts
- src/pages/generate/v2/pages/loading/hooks/useGenerateImageRequest.ts


### RecentSheet & FloorPlanSheet 동시 노출 race condition 수정
**문제**
- 배너로 퍼널 진입 후 뒤로가기 → 홈 → 홈에서 도면을 클릭해 퍼널 진입 시 RecentSheet와 FloorPlanSheet가 동시에 뜸. 
- useRecentFloorPlanQuery 데이터가 React Query 캐시에 남아있어 첫 렌더부터 truthy → 두 useEffect가 같은 mount commit에서 race. 두 번째 effect의 store 변수가 첫 렌더의 stale snapshot이라 첫 effect의 openFloorPlanSheet()가 반영 안 됨.

**해결**
- RecentSheet 자동 오픈 effect에서 store.isFloorPlanSheetOpen 대신 useFloorPlanStore.getState().isFloorPlanSheetOpen으로 zustand 최신값을 동기적으로 읽도록 변경

**변경 파일**
- src/pages/imageSetup/v2/hooks/useFloorPlanSelect.ts
- 코드 주석 참고

### 이탈 가드 Popup이 바텀시트 위에서 클릭 안 되는 문제

**문제**
- 바텀시트가 떠 있는 상태에서 브라우저 기본 뒤로가기 → 이탈 Popup이 시각적으로는 뜨지만 클릭이 안 됨. 
- vaul Drawer.Root의 modal=true가 outside elements(overlay-kit으로 띄운 Popup)의 pointer-events를 차단하기 때문
- z-index는 popup(600 + 1) > sheet(550)으로 정상이지만 vaul/Radix Dialog가 outside 트리에 차단을 거는 게 원인

**해결**
- 이탈 가드 Popup이 표시되는 동안 시트들을 일시 close하고, '계속 입력하기' 클릭 시 원상 복구
  -  useFloorPlanStore에 `pauseSheets`, `restoreSheets(snapshot)` 메서드 추가
  - FunnelLayout의 onBlocked 콜백에서 snapshot 저장 → pauseSheets() → popup 표시 → stay 시 restoreSheets(snapshot)
  - 바텀시트가 popup의 pointer-events를 차단하는 문제를 수정하는게 가장 깔끔하지만, 이 문제를 해결하기 위해서는 `상품 탭`에서 바텀시트가 뒷배경과 상호작용 가능하도록 만드는 style 속성인 `backgroundInteractable`을 수정해야 함 -> 수정이 연쇄적으로 발생해 수정 볼륨이 커짐 => 우회책으로 퍼널에서 뒤로가기 시 바텀시트를 일시적으로 닫고 이탈 방지 팝업을 띄우는 방식 선택

**변경 파일**
- src/pages/imageSetup/v2/stores/useFloorPlanStore.ts
- src/pages/imageSetup/components/layout/FunnelLayout.tsx



_해당 PR에 수행한 작업을 작성해주세요._

## 🔍 To Reviewer

- 

_리뷰어에게 요청하는 내용을 작성해주세요._

## 📸 Screenshot

-

_작업한 내용에 대한 스크린샷을 첨부해주세요._
