### PR TITLE
[fix] QA 반영 및 찜 API 연동

### DIFF
--- a/src/pages/generate/v2/pages/result/components/curation/CurationResult.css.ts
+++ b/src/pages/generate/v2/pages/result/components/curation/CurationResult.css.ts
@@ -40,9 +40,16 @@ export const content = style({
 export const chipList = style({
   display: 'flex',
   flexDirection: 'row',
-  flexWrap: 'wrap',
+  flexWrap: 'nowrap',
   gap: unitVars.unit.gapPadding['200'],
   width: '100%',
+  overflowX: 'auto',
+  overflowY: 'hidden',
+  selectors: {
+    '&::-webkit-scrollbar': {
+      display: 'none',
+    },
+  },
 });
 
 export const productList = style({

--- a/src/pages/generate/v2/pages/result/components/curation/CurationResult.tsx
+++ b/src/pages/generate/v2/pages/result/components/curation/CurationResult.tsx
@@ -183,9 +183,7 @@ const CurationResult = ({
                           discountRate: p.discountRate,
                         }}
                         save={{
-                          isSaved:
-                            savedProductIds.has(rawProductId) ||
-                            Boolean(p.isLiked),
+                          isSaved: savedProductIds.has(rawProductId),
                           onToggle: () => toggleJjym(rawProductId),
                         }}
                         link={{

--- a/src/pages/generate/v2/pages/result/components/curation/CurationResult.tsx
+++ b/src/pages/generate/v2/pages/result/components/curation/CurationResult.tsx
@@ -3,8 +3,12 @@ import { useEffect, useState } from 'react';
 import { useCurationCategoriesQuery } from '@pages/generate/v2/apis/queries/useCurationCategoriesQuery';
 import { useCurationProductsQuery } from '@pages/generate/v2/apis/queries/useCurationProductsQuery';
 
+import { useSavedItemsStore } from '@store/useSavedItemsStore';
+
 import Chip from '@shared/components/v2/chip/Chip';
 import ProductCard from '@shared/components/v2/productCard/ProductCard';
+
+import { useJjymMutation } from '@apis/mutations/useJjymMutation';
 
 import InlineError from '@components/inlineError/InlineError';
 import Loading from '@components/loading/Loading';
@@ -60,6 +64,8 @@ const CurationResult = ({
   } = useCurationProductsQuery(currentImageId, selectedCategoryId ?? 0);
   const products = productsData?.products ?? [];
   const categories = categoriesData?.categories ?? [];
+  const { mutate: toggleJjym } = useJjymMutation();
+  const savedProductIds = useSavedItemsStore((s) => s.savedProductIds);
 
   const showCategoriesEmptyUnexpected =
     !isCategoriesLoading && !isCategoriesError && categories.length === 0;
@@ -158,6 +164,7 @@ const CurationResult = ({
                     if (p == null) return null;
                     const key = p.id ?? p.productId ?? `product-${index}`;
                     const href = p.linkUrl ?? '';
+                    const rawProductId = p.id ?? p.productId;
                     return (
                       <ProductCard
                         key={key}
@@ -175,8 +182,13 @@ const CurationResult = ({
                           discountRate: p.discountRate,
                         }}
                         save={{
-                          isSaved: Boolean(p.isLiked),
-                          onToggle: () => {},
+                          isSaved:
+                            (rawProductId != null &&
+                              savedProductIds.has(rawProductId)) ||
+                            Boolean(p.isLiked),
+                          onToggle: () => {
+                            if (rawProductId != null) toggleJjym(rawProductId);
+                          },
                         }}
                         link={{
                           href,

--- a/src/pages/generate/v2/pages/result/components/curation/CurationResult.tsx
+++ b/src/pages/generate/v2/pages/result/components/curation/CurationResult.tsx
@@ -157,6 +157,7 @@ const CurationResult = ({
                     const p = wrapper.product;
                     if (p == null) return null;
                     const key = p.id ?? p.productId ?? `product-${index}`;
+                    const href = p.linkUrl ?? '';
                     return (
                       <ProductCard
                         key={key}
@@ -178,10 +179,11 @@ const CurationResult = ({
                           onToggle: () => {},
                         }}
                         link={{
-                          href: p.linkUrl ?? '',
-                          onClick: () => {},
+                          href,
+                          onClick: () =>
+                            href &&
+                            window.open(href, '_blank', 'noopener,noreferrer'),
                         }}
-                        enableWholeCardLink={Boolean(p.linkUrl)}
                       />
                     );
                   })

--- a/src/pages/generate/v2/pages/result/components/curation/CurationResult.tsx
+++ b/src/pages/generate/v2/pages/result/components/curation/CurationResult.tsx
@@ -159,12 +159,13 @@ const CurationResult = ({
               {!isProductsLoading &&
               !isProductsError &&
               !showProductsEmptyUnexpected
-                ? products.map((wrapper, index) => {
+                ? products.map((wrapper) => {
                     const p = wrapper.product;
                     if (p == null) return null;
-                    const key = p.id ?? p.productId ?? `product-${index}`;
                     const href = p.linkUrl ?? '';
-                    const rawProductId = p.id ?? p.productId;
+                    const rawProductId = p.id;
+                    if (rawProductId == null) return null;
+                    const key = rawProductId;
                     return (
                       <ProductCard
                         key={key}
@@ -183,12 +184,9 @@ const CurationResult = ({
                         }}
                         save={{
                           isSaved:
-                            (rawProductId != null &&
-                              savedProductIds.has(rawProductId)) ||
+                            savedProductIds.has(rawProductId) ||
                             Boolean(p.isLiked),
-                          onToggle: () => {
-                            if (rawProductId != null) toggleJjym(rawProductId);
-                          },
+                          onToggle: () => toggleJjym(rawProductId),
                         }}
                         link={{
                           href,

--- a/src/pages/generate/v2/pages/result/components/list/ListResult.tsx
+++ b/src/pages/generate/v2/pages/result/components/list/ListResult.tsx
@@ -40,35 +40,42 @@ const ListResult = ({ image }: ListResultProps) => {
         <div className={styles.section}>
           <h1 className={styles.sectionTitle}>선택한 상품</h1>
           <div className={styles.flexContent}>
-            {selectedProducts.map((item) => (
-              <ListProductCard
-                key={item.id}
-                cardSize="m"
-                product={{
-                  title: item.name!,
-                  imageUrl: item.imageUrl!,
-                  colorHexes: (item.colors ?? []).map((color) => color.value!),
-                }}
-                price={{
-                  original: item.originalPrice!,
-                  discount: item.finalPrice!,
-                  discountRate: item.discountRate!,
-                }}
-                save={{
-                  isSaved:
-                    (item.id != null && savedProductIds.has(item.id)) ||
-                    Boolean(item.isLiked),
-                  onToggle: () => {
-                    if (item.id != null) toggleJjym(item.id);
-                  },
-                }}
-                link={{
-                  href: item.linkUrl!,
-                  onClick: () => {},
-                }}
-                enableWholeCardLink={true}
-              />
-            ))}
+            {selectedProducts.map((item) => {
+              const href = item.linkUrl ?? '';
+
+              return (
+                <ListProductCard
+                  key={item.id}
+                  cardSize="m"
+                  product={{
+                    title: item.name!,
+                    imageUrl: item.imageUrl!,
+                    colorHexes: (item.colors ?? []).map(
+                      (color) => color.value!
+                    ),
+                  }}
+                  price={{
+                    original: item.originalPrice!,
+                    discount: item.finalPrice!,
+                    discountRate: item.discountRate!,
+                  }}
+                  save={{
+                    isSaved:
+                      (item.id != null && savedProductIds.has(item.id)) ||
+                      Boolean(item.isLiked),
+                    onToggle: () => {
+                      if (item.id != null) toggleJjym(item.id);
+                    },
+                  }}
+                  link={{
+                    href,
+                    onClick: () =>
+                      href &&
+                      window.open(href, '_blank', 'noopener,noreferrer'),
+                  }}
+                />
+              );
+            })}
           </div>
         </div>
         <div className={styles.section}>
@@ -76,36 +83,43 @@ const ListResult = ({ image }: ListResultProps) => {
             방금 담은 스타일과 비슷한 상품
           </h1>
           <div className={styles.gridContent}>
-            {similarProducts.map((item) => (
-              <ProductCard
-                key={item.id}
-                product={{
-                  brand: item.brand!,
-                  title: item.name!,
-                  imageUrl: item.imageUrl!,
-                  colorHexes: (item.colors ?? []).map((color) => color.value!),
-                }}
-                price={{
-                  original: item.originalPrice!,
-                  discount: item.finalPrice!,
-                  discountRate: item.discountRate!,
-                }}
-                save={{
-                  isSaved:
-                    (item.id != null && savedProductIds.has(item.id)) ||
-                    Boolean(item.isLiked),
-                  onToggle: () => {
-                    if (item.id != null) toggleJjym(item.id);
-                  },
-                  count: item.jjymCount!,
-                }}
-                link={{
-                  href: item.linkUrl!,
-                  onClick: () => {},
-                }}
-                enableWholeCardLink={true}
-              />
-            ))}
+            {similarProducts.map((item) => {
+              const href = item.linkUrl ?? '';
+
+              return (
+                <ProductCard
+                  key={item.id}
+                  product={{
+                    brand: item.brand!,
+                    title: item.name!,
+                    imageUrl: item.imageUrl!,
+                    colorHexes: (item.colors ?? []).map(
+                      (color) => color.value!
+                    ),
+                  }}
+                  price={{
+                    original: item.originalPrice!,
+                    discount: item.finalPrice!,
+                    discountRate: item.discountRate!,
+                  }}
+                  save={{
+                    isSaved:
+                      (item.id != null && savedProductIds.has(item.id)) ||
+                      Boolean(item.isLiked),
+                    onToggle: () => {
+                      if (item.id != null) toggleJjym(item.id);
+                    },
+                    count: item.jjymCount!,
+                  }}
+                  link={{
+                    href,
+                    onClick: () =>
+                      href &&
+                      window.open(href, '_blank', 'noopener,noreferrer'),
+                  }}
+                />
+              );
+            })}
           </div>
         </div>
         <div className={styles.section}>

--- a/src/pages/generate/v2/pages/result/components/list/ListResult.tsx
+++ b/src/pages/generate/v2/pages/result/components/list/ListResult.tsx
@@ -1,6 +1,10 @@
+import { useNavigate } from 'react-router-dom';
+
 import { useGenerateListResultQuery } from '@pages/generate/v2/apis/queries/useGenerateListResultQuery';
 import { useRelatedImagesQuery } from '@pages/generate/v2/apis/queries/useRelatedImagesQuery';
 import { useSimilarItemsQuery } from '@pages/generate/v2/apis/queries/useSimilarItemsQuery';
+
+import { ROUTES } from '@routes/paths';
 
 import { useSavedItemsStore } from '@store/useSavedItemsStore';
 
@@ -15,11 +19,18 @@ import * as styles from './ListResult.css';
 
 import type { ResultImageMeta } from '../../types';
 
+const getGenerateResultPath = (houseId: number, viewType: string) =>
+  `${ROUTES.GENERATE_RESULT}?${new URLSearchParams({
+    houseId: String(houseId),
+    viewType,
+  })}`;
+
 export interface ListResultProps {
   image: ResultImageMeta;
 }
 
 const ListResult = ({ image }: ListResultProps) => {
+  const navigate = useNavigate();
   const { data: listData } = useGenerateListResultQuery(image.imageId);
   const { data: similarData } = useSimilarItemsQuery(image.imageId);
   const { data: relatedData } = useRelatedImagesQuery(image.imageId);
@@ -128,7 +139,18 @@ const ListResult = ({ image }: ListResultProps) => {
           </h1>
           <div className={styles.gridContent}>
             {includedImages.map((item) => (
-              <StyleCard key={item.id} imageSrc={item.imageUrl!} size="s" />
+              <StyleCard
+                key={item.id}
+                imageSrc={item.imageUrl!}
+                size="s"
+                onClick={() => {
+                  if (item.id == null || item.resultType == null) return;
+
+                  navigate(getGenerateResultPath(item.id, item.resultType), {
+                    state: { imageUrl: item.imageUrl },
+                  });
+                }}
+              />
             ))}
           </div>
         </div>

--- a/src/pages/generate/v2/pages/result/components/list/ListResult.tsx
+++ b/src/pages/generate/v2/pages/result/components/list/ListResult.tsx
@@ -52,11 +52,14 @@ const ListResult = ({ image }: ListResultProps) => {
           <h1 className={styles.sectionTitle}>선택한 상품</h1>
           <div className={styles.flexContent}>
             {selectedProducts.map((item) => {
+              const id = item.id;
+              if (id == null) return null;
+
               const href = item.linkUrl ?? '';
 
               return (
                 <ListProductCard
-                  key={item.id}
+                  key={id}
                   cardSize="m"
                   product={{
                     title: item.name!,
@@ -71,12 +74,8 @@ const ListResult = ({ image }: ListResultProps) => {
                     discountRate: item.discountRate!,
                   }}
                   save={{
-                    isSaved:
-                      (item.id != null && savedProductIds.has(item.id)) ||
-                      Boolean(item.isLiked),
-                    onToggle: () => {
-                      if (item.id != null) toggleJjym(item.id);
-                    },
+                    isSaved: savedProductIds.has(id),
+                    onToggle: () => toggleJjym(id),
                   }}
                   link={{
                     href,
@@ -95,11 +94,14 @@ const ListResult = ({ image }: ListResultProps) => {
           </h1>
           <div className={styles.gridContent}>
             {similarProducts.map((item) => {
+              const id = item.id;
+              if (id == null) return null;
+
               const href = item.linkUrl ?? '';
 
               return (
                 <ProductCard
-                  key={item.id}
+                  key={id}
                   product={{
                     brand: item.brand!,
                     title: item.name!,
@@ -114,12 +116,8 @@ const ListResult = ({ image }: ListResultProps) => {
                     discountRate: item.discountRate!,
                   }}
                   save={{
-                    isSaved:
-                      (item.id != null && savedProductIds.has(item.id)) ||
-                      Boolean(item.isLiked),
-                    onToggle: () => {
-                      if (item.id != null) toggleJjym(item.id);
-                    },
+                    isSaved: savedProductIds.has(id),
+                    onToggle: () => toggleJjym(id),
                     count: item.jjymCount!,
                   }}
                   link={{

--- a/src/pages/generate/v2/pages/result/components/list/ListResult.tsx
+++ b/src/pages/generate/v2/pages/result/components/list/ListResult.tsx
@@ -2,6 +2,10 @@ import { useGenerateListResultQuery } from '@pages/generate/v2/apis/queries/useG
 import { useRelatedImagesQuery } from '@pages/generate/v2/apis/queries/useRelatedImagesQuery';
 import { useSimilarItemsQuery } from '@pages/generate/v2/apis/queries/useSimilarItemsQuery';
 
+import { useSavedItemsStore } from '@store/useSavedItemsStore';
+
+import { useJjymMutation } from '@apis/mutations/useJjymMutation';
+
 import ListProductCard from '@/shared/components/v2/productCard/ListProductCard';
 import ProductCard from '@/shared/components/v2/productCard/ProductCard';
 import StyleCard from '@/shared/components/v2/styleCard/StyleCard';
@@ -26,6 +30,8 @@ const ListResult = ({ image }: ListResultProps) => {
   const includedImages = (relatedData?.images ?? []).filter(
     (item) => item.resultType === 'LIST' || item.resultType === 'RECOMMEND'
   );
+  const { mutate: toggleJjym } = useJjymMutation();
+  const savedProductIds = useSavedItemsStore((s) => s.savedProductIds);
 
   return (
     <div className={styles.root}>
@@ -49,8 +55,12 @@ const ListResult = ({ image }: ListResultProps) => {
                   discountRate: item.discountRate!,
                 }}
                 save={{
-                  isSaved: item.isLiked!,
-                  onToggle: () => {},
+                  isSaved:
+                    (item.id != null && savedProductIds.has(item.id)) ||
+                    Boolean(item.isLiked),
+                  onToggle: () => {
+                    if (item.id != null) toggleJjym(item.id);
+                  },
                 }}
                 link={{
                   href: item.linkUrl!,
@@ -81,8 +91,12 @@ const ListResult = ({ image }: ListResultProps) => {
                   discountRate: item.discountRate!,
                 }}
                 save={{
-                  isSaved: item.isLiked!,
-                  onToggle: () => {},
+                  isSaved:
+                    (item.id != null && savedProductIds.has(item.id)) ||
+                    Boolean(item.isLiked),
+                  onToggle: () => {
+                    if (item.id != null) toggleJjym(item.id);
+                  },
                   count: item.jjymCount!,
                 }}
                 link={{

--- a/src/pages/home/apis/queries/useProductDetailQuery.ts
+++ b/src/pages/home/apis/queries/useProductDetailQuery.ts
@@ -8,23 +8,23 @@ import { API_ENDPOINT } from '@constants/apiEndpoints';
 import { queryKeys } from '@constants/queryKey';
 
 export const getProductDetail = async (
-  productId: number
+  id: number
 ): Promise<CurationProductDetailResponse> => {
   return request<CurationProductDetailResponse>({
     method: HTTPMethod.GET,
-    url: API_ENDPOINT.PRODUCT.DETAIL(productId),
+    url: API_ENDPOINT.PRODUCT.DETAIL(id),
   });
 };
 
 export const useProductDetailQuery = (
-  productId: number,
+  id: number,
   options?: { enabled?: boolean }
 ) => {
   const enabled = options?.enabled ?? true;
 
   return useQuery({
-    queryKey: queryKeys.product.productDetail(productId),
-    queryFn: () => getProductDetail(productId),
+    queryKey: queryKeys.product.productDetail(id),
+    queryFn: () => getProductDetail(id),
     enabled,
     staleTime: 1000 * 60,
     gcTime: 1000 * 60 * 10,

--- a/src/pages/home/components/product/ProductPopup/ProductDetailCard.tsx
+++ b/src/pages/home/components/product/ProductPopup/ProductDetailCard.tsx
@@ -31,6 +31,10 @@ const ProductDetailCard = ({
     getPriceTexts(price?.original, price?.discount, price?.discountRate);
 
   const linkHref = linkHrefOverride ?? link?.href;
+  const hasDiscount =
+    typeof price?.discountRate === 'number' &&
+    Number.isFinite(price.discountRate) &&
+    price.discountRate > 0;
 
   return (
     <div className={styles.popupPreviewCard}>
@@ -103,17 +107,17 @@ const ProductDetailCard = ({
         <p className={styles.popupPreviewTitle}>{product.title}</p>
         {(originalPriceText || discountPriceText) && (
           <div className={styles.popupPreviewPriceSection}>
-            {originalPriceText && (
+            {hasDiscount && originalPriceText ? (
               <p className={styles.popupPreviewOriginalPrice}>
                 {originalPriceText}
               </p>
-            )}
+            ) : null}
             <div className={styles.popupPreviewDiscountRow}>
-              {discountRateText && (
+              {hasDiscount && discountRateText ? (
                 <span className={styles.popupPreviewDiscountRate}>
                   {discountRateText}
                 </span>
-              )}
+              ) : null}
               {discountPriceText && (
                 <span className={styles.popupPreviewDiscountPrice}>
                   {discountPriceText}

--- a/src/pages/home/components/product/ProductPopup/ProductDetailCard.tsx
+++ b/src/pages/home/components/product/ProductPopup/ProductDetailCard.tsx
@@ -91,7 +91,7 @@ const ProductDetailCard = ({
               <div className={styles.popupPreviewLikeRow}>
                 <Icon name="HeartFillGray" size="14" />
                 <span className={styles.popupPreviewLikeCount}>
-                  {saveCount.toLocaleString('ko-KR')}
+                  {saveCount}
                 </span>
               </div>
             ) : null}

--- a/src/pages/home/components/product/ProductPopup/ProductDetailCard.tsx
+++ b/src/pages/home/components/product/ProductPopup/ProductDetailCard.tsx
@@ -95,7 +95,7 @@ const ProductDetailCard = ({
               <div className={styles.popupPreviewLikeRow}>
                 <Icon name="HeartFillGray" size="14" />
                 <span className={styles.popupPreviewLikeCount}>
-                  {saveCount}
+                  {saveCount.toLocaleString('ko-KR')}
                 </span>
               </div>
             ) : null}

--- a/src/pages/home/components/product/ProductPopup/ProductDetailOverlay.tsx
+++ b/src/pages/home/components/product/ProductPopup/ProductDetailOverlay.tsx
@@ -69,8 +69,15 @@ const ProductDetailOverlay = ({
 
     const linkHrefOverride = detail?.linkUrl ?? link?.href;
 
-    return { product, price, linkHrefOverride };
-  }, [detail, link?.href, listPrice, listProduct]);
+    const saveCount =
+      detail != null
+        ? detail.jjymCount
+        : save.count != null && save.count > 0
+          ? save.count
+          : undefined;
+
+    return { product, price, linkHrefOverride, saveCount };
+  }, [detail, link?.href, listPrice, listProduct, save.count]);
 
   const isSaved =
     savedProductIds.has(id) || Boolean(detail?.isLiked) || save.isSaved;
@@ -96,7 +103,7 @@ const ProductDetailOverlay = ({
         <ProductDetailCard
           product={merged.product}
           price={merged.price}
-          saveCount={save.count}
+          saveCount={merged.saveCount}
           link={link}
           linkHrefOverride={merged.linkHrefOverride}
         />

--- a/src/pages/home/components/product/ProductPopup/ProductDetailOverlay.tsx
+++ b/src/pages/home/components/product/ProductPopup/ProductDetailOverlay.tsx
@@ -79,8 +79,7 @@ const ProductDetailOverlay = ({
     return { product, price, linkHrefOverride, saveCount };
   }, [detail, link?.href, listPrice, listProduct, save.count]);
 
-  const isSaved =
-    savedProductIds.has(id) || Boolean(detail?.isLiked) || save.isSaved;
+  const isSaved = savedProductIds.has(id);
 
   const handleSaveToggle = () => {
     toggleJjym(id);

--- a/src/pages/home/components/product/ProductPopup/ProductDetailOverlay.tsx
+++ b/src/pages/home/components/product/ProductPopup/ProductDetailOverlay.tsx
@@ -2,6 +2,8 @@ import { useMemo } from 'react';
 
 import { useProductDetailQuery } from '@pages/home/apis/queries/useProductDetailQuery';
 
+import { useSavedItemsStore } from '@store/useSavedItemsStore';
+
 import type { ProductColorDetail } from '@shared/apis/__generated__/data-contracts';
 import Popup from '@shared/components/v2/popup/Popup';
 import type {
@@ -11,11 +13,13 @@ import type {
   SaveInfo,
 } from '@shared/types/productCard';
 
+import { useJjymMutation } from '@apis/mutations/useJjymMutation';
+
 import ProductDetailCard from './ProductDetailCard';
 
 interface ProductDetailOverlayProps {
   unmount: () => void;
-  detailProductId: number;
+  id: number;
   product: ProductInfo;
   price?: PriceInfo;
   save: SaveInfo;
@@ -29,15 +33,17 @@ interface ProductDetailOverlayProps {
 
 const ProductDetailOverlay = ({
   unmount,
-  detailProductId,
+  id,
   product: listProduct,
   price: listPrice,
   save,
   link,
   shoppingAction,
 }: ProductDetailOverlayProps) => {
-  const { data } = useProductDetailQuery(detailProductId);
+  const { data } = useProductDetailQuery(id);
   const detail = data?.product;
+  const { mutate: toggleJjym } = useJjymMutation();
+  const savedProductIds = useSavedItemsStore((s) => s.savedProductIds);
 
   const merged = useMemo(() => {
     const detailColorHexes =
@@ -66,7 +72,12 @@ const ProductDetailOverlay = ({
     return { product, price, linkHrefOverride };
   }, [detail, link?.href, listPrice, listProduct]);
 
-  const isSaved = detail?.isLiked ?? save.isSaved;
+  const isSaved =
+    savedProductIds.has(id) || Boolean(detail?.isLiked) || save.isSaved;
+
+  const handleSaveToggle = () => {
+    toggleJjym(id);
+  };
 
   return (
     <Popup
@@ -74,13 +85,13 @@ const ProductDetailOverlay = ({
       btnText={shoppingAction?.label ?? '선택'}
       confirmDisabled={shoppingAction?.disabled}
       onClose={unmount}
-      onCancel={save.onToggle}
+      onCancel={handleSaveToggle}
       onConfirm={() => {
         shoppingAction?.onClick();
         unmount();
       }}
       showCloseButton
-      sideIconName={isSaved ? 'HeartFillGray' : 'HeartStrokeGray'}
+      sideIconName={isSaved ? 'HeartFillColor' : 'HeartStrokeGray'}
       content={
         <ProductDetailCard
           product={merged.product}

--- a/src/pages/home/components/product/SearchSection/SearchSection.tsx
+++ b/src/pages/home/components/product/SearchSection/SearchSection.tsx
@@ -31,7 +31,7 @@ interface SearchSectionProps {
     category: ProductFilterChipCategory,
     id: string
   ) => void;
-  selectedProductIds: string[];
+  selectedProductIds: number[];
   onSelectProduct: (product: SelectedProduct) => void;
   productListQueryParams: ProductListQueryVariables;
 }
@@ -146,7 +146,6 @@ const SearchSection = ({
         {products.map(
           ({
             id,
-            detailProductId,
             title,
             brand,
             imageUrl,
@@ -190,8 +189,6 @@ const SearchSection = ({
                 }),
             };
 
-            const canOpenProductDetail = Number.isFinite(detailProductId);
-
             return (
               <ProductCard
                 key={id}
@@ -201,23 +198,19 @@ const SearchSection = ({
                 save={cardSave}
                 link={cardLink}
                 shoppingAction={cardShoppingAction}
-                {...(canOpenProductDetail
-                  ? {
-                      onShoppingViewDetailClick: () => {
-                        overlay.open(({ unmount }) => (
-                          <ProductDetailOverlay
-                            unmount={unmount}
-                            detailProductId={detailProductId}
-                            link={cardLink}
-                            price={cardPrice}
-                            product={cardProduct}
-                            save={cardSave}
-                            shoppingAction={cardShoppingAction}
-                          />
-                        ));
-                      },
-                    }
-                  : {})}
+                onShoppingViewDetailClick={() => {
+                  overlay.open(({ unmount }) => (
+                    <ProductDetailOverlay
+                      unmount={unmount}
+                      id={id}
+                      link={cardLink}
+                      price={cardPrice}
+                      product={cardProduct}
+                      save={cardSave}
+                      shoppingAction={cardShoppingAction}
+                    />
+                  ));
+                }}
               />
             );
           }

--- a/src/pages/home/components/product/SelectedProductSheet/SelectedProductSheet.tsx
+++ b/src/pages/home/components/product/SelectedProductSheet/SelectedProductSheet.tsx
@@ -6,7 +6,7 @@ import Icon from '@shared/components/v2/icon/Icon';
 import * as styles from './SelectedProductSheet.css';
 
 interface SelectedProductItem {
-  id: string;
+  id: number;
   title: string;
   imageUrl?: string;
   originalPrice: number;
@@ -17,7 +17,7 @@ interface SelectedProductItem {
 interface SelectedProductSheetProps {
   expanded: boolean;
   selectedProducts: SelectedProductItem[];
-  onRemoveProduct: (productId: string) => void;
+  onRemoveProduct: (id: number) => void;
   maxCount?: number;
 }
 
@@ -34,8 +34,8 @@ const SelectedProductSheet = ({
   const formatPrice = (price: number) => price.toLocaleString('ko-KR');
 
   const handleRemoveProductClick = useCallback(
-    (productId: string) => {
-      onRemoveProduct(productId);
+    (id: number) => {
+      onRemoveProduct(id);
     },
     [onRemoveProduct]
   );

--- a/src/pages/home/hooks/useProductSearch.ts
+++ b/src/pages/home/hooks/useProductSearch.ts
@@ -11,8 +11,7 @@ import type { ProductListQueryVariables } from '@constants/queryKey';
  * - SearchSection ProductCard 입력 형태를 기준으로 정의한다.
  */
 interface ProductSearchCardItem {
-  id: string;
-  detailProductId: number;
+  id: number;
   title: string;
   brand: string;
   imageUrl: string;
@@ -33,8 +32,7 @@ const toProductSearchCardItems = (
   products
     .filter((product) => product.id != null)
     .map((product) => ({
-      id: String(product.id),
-      detailProductId: product.productId ?? (product.id as number),
+      id: product.id as number,
       title: product.name ?? '',
       brand: product.brand ?? '',
       imageUrl: product.imageUrl ?? '',

--- a/src/pages/home/hooks/useProductSelection.ts
+++ b/src/pages/home/hooks/useProductSelection.ts
@@ -54,10 +54,8 @@ const useProductSelection = () => {
   );
 
   /** 선택된 상품 1개 제거 */
-  const handleRemoveSelectedProduct = useCallback((productId: string) => {
-    setSelectedProducts((prev) =>
-      prev.filter((product) => product.id !== productId)
-    );
+  const handleRemoveSelectedProduct = useCallback((id: number) => {
+    setSelectedProducts((prev) => prev.filter((product) => product.id !== id));
   }, []);
 
   /** "꾸미기" CTA 클릭 시 최소 1개 선택 검증 */

--- a/src/pages/home/types/productTab.ts
+++ b/src/pages/home/types/productTab.ts
@@ -8,7 +8,7 @@ export interface AppliedFilterChip {
 }
 
 export interface SelectedProduct {
-  id: string;
+  id: number;
   title: string;
   brand: string;
   imageUrl?: string;

--- a/src/shared/apis/__generated__/data-contracts.ts
+++ b/src/shared/apis/__generated__/data-contracts.ts
@@ -507,6 +507,11 @@ export interface SoozipRawProductSaveResponse {
   skippedCount?: number;
 }
 
+export interface AdminCurationRawProductColorRequest {
+  rawColorName?: string;
+  clientColorName?: string;
+}
+
 export interface AdminCurationRawProductCreateRequest {
   /** @pattern ^[a-zA-Z0-9][a-zA-Z0-9_-]{0,49}$ */
   source: string;
@@ -541,6 +546,7 @@ export interface AdminCurationRawProductCreateRequest {
   isExposed?: boolean;
   /** @format date-time */
   fetchedAt?: string;
+  colors?: AdminCurationRawProductColorRequest[];
 }
 
 export interface AdminCurationRawProductColorResponse {
@@ -862,6 +868,7 @@ export interface AdminCurationRawProductUpdateRequest {
   isExposed?: boolean;
   /** @format date-time */
   fetchedAt?: string;
+  colors?: AdminCurationRawProductColorRequest[];
 }
 
 export interface AdminCurationRawProductFurnitureTagUpdateRequest {
@@ -1619,6 +1626,8 @@ export interface ProductDetail {
   linkUrl?: string;
   colors?: ProductColorDetail[];
   isLiked?: boolean;
+  /** @format int64 */
+  jjymCount?: number;
 }
 
 export interface ApiResponseCurationProductFilterResponse {

--- a/src/shared/constants/queryKey.ts
+++ b/src/shared/constants/queryKey.ts
@@ -37,8 +37,8 @@ export const queryKeys = {
     productFilters: () => [...queryKeys.product.all, 'productFilters'] as const,
     productList: (params: Omit<ProductListQueryVariables, 'cursor'>) =>
       [...queryKeys.product.all, 'productList', params] as const,
-    productDetail: (productId: number) =>
-      [...queryKeys.product.all, 'productDetail', productId] as const,
+    productDetail: (id: number) =>
+      [...queryKeys.product.all, 'productDetail', id] as const,
   },
 
   // 배너


### PR DESCRIPTION
## 📌 Summary

- close #558

생성 결과(추천형·목록형) QA와 홈 상품 상세 팝업 QA를 반영했습니다.
찜(jjym) API 연동, 사이트 이동, 상세 조회·jjymCount 표시, 할인율 0% UI 처리도 함께 진행했어요.

## 📄 Tasks

- 추천형 결과(CurationResult)
  - 큐레이션 상품 찜 API 연동
  - 사이트 이동 href 연결
  - 카테고리 칩 좌우 스크롤 스타일
- 목록형 결과(ListResult)
  - 찜 API 연동
  - 사이트 이동 버튼
  - 아이템 포함 이미지 페이지 이동 로직
- 홈 상품 상세 팝업
  - useProductDetailQuery 연동
  - 목록 id로 상세 조회
  - 팝업 하트 찜 토글 및 jjymCount 렌더링
  - 상품 선택 시 선택 상품 id를 number로 통일
  - 상세 모달 UI에서 할인율 0%일 때 정가·할인율 숨김 처리
- data-contracts 업데이트
- queryKey 상품 상세 키 추가


## 🔍 To Reviewer

### 상품 상세 조회 시 `productId` 대신 `id`를 사용하는 이유

기존 홈 상품 플로우에서는 목록 API(`CurationProductResponse`)가 내려주는 두 식별자(`id`, `productId`)를 함께 사용하고 있었습니다.

기존 구현 흐름은 아래와 같았어요.

* 목록 카드/선택 상태 → `id`
* 상세 조회 → `product.productId ?? product.id`
* 찜 API → 상세 응답의 `id` 또는 `productId` 우선 사용

즉, 프론트 내부에서 `id`와 `productId`가 혼용되고 있었습니다.

### 실제 문제

QA 과정에서 확인해보니, 상세 API와 찜 API 모두 `productId` 기준으로는 정상 동작하지 않았어요.

#### 상품 상세 조회

기존에는 아래 값으로 상세 API를 호출했습니다.

```ts
product.productId ?? product.id
```

* `GET /api/v1/curations/products/{productId}` → 실패
* `GET /api/v1/curations/products/{id}` → 정상

즉, 상세 API path parameter는 실제로 목록 API의 `id`를 사용해야 했어요. 


#### 찜 API

찜 API(`curation-raw-products/{rawProductId}/jjym`) 역시 동일했어요.
`productId` 기반으로 요청 시 오류가 발생했고, 목록 `id`를 사용할 때만 정상적으로 찜 처리가 가능했습니다.


### 최종 변경사항

프론트 내부 식별자를 목록 API의 `id(number)` 하나로 통일했습니다.

#### 제거한 것

* `detailProductId`
* `rawProductId`
* `product.productId ?? id` 매핑 로직
* `CurationProductResponse.productId` 참조 로직

#### 변경한 것

* `ProductSearchCardItem.id` >> `string` → `number`
* 선택 상품 관련 id (`SelectedProduct`, `selectedProductIds`) >> 모두 `number` 기준 통일
* 상세 조회 >> 항상 목록 `id` 사용
* 찜 API >> 항상 목록 `id` 사용


### 결과적으로 바뀐 점

실제 서버 기준에 맞게 식별자만 변경한 것으로, 비즈니스 흐름 자체에 변경사항은 없습니다!

| 영역       | 이전                | 이후           |
| -------- | ----------------- | ------------ |
| 상세 조회    | `productId ?? id` | 항상 목록 `id`   |
| 찜 API    | `id/productId` 혼용 | 항상 목록 `id`   |
| 선택 상태 비교 | string id 비교      | number id 비교 |
| 상세/찜 식별자 | 여러 필드 혼용          | 단일 `id`      |

---

### 추가로 함께 반영한 내용

QA 진행하면서 아래 연동도 같이 정리했습니다.

* 추천형 결과

  * 상품 카드 찜
  * 사이트 이동
  * 카테고리 칩 가로 스크롤

* 목록형 결과

  * 선택/비슷한 상품 찜
  * 사이트 이동
  * 관련 이미지 클릭 시 `ResultPage` 이동

* 홈 상품 상세 팝업

  * `useJjymMutation` 패턴 적용
  * 팝업 내부 찜 상태 연동
  * store 기반 찜 상태 반영 (`useSavedItemsStore`)


## 📸 Screenshot

.
