### PR TITLE
[feat] 로그인 게이트 SSOT 적용 및 overlay-kit 컨텍스트 충돌 해결 + 컴포넌트 책임 비대화: 흐름이 effect와 implicit shared state로 흩어지는 문제 정리

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,7 +1,6 @@
 // import { StrictMode } from 'react';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
-import { OverlayProvider } from 'overlay-kit';
 import { createRoot } from 'react-dom/client';
 import { ErrorBoundary } from 'react-error-boundary';
 import { HelmetProvider } from 'react-helmet-async';
@@ -48,11 +47,9 @@ createRoot(rootElement, getSentryReactErrorHandlerOptions()).render(
   <ErrorBoundary FallbackComponent={AppErrorFallback}>
     <HelmetProvider>
       <QueryClientProvider client={queryClient}>
-        <OverlayProvider>
-          <App />
-          <MainToaster />
-          {import.meta.env.DEV && <ReactQueryDevtools initialIsOpen={false} />}
-        </OverlayProvider>
+        <App />
+        <MainToaster />
+        {import.meta.env.DEV && <ReactQueryDevtools initialIsOpen={false} />}
       </QueryClientProvider>
     </HelmetProvider>
   </ErrorBoundary>

--- a/src/pages/banner/BannerDetailPage.tsx
+++ b/src/pages/banner/BannerDetailPage.tsx
@@ -1,13 +1,12 @@
 import { useEffect, useId, useState } from 'react';
 
-import { useLocation, useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 
 import { useBannerDetailQuery } from '@pages/home/apis/queries/useBannerDetailQuery';
 
 import { ROUTES } from '@routes/paths';
 
 import { ENTRY_ROUTE, useImageFlowStore } from '@store/useImageFlowStore';
-import { useUserStore } from '@store/useUserStore';
 
 import ActionButton from '@shared/components/v2/button/actionButton/ActionButton';
 import Icon from '@shared/components/v2/icon/Icon';
@@ -16,7 +15,7 @@ import TitleNavBar from '@shared/components/v2/navBar/TitleNavBar';
 import InlineError from '@components/inlineError/InlineError';
 import Loading from '@components/loading/Loading';
 
-import { setLoginRedirect } from '@utils/loginRedirect';
+import { useLoginGate } from '@hooks/useLoginGate';
 
 import StyleCard from '@/shared/components/v2/styleCard/StyleCard';
 
@@ -24,11 +23,10 @@ import * as styles from './BannerDetailPage.css';
 
 const BannerDetailPage = () => {
   const navigate = useNavigate();
-  const location = useLocation();
+  const { requireLogin } = useLoginGate();
   const { bannerId = '' } = useParams<{ bannerId: string }>();
   const questionId = useId();
   const [selectedAnswerId, setSelectedAnswerId] = useState<number | null>(null);
-  const isLoggedIn = !!useUserStore((state) => state.accessToken);
   const parsedBannerId = Number(bannerId);
   const {
     data: bannerDetail,
@@ -88,13 +86,7 @@ const BannerDetailPage = () => {
       },
     });
 
-    if (isLoggedIn) {
-      navigate(ROUTES.IMAGE_SETUP);
-    } else {
-      // pathname과 쿼리 파라미터 모두 저장
-      setLoginRedirect(location.pathname + location.search);
-      navigate(ROUTES.LOGIN);
-    }
+    requireLogin(() => navigate(ROUTES.IMAGE_SETUP));
   };
 
   return (

--- a/src/pages/generate/v2/pages/result/components/curation/CurationResult.tsx
+++ b/src/pages/generate/v2/pages/result/components/curation/CurationResult.tsx
@@ -187,12 +187,7 @@ const CurationResult = ({
                           isSaved: getSavedState(rawProductId, p.isLiked),
                           onToggle: () => toggleJjym(rawProductId),
                         }}
-                        link={{
-                          href,
-                          onClick: () =>
-                            href &&
-                            window.open(href, '_blank', 'noopener,noreferrer'),
-                        }}
+                        link={{ href }}
                       />
                     );
                   })

--- a/src/pages/generate/v2/pages/result/components/list/ListResult.tsx
+++ b/src/pages/generate/v2/pages/result/components/list/ListResult.tsx
@@ -120,12 +120,7 @@ const ListResult = ({ image, isProductView }: ListResultProps) => {
                     isSaved: getSavedState(id, item.isLiked),
                     onToggle: () => toggleJjym(id),
                   }}
-                  link={{
-                    href,
-                    onClick: () =>
-                      href &&
-                      window.open(href, '_blank', 'noopener,noreferrer'),
-                  }}
+                  link={{ href }}
                 />
               );
             })}
@@ -163,12 +158,7 @@ const ListResult = ({ image, isProductView }: ListResultProps) => {
                     onToggle: () => toggleJjym(id),
                     count: item.jjymCount!,
                   }}
-                  link={{
-                    href,
-                    onClick: () =>
-                      href &&
-                      window.open(href, '_blank', 'noopener,noreferrer'),
-                  }}
+                  link={{ href }}
                 />
               );
             })}

--- a/src/pages/home/HomePage.tsx
+++ b/src/pages/home/HomePage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate, useSearchParams } from 'react-router-dom';
 
 import { useMyPageUserQuery } from '@pages/mypage/apis/queries/useMyPageUserQuery';
 
@@ -34,6 +34,8 @@ const HomePage = () => {
   const isLoggedIn = !!accessToken;
   const location = useLocation();
   const homeState = location.state as HomeLocationState | undefined;
+  const [searchParams, setSearchParams] = useSearchParams();
+  const tabParam = searchParams.get('tab');
 
   // 외부 진입(로그인 복귀/ResultPage 재선택) 흐름 감지:
   // useImageFlowStore.preset.type === 'product'이고 productsToBeRestored이 비어있지 않으면
@@ -45,9 +47,25 @@ const HomePage = () => {
   }, []);
 
   const [activeMenuTab, setActiveMenuTab] = useState<HomeMenuTab>(
-    homeState?.activeTab ??
-      (presetHasProductsToBeRestored ? 'product' : 'explore')
+    tabParam === 'product' || tabParam === 'explore'
+      ? tabParam
+      : (homeState?.activeTab ??
+          (presetHasProductsToBeRestored ? 'product' : 'explore'))
   );
+
+  // 탭 전환 시 URL ?tab= 에 반영 → 로그인 게이트로 이탈했다 복귀해도 같은 탭으로 돌아옴
+  const handleTabChange = (tab: HomeMenuTab) => {
+    setActiveMenuTab(tab);
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        if (tab === 'product') next.set('tab', 'product');
+        else next.delete('tab');
+        return next;
+      },
+      { replace: true }
+    );
+  };
 
   const scrollDepth50Sent = useRef(false);
   const scrollDepth100Sent = useRef(false);
@@ -127,7 +145,7 @@ const HomePage = () => {
         ]}
         activeTab={activeMenuTab}
         sticky={activeMenuTab === 'explore'}
-        onTabChange={setActiveMenuTab}
+        onTabChange={handleTabChange}
       />
       {activeMenuTab === 'explore' && (
         <ExploreTab exploreSeedBannerId={homeState?.exploreSeedBannerId} />

--- a/src/pages/home/components/product/ProductPopup/ProductDetailCard.tsx
+++ b/src/pages/home/components/product/ProductPopup/ProductDetailCard.tsx
@@ -9,6 +9,8 @@ import type {
 
 import CardImage from '@assets/images/cardExImg.svg?url';
 
+import { useProductLink } from '@hooks/useProductLink';
+
 import { getColorChips, getPriceTexts } from '@utils/productCardUtils';
 
 export interface ProductDetailCardProps {
@@ -26,6 +28,7 @@ const ProductDetailCard = ({
   link,
   linkHrefOverride,
 }: ProductDetailCardProps) => {
+  const { openProductLink } = useProductLink();
   const { visibleColors, extraColorCount } = getColorChips(product.colorHexes);
   const { originalPriceText, discountPriceText, discountRateText } =
     getPriceTexts(price?.original, price?.discount, price?.discountRate);
@@ -52,13 +55,7 @@ const ProductDetailCard = ({
               size="XS"
               leftIcon="Link"
               aria-label="공식 사이트로 이동"
-              onClick={() => {
-                if (link?.onClick) {
-                  link.onClick();
-                  return;
-                }
-                window.open(linkHref, '_blank', 'noopener,noreferrer');
-              }}
+              onClick={() => openProductLink(linkHref, link?.onClick)}
             >
               {link?.label || '사이트'}
             </ActionButton>

--- a/src/pages/home/components/product/ProductPopup/ProductDetailOverlay.tsx
+++ b/src/pages/home/components/product/ProductPopup/ProductDetailOverlay.tsx
@@ -86,6 +86,10 @@ const ProductDetailOverlay = ({
     return { product, price, linkHrefOverride, saveCount };
   }, [detail, link?.href, listPrice, listProduct, save.count]);
 
+  // nav effect가 매 렌더 새 merged 객체 때문에 재구독되지 않도록 최신값을 ref로 읽음
+  const mergedRef = useRef(merged);
+  mergedRef.current = merged;
+
   const isSaved = savedProductIds.has(id);
 
   const handleSaveToggle = () => {
@@ -99,15 +103,11 @@ const ProductDetailOverlay = ({
 
     // 로그인 게이트 플로우로 진입하는 경우 복귀 후 이 상품 모달을 다시 띄우기 위해 정보 저장
     if (location.pathname === ROUTES.LOGIN) {
-      setReopenProduct({
-        id,
-        product: merged.product,
-        price: merged.price,
-        linkHref: merged.linkHrefOverride,
-      });
+      const { product, price, linkHrefOverride } = mergedRef.current;
+      setReopenProduct({ id, product, price, linkHref: linkHrefOverride });
     }
     unmount();
-  }, [location.pathname, unmount, id, merged]);
+  }, [location.pathname, unmount, id]);
 
   return (
     <Popup

--- a/src/pages/home/components/product/ProductPopup/ProductDetailOverlay.tsx
+++ b/src/pages/home/components/product/ProductPopup/ProductDetailOverlay.tsx
@@ -1,4 +1,6 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
+
+import { useLocation } from 'react-router-dom';
 
 import { useProductDetailQuery } from '@pages/home/apis/queries/useProductDetailQuery';
 
@@ -44,6 +46,16 @@ const ProductDetailOverlay = ({
   const detail = data?.product;
   const { mutate: toggleJjym } = useJjymMutation();
   const savedProductIds = useSavedItemsStore((s) => s.savedProductIds);
+  const location = useLocation();
+  const openedPathRef = useRef(location.pathname);
+
+  // 로그인 게이트가 로그인 페이지로 보내는 등 라우트가 바뀌면 오버레이를 닫음
+  // overlay-kit은 라우트 변경 시 자동으로 닫히지 않으므로 직접 unmount
+  useEffect(() => {
+    if (location.pathname !== openedPathRef.current) {
+      unmount();
+    }
+  }, [location.pathname, unmount]);
 
   const merged = useMemo(() => {
     const detailColorHexes =

--- a/src/pages/home/components/product/ProductPopup/ProductDetailOverlay.tsx
+++ b/src/pages/home/components/product/ProductPopup/ProductDetailOverlay.tsx
@@ -3,6 +3,9 @@ import { useEffect, useMemo, useRef } from 'react';
 import { useLocation } from 'react-router-dom';
 
 import { useProductDetailQuery } from '@pages/home/apis/queries/useProductDetailQuery';
+import { setReopenProduct } from '@pages/home/utils/productDetailOverlayReopen';
+
+import { ROUTES } from '@routes/paths';
 
 import { useSavedItemsStore } from '@store/useSavedItemsStore';
 
@@ -49,14 +52,6 @@ const ProductDetailOverlay = ({
   const location = useLocation();
   const openedPathRef = useRef(location.pathname);
 
-  // 로그인 게이트가 로그인 페이지로 보내는 등 라우트가 바뀌면 오버레이를 닫음
-  // overlay-kit은 라우트 변경 시 자동으로 닫히지 않으므로 직접 unmount
-  useEffect(() => {
-    if (location.pathname !== openedPathRef.current) {
-      unmount();
-    }
-  }, [location.pathname, unmount]);
-
   const merged = useMemo(() => {
     const detailColorHexes =
       detail?.colors
@@ -96,6 +91,23 @@ const ProductDetailOverlay = ({
   const handleSaveToggle = () => {
     toggleJjym(id);
   };
+
+  // 라우트가 바뀌면(ex: 로그인 게이트) 상품상세 오버레이 닫기
+  // overlay-kit은 라우트 변경 시 자동으로 닫히지 않으므로 직접 unmount
+  useEffect(() => {
+    if (location.pathname === openedPathRef.current) return;
+
+    // 로그인 게이트 플로우로 진입하는 경우 복귀 후 이 상품 모달을 다시 띄우기 위해 정보 저장
+    if (location.pathname === ROUTES.LOGIN) {
+      setReopenProduct({
+        id,
+        product: merged.product,
+        price: merged.price,
+        linkHref: merged.linkHrefOverride,
+      });
+    }
+    unmount();
+  }, [location.pathname, unmount, id, merged]);
 
   return (
     <Popup

--- a/src/pages/home/components/product/ProductTab.tsx
+++ b/src/pages/home/components/product/ProductTab.tsx
@@ -1,10 +1,13 @@
 import { useEffect, useMemo } from 'react';
 
+import { overlay } from 'overlay-kit';
+
 import ProductFilterSheet from '@pages/home/components/product/ProductFilterSheet/ProductFilterSheet';
 import {
   MAX_SELECTED_PRODUCTS,
   useProductTabController,
 } from '@pages/home/hooks/useProductTabController';
+import { consumeReopenProduct } from '@pages/home/utils/productDetailOverlayReopen';
 
 import { useImageFlowStore } from '@store/useImageFlowStore';
 
@@ -13,6 +16,7 @@ import DragHandleBottomSheet from '@shared/components/v2/bottomSheet/DragHandleB
 import ActionButton from '@shared/components/v2/button/actionButton/ActionButton';
 
 import IntroSection from './IntroSection/IntroSection';
+import ProductDetailOverlay from './ProductPopup/ProductDetailOverlay';
 import * as styles from './ProductTab.css';
 import SearchSection from './SearchSection/SearchSection';
 import SelectedProductSheet from './SelectedProductSheet/SelectedProductSheet';
@@ -62,6 +66,39 @@ const ProductTab = () => {
     initialSheetExpanded: hasProductsToBeRestored,
     resetFiltersOnMount: hasProductsToBeRestored,
   });
+
+  // 로그인 게이트로 상품 상세 모달이 닫힌 채 복귀한 경우, 저장된 정보로 그 모달을 다시 띄움
+  // 리스트(검색/필터/무한스크롤) 상태에 의존하지 않으므로 깊은 페이지/검색 결과의 상품도 복원됨
+  useEffect(() => {
+    const reopen = consumeReopenProduct();
+    if (!reopen) return;
+
+    overlay.open(({ unmount }) => (
+      <ProductDetailOverlay
+        unmount={unmount}
+        id={reopen.id}
+        product={reopen.product}
+        price={reopen.price}
+        link={{ href: reopen.linkHref }}
+        save={{ isSaved: false, onToggle: () => {} }}
+        shoppingAction={{
+          label: '선택',
+          disabled: selectedProducts.some((p) => p.id === reopen.id),
+          onClick: () =>
+            handleSelectProduct({
+              id: reopen.id,
+              title: reopen.product.title,
+              brand: reopen.product.brand ?? '',
+              imageUrl: reopen.product.imageUrl,
+              originalPrice: reopen.price?.original ?? 0,
+              discountPrice: reopen.price?.discount ?? 0,
+              discountRate: reopen.price?.discountRate ?? 0,
+            }),
+        }}
+      />
+    ));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return (
     <div className={styles.container}>

--- a/src/pages/home/hooks/useProductFilterState.ts
+++ b/src/pages/home/hooks/useProductFilterState.ts
@@ -129,7 +129,8 @@ const useProductFilterState = () => {
     [colorMeta.allId, furnitureMeta.allId, priceMeta.allId]
   );
 
-  /** allId 확정/변경 시 draft를 정규화 */
+  // allId 확정/변경 시 draft 정규화.
+  // 주의(무한루프): allIds 참조 안정 전제(useFilterListQuery staleTime:Infinity). 불안정해지면 setDraftValues가 매 렌더 새 객체 → 루프. 그땐 값 동일 시 set 생략 가드 추가.
   useEffect(() => {
     setDraftValues((prev) =>
       toDraftFromExternal(toExternalFromDraft(prev, allIds), allIds)

--- a/src/pages/home/hooks/useProductTabController.ts
+++ b/src/pages/home/hooks/useProductTabController.ts
@@ -16,11 +16,10 @@ import { useFunnelStore } from '@pages/imageSetup/stores/useFunnelStore';
 import { ROUTES } from '@routes/paths';
 
 import { ENTRY_ROUTE, useImageFlowStore } from '@store/useImageFlowStore';
-import { useUserStore } from '@store/useUserStore';
 
 import { useToast } from '@components/toast/useToast';
 
-import { setLoginRedirect } from '@utils/loginRedirect';
+import { useLoginGate } from '@hooks/useLoginGate';
 
 /**
  * 필터 상단 칩 선택 상태 기본값
@@ -54,6 +53,7 @@ const useProductTabController = ({
 }: UseProductTabControllerOptions = {}) => {
   const navigate = useNavigate();
   const { notify } = useToast();
+  const { requireLogin } = useLoginGate();
 
   /** 바텀시트/칩 UI 상태 */
   const [sheetExpanded, setSheetExpanded] = useState(initialSheetExpanded);
@@ -169,17 +169,9 @@ const useProductTabController = ({
       },
     });
 
-    const isLoggedIn = !!useUserStore.getState().accessToken;
-    if (!isLoggedIn) {
-      setLoginRedirect(ROUTES.HOME);
-      navigate(ROUTES.LOGIN);
-      return;
-
-      // 이후 로그인 복귀 시 HOME으로 이동 -> HomePage가 preset.productsToBeRestored 감지해 상품 탭으로 이동, ProductTab이 store 값을 useState 초기값으로 복원
-    }
-
-    navigate(ROUTES.IMAGE_SETUP);
-  }, [navigate, notify, selectedProducts]);
+    // 로그인 복귀 시 HOME으로 이동 -> HomePage가 preset.productsToBeRestored 감지해 상품 탭으로 이동, ProductTab이 store 값을 useState 초기값으로 복원
+    requireLogin(() => navigate(ROUTES.IMAGE_SETUP));
+  }, [navigate, notify, requireLogin, selectedProducts]);
 
   /** ProductTab에서 사용할 공개 값 */
   return {

--- a/src/pages/home/utils/productDetailOverlayReopen.ts
+++ b/src/pages/home/utils/productDetailOverlayReopen.ts
@@ -1,0 +1,35 @@
+import type { PriceInfo, ProductInfo } from '@shared/types/productCard';
+
+// 로그인 게이트로 ProductDetailOverlay가 닫힌 채 복귀할 때, 그 상품 모달을 다시 띄우기 위한 정보
+// 리스트(검색/필터/무한스크롤) 상태에 의존하지 않도록 모달 재구성에 필요한 데이터를 통째로 보관
+export interface ReopenProduct {
+  id: number;
+  product: ProductInfo;
+  price?: PriceInfo;
+  linkHref?: string;
+}
+
+const STORAGE_KEY = 'productDetailOverlayReopen';
+
+/**
+ * 로그인 게이트로 모달이 닫히기 직전 저장
+ * 카카오 OAuth는 window.location.href로 전체 리로드되어 React 상태가 소멸하므로 sessionStorage 사용
+ */
+export const setReopenProduct = (data: ReopenProduct): void => {
+  sessionStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+};
+
+/**
+ * 저장된 재오픈 정보를 읽고 삭제 (없으면 null)
+ */
+export const consumeReopenProduct = (): ReopenProduct | null => {
+  const raw = sessionStorage.getItem(STORAGE_KEY);
+  sessionStorage.removeItem(STORAGE_KEY);
+  if (!raw) return null;
+
+  try {
+    return JSON.parse(raw) as ReopenProduct;
+  } catch {
+    return null;
+  }
+};

--- a/src/pages/imageSetup/ImageSetupPage.tsx
+++ b/src/pages/imageSetup/ImageSetupPage.tsx
@@ -6,11 +6,12 @@ import { Navigate, useNavigate } from 'react-router-dom';
 import { ROUTES } from '@routes/paths';
 
 import { getNextFunnelStep, useImageFlowStore } from '@store/useImageFlowStore';
-import { useUserStore } from '@store/useUserStore';
 
 import FeatureErrorFallback from '@components/errorFallback/FeatureErrorFallback';
 
-import { getLoginRedirect, setLoginRedirect } from '@utils/loginRedirect';
+import { useLoginGate } from '@hooks/useLoginGate';
+
+import { getLoginRedirect } from '@utils/loginRedirect';
 
 import FunnelLayout from './components/layout/FunnelLayout';
 import { useImageSetup } from './hooks/useImageSetup';
@@ -44,6 +45,7 @@ const StepWrapper = ({ step, onMount, children }: StepWrapperProps) => {
 const ImageSetupPage = () => {
   const funnel = useImageSetup();
   const navigate = useNavigate();
+  const { requireLogin } = useLoginGate();
   const [currentStep, setCurrentStep] = useState<StepType>('FloorPlanSelect');
 
   // 퍼널 데이터 정리 방식
@@ -98,18 +100,9 @@ const ImageSetupPage = () => {
                 const nextStep = getNextFunnelStep(entryRoute);
 
                 if (nextStep === 'INTERIOR_STYLE') {
-                  // 풀퍼널 (경로 1, 3): 로그인 체크 후 다음 스텝으로 이동
-                  const isLoggedIn = !!useUserStore.getState().accessToken;
-
-                  if (!isLoggedIn) {
-                    // 미로그인: 도면 선택값은 useFunnelStore persist로 유지됨
-                    setLoginRedirect(ROUTES.IMAGE_SETUP);
-                    navigate(ROUTES.LOGIN);
-                    return;
-                  }
-
-                  // 퍼널 내에서 다음 스텝(InteriorStyle)으로 이동
-                  history.push('InteriorStyle', data);
+                  // 풀퍼널 (경로 1, 3): 로그인 게이트 통과 후 다음 스텝(InteriorStyle)으로 이동
+                  // 미로그인 시 도면 선택값은 useFunnelStore persist로 유지됨
+                  requireLogin(() => history.push('InteriorStyle', data));
                 } else {
                   // 숏퍼널(경로 2, 4, 5): FloorPlanSelect가 마지막 스텝 → 바로 이미지 생성으로 이동
                   // payload는 LoadingPage가 useImageFlowStore.preset + useFunnelStore.floorPlan으로 조립

--- a/src/pages/imageSetup/steps/activityInfo/ActivityInfo.tsx
+++ b/src/pages/imageSetup/steps/activityInfo/ActivityInfo.tsx
@@ -1,3 +1,5 @@
+import { useRef, useState } from 'react';
+
 import { overlay } from 'overlay-kit';
 
 import { useActivityInfo } from '@pages/imageSetup/hooks/activityInfo/useActivityInfo';
@@ -8,6 +10,8 @@ import ActionButton from '@components/v2/button/actionButton/ActionButton';
 import Chip from '@components/v2/chip/Chip';
 import Icon from '@components/v2/icon/Icon';
 import TextHeading from '@components/v2/textHeading/TextHeading';
+
+import { useExitBlocker } from '@hooks/useExitBlocker';
 
 import * as styles from './ActivityInfo.css';
 import ActivityTypeSheet from './ActivityTypeSheet';
@@ -35,19 +39,41 @@ const ActivityInfo = ({ context }: ActivityInfoProps) => {
     handleSubmit,
   } = useActivityInfo(context);
 
+  const [isSheetOpen, setIsSheetOpen] = useState(false);
+  const sheetIdRef = useRef<string | null>(null);
+
+  const closeSheet = () => {
+    if (sheetIdRef.current) {
+      overlay.unmount(sheetIdRef.current);
+      sheetIdRef.current = null;
+    }
+    setIsSheetOpen(false);
+  };
+
+  // 바텀시트 열린 동안 뒤로가기(NavBar/브라우저/모바일 스와이프) 가로채서
+  // 페이지 이동 대신 바텀시트만 닫기
+  useExitBlocker({
+    enabled: isSheetOpen,
+    onBlocked: ({ reset }) => {
+      closeSheet();
+      reset();
+    },
+  });
+
   const handleActivityTriggerClick = () => {
-    overlay.open(({ unmount }) => (
+    sheetIdRef.current = overlay.open(() => (
       <ActivityTypeSheet
         open
         activities={activities}
         selectedActivityCode={activitySelection.selectedActivityItem?.code}
         onConfirm={(activityCode) => {
           setFormData((prev) => ({ ...prev, activity: activityCode }));
-          unmount();
+          closeSheet();
         }}
-        onClose={unmount}
+        onClose={closeSheet}
       />
     ));
+    setIsSheetOpen(true);
   };
 
   if (isError) return <InlineError onRetry={refetch} />;

--- a/src/pages/imageSetup/v2/steps/floorPlanSelect/FloorPlanSheet.css.ts
+++ b/src/pages/imageSetup/v2/steps/floorPlanSelect/FloorPlanSheet.css.ts
@@ -52,7 +52,7 @@ export const titleMeta = style({
 });
 
 export const swiperContainer = style({
-  aspectRatio: '1 / 1',
+  aspectRatio: '3 / 2',
   position: 'relative',
   borderRadius: unitVars.unit.radius['600'],
   width: '100%',
@@ -60,9 +60,9 @@ export const swiperContainer = style({
 });
 
 export const slideImage = style({
+  aspectRatio: '3 / 2',
   objectFit: 'cover',
   width: '100%',
-  height: '100%',
 });
 
 const navButtonBase = style({

--- a/src/pages/style/StyleDetailPage.tsx
+++ b/src/pages/style/StyleDetailPage.tsx
@@ -1,10 +1,9 @@
-import { useNavigate, useLocation, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 
 import { ROUTES } from '@routes/paths';
 
 import { ENTRY_ROUTE, useImageFlowStore } from '@store/useImageFlowStore';
 import { useSavedItemsStore } from '@store/useSavedItemsStore';
-import { useUserStore } from '@store/useUserStore';
 
 import { useJjymMutation } from '@apis/mutations/useJjymMutation';
 
@@ -17,7 +16,8 @@ import TitleNavBar from '@components/v2/navBar/TitleNavBar';
 import ListCardProduct from '@components/v2/productCard/ListProductCard';
 import StyleCard from '@components/v2/styleCard/StyleCard';
 
-import { setLoginRedirect } from '@utils/loginRedirect';
+import { useLoginGate } from '@hooks/useLoginGate';
+
 import { normalizeColorHexes } from '@utils/normalizeColorHexes';
 
 import { useGetStyleDetailQuery } from './apis/useGetStyleDetailQuery';
@@ -26,8 +26,7 @@ import * as styles from './StyleDetailPage.css';
 const StyleDetailPage = () => {
   const { styleId } = useParams();
   const navigate = useNavigate();
-  const location = useLocation();
-  const isLoggedIn = !!useUserStore((state) => state.accessToken);
+  const { requireLogin } = useLoginGate();
 
   const savedProductIds = useSavedItemsStore((state) => state.savedProductIds);
 
@@ -60,13 +59,7 @@ const StyleDetailPage = () => {
       preset: { type: 'style', styleId: parsedId },
     });
 
-    if (isLoggedIn) {
-      navigate(ROUTES.IMAGE_SETUP);
-    } else {
-      // pathname과 쿼리 파라미터 모두 저장
-      setLoginRedirect(location.pathname + location.search);
-      navigate(ROUTES.LOGIN);
-    }
+    requireLogin(() => navigate(ROUTES.IMAGE_SETUP));
   };
 
   return (

--- a/src/routes/RootLayout.tsx
+++ b/src/routes/RootLayout.tsx
@@ -1,3 +1,4 @@
+import { OverlayProvider } from 'overlay-kit';
 import { Outlet } from 'react-router-dom';
 
 import { useGenerateWarmup } from '@pages/generate/hooks/useGenerateWarmup';
@@ -12,9 +13,11 @@ function RootLayout() {
   useGenerateWarmup();
 
   return (
-    <div className={styles.container}>
-      <Outlet />
-    </div>
+    <OverlayProvider>
+      <div className={styles.container}>
+        <Outlet />
+      </div>
+    </OverlayProvider>
   );
 }
 

--- a/src/shared/apis/mutations/useJjymMutation.ts
+++ b/src/shared/apis/mutations/useJjymMutation.ts
@@ -13,6 +13,8 @@ import { useToast } from '@components/v2/toast/useToast';
 import { API_ENDPOINT } from '@constants/apiEndpoints';
 import { TOAST_ACTION_LABEL, TOAST_MESSAGE } from '@constants/toastMessage';
 
+import { useLoginGate } from '@hooks/useLoginGate';
+
 import { invalidateJjymRelatedQueries } from '@utils/invalidateJjymQueries';
 
 import type { AxiosError } from 'axios';
@@ -55,6 +57,7 @@ const getSavedToastContent = (type: JjymSavedToast) => {
 export const useJjymMutation = (options?: UseJjymMutationOptions) => {
   const toggleSaveProduct = useSavedItemsStore((s) => s.toggleSaveProduct);
   const { notify } = useToast();
+  const { requireLogin } = useLoginGate();
   const savedToastType = options?.savedToastType ?? 'move';
   const removedToastType = options?.removedToastType ?? 'info';
   const shouldInvalidateSavedItemsList =
@@ -76,7 +79,7 @@ export const useJjymMutation = (options?: UseJjymMutationOptions) => {
     );
   };
 
-  return useMutation<SaveItemsResponse, AxiosError, number>({
+  const mutation = useMutation<SaveItemsResponse, AxiosError, number>({
     mutationKey: ['jjym'],
     mutationFn: (rawProductId) => postJjym({ rawProductId }),
 
@@ -143,4 +146,11 @@ export const useJjymMutation = (options?: UseJjymMutationOptions) => {
       toggleSaveProduct(rawProductId);
     },
   });
+
+  // 찜 토글 전 로그인 게이트: 비로그인이면 mutate 미실행 → onMutate 낙관적 업데이트도 일어나지 않음
+  const mutate: typeof mutation.mutate = (rawProductId, mutateOptions) => {
+    requireLogin(() => mutation.mutate(rawProductId, mutateOptions));
+  };
+
+  return { ...mutation, mutate };
 };

--- a/src/shared/components/v2/bottomSheet/DragHandleBottomSheet.tsx
+++ b/src/shared/components/v2/bottomSheet/DragHandleBottomSheet.tsx
@@ -56,7 +56,12 @@ const DragHandleBottomSheet = ({
 }: DragHandleBottomSheetProps) => {
   const isPersistent = collapsedHeight !== undefined;
 
-  const [expanded, setExpanded] = useState(!isPersistent);
+  // 내부 expanded 초기값을 부모 prop과 똑같이 맞춤
+  // 마운트 시 내부(expanded)와 부모(expandedFromParent)가 어긋나면,
+  // 부모→자식(아래 effect)/자식→부모(onExpandedChange effect) 양방향 동기화가
+  // 서로 반대값으로 끊임없이 진동 -> Maximum update depth 오류 발생
+  // expandedFromParent 미전달(Dismissible 모드)이면 기존과 동일하게 !isPersistent.
+  const [expanded, setExpanded] = useState(expandedFromParent ?? !isPersistent);
 
   useEffect(() => {
     if (expandedFromParent !== undefined) {

--- a/src/shared/components/v2/productCard/ListProductCard.tsx
+++ b/src/shared/components/v2/productCard/ListProductCard.tsx
@@ -9,6 +9,8 @@ import type {
 
 import CardImage from '@assets/images/cardExImg.svg?url';
 
+import { useProductLink } from '@hooks/useProductLink';
+
 import {
   createCardClickHandler,
   getColorChips,
@@ -44,6 +46,7 @@ const ListProductCard = ({
 }: ListProductCardProps) => {
   const [isLoaded, setIsLoaded] = useState(false);
   const linkHref = link?.href;
+  const { openProductLink } = useProductLink();
 
   useEffect(() => {
     setIsLoaded(false);
@@ -53,22 +56,14 @@ const ListProductCard = ({
   const { originalPriceText, discountPriceText, discountRateText } =
     getPriceTexts(price?.original, price?.discount, price?.discountRate);
 
+  const handleLinkButtonClick = () => openProductLink(linkHref, link?.onClick);
+
   const { handleWrapperClick, handleWrapperKeyDown } = createCardClickHandler({
     onCardClick,
     enableWholeCardLink,
     linkHref,
+    onNavigate: handleLinkButtonClick,
   });
-
-  const handleLinkButtonClick = () => {
-    if (link?.onClick) {
-      link.onClick();
-      return;
-    }
-
-    if (linkHref && typeof window !== 'undefined') {
-      window.open(linkHref, '_blank', 'noopener,noreferrer');
-    }
-  };
 
   return (
     <div

--- a/src/shared/components/v2/productCard/ProductCard.tsx
+++ b/src/shared/components/v2/productCard/ProductCard.tsx
@@ -9,6 +9,8 @@ import type {
 
 import CardImage from '@assets/images/cardExImg.svg?url';
 
+import { useProductLink } from '@hooks/useProductLink';
+
 import {
   createCardClickHandler,
   getColorChips,
@@ -55,6 +57,7 @@ const ProductCard = ({
   const isDefault = cardType === 'default';
   const [isLoaded, setIsLoaded] = useState(false);
   const linkHref = link?.href;
+  const { openProductLink } = useProductLink();
 
   useEffect(() => {
     setIsLoaded(false);
@@ -64,10 +67,13 @@ const ProductCard = ({
   const { originalPriceText, discountPriceText, discountRateText } =
     getPriceTexts(price?.original, price?.discount, price?.discountRate);
 
+  const handleLinkClick = () => openProductLink(linkHref, link?.onClick);
+
   const { handleWrapperClick, handleWrapperKeyDown } = createCardClickHandler({
     onCardClick,
     enableWholeCardLink,
     linkHref,
+    onNavigate: handleLinkClick,
   });
 
   return (
@@ -105,7 +111,7 @@ const ProductCard = ({
               size="XS"
               leftIcon="Link"
               aria-label={'공식 사이트로 이동'}
-              onClick={link?.onClick}
+              onClick={handleLinkClick}
             >
               {link?.label || '사이트'}
             </ActionButton>

--- a/src/shared/hooks/useLoginGate.ts
+++ b/src/shared/hooks/useLoginGate.ts
@@ -1,0 +1,36 @@
+import { useCallback } from 'react';
+
+import { useLocation, useNavigate } from 'react-router-dom';
+
+import { ROUTES } from '@routes/paths';
+
+import { useUserStore } from '@store/useUserStore';
+
+import { setLoginRedirect } from '@utils/loginRedirect';
+
+/**
+ * 로그인 게이트 진입 관리 훅
+ * - 로그인 상태면 action 실행
+ * - 비로그인이면 현재 경로를 저장하고 로그인 페이지로 이동 (로그인 성공 후 consumeLoginRedirect로 복귀)
+ */
+export const useLoginGate = () => {
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  const requireLogin = useCallback(
+    (action: () => void) => {
+      const isLoggedIn = !!useUserStore.getState().accessToken;
+
+      if (!isLoggedIn) {
+        setLoginRedirect(location.pathname + location.search);
+        navigate(ROUTES.LOGIN);
+        return;
+      }
+
+      action();
+    },
+    [navigate, location.pathname, location.search]
+  );
+
+  return { requireLogin };
+};

--- a/src/shared/hooks/useLoginGate.ts
+++ b/src/shared/hooks/useLoginGate.ts
@@ -1,6 +1,6 @@
 import { useCallback } from 'react';
 
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 
 import { ROUTES } from '@routes/paths';
 
@@ -12,24 +12,25 @@ import { setLoginRedirect } from '@utils/loginRedirect';
  * 로그인 게이트 진입 관리 훅
  * - 로그인 상태면 action 실행
  * - 비로그인이면 현재 경로를 저장하고 로그인 페이지로 이동 (로그인 성공 후 consumeLoginRedirect로 복귀)
+ *
+ * useLocation을 구독하면 네비게이션마다 카드 N개가 전부 리렌더되는데, 경로는 클릭 순간에만 필요하므로 구독 불필요 -> useLocation 대신 window.location으로 읽기
  */
 export const useLoginGate = () => {
   const navigate = useNavigate();
-  const location = useLocation();
 
   const requireLogin = useCallback(
     (action: () => void) => {
       const isLoggedIn = !!useUserStore.getState().accessToken;
 
       if (!isLoggedIn) {
-        setLoginRedirect(location.pathname + location.search);
+        setLoginRedirect(window.location.pathname + window.location.search);
         navigate(ROUTES.LOGIN);
         return;
       }
 
       action();
     },
-    [navigate, location.pathname, location.search]
+    [navigate]
   );
 
   return { requireLogin };

--- a/src/shared/hooks/useProductLink.ts
+++ b/src/shared/hooks/useProductLink.ts
@@ -8,10 +8,15 @@ import { useLoginGate } from '@hooks/useLoginGate';
 export const useProductLink = () => {
   const { requireLogin } = useLoginGate();
 
-  const openProductLink = (href?: string) => {
+  /**
+   * @param href 외부 상품 URL
+   * @param onBeforeOpen 게이트 통과 후 새 탭을 열기 직전 실행할 사이드이펙트 (예: 클릭 분석 로깅)
+   */
+  const openProductLink = (href?: string, onBeforeOpen?: () => void) => {
     if (!href || typeof window === 'undefined') return;
 
     requireLogin(() => {
+      onBeforeOpen?.();
       window.open(href, '_blank', 'noopener,noreferrer');
     });
   };

--- a/src/shared/hooks/useProductLink.ts
+++ b/src/shared/hooks/useProductLink.ts
@@ -10,7 +10,7 @@ export const useProductLink = () => {
 
   /**
    * @param href 외부 상품 URL
-   * @param onBeforeOpen 게이트 통과 후 새 탭을 열기 직전 실행할 사이드이펙트 (예: 클릭 분석 로깅)
+   * @param onBeforeOpen 로그인 게이트 통과 후 새 탭을 열기 직전 실행할 sideEffect (ex: GA 이벤트)
    */
   const openProductLink = (href?: string, onBeforeOpen?: () => void) => {
     if (!href || typeof window === 'undefined') return;

--- a/src/shared/hooks/useProductLink.ts
+++ b/src/shared/hooks/useProductLink.ts
@@ -1,0 +1,20 @@
+import { useLoginGate } from '@hooks/useLoginGate';
+
+/**
+ * 외부 상품 링크 이동의 SSOT
+ * - 로그인 게이트를 통과한 뒤 새 탭으로 외부 상품 페이지를 연다
+ * - 외부 URL이므로 새 탭(_blank) 유지: 같은 탭 내에서 외부 URL로 이동하면 SPA가 언로드되어 HOUME 컨텍스트가 소실됨
+ */
+export const useProductLink = () => {
+  const { requireLogin } = useLoginGate();
+
+  const openProductLink = (href?: string) => {
+    if (!href || typeof window === 'undefined') return;
+
+    requireLogin(() => {
+      window.open(href, '_blank', 'noopener,noreferrer');
+    });
+  };
+
+  return { openProductLink };
+};

--- a/src/shared/utils/productCardUtils.ts
+++ b/src/shared/utils/productCardUtils.ts
@@ -39,10 +39,13 @@ export const createCardClickHandler = ({
   onCardClick,
   enableWholeCardLink,
   linkHref,
+  onNavigate,
 }: {
   onCardClick?: (area?: CardClickArea) => void;
   enableWholeCardLink: boolean;
   linkHref?: string;
+  // 카드 본문(이미지/제목) 클릭 시 실제 이동 동작. 로그인 게이트 + 새 탭 열기는 호출부(useProductLink)가 담당
+  onNavigate?: () => void;
 }) => ({
   handleWrapperClick: (event: React.MouseEvent<HTMLDivElement>) => {
     const target = event.target as HTMLElement | null;
@@ -53,18 +56,16 @@ export const createCardClickHandler = ({
 
     onCardClick?.(resolvedArea);
 
-    if (!enableWholeCardLink || !linkHref || typeof window === 'undefined')
-      return;
-    window.open(linkHref, '_blank', 'noopener,noreferrer');
+    if (!enableWholeCardLink || !linkHref) return;
+    onNavigate?.();
   },
 
   handleWrapperKeyDown: (event: React.KeyboardEvent<HTMLDivElement>) => {
-    if (!enableWholeCardLink || !linkHref || typeof window === 'undefined')
-      return;
+    if (!enableWholeCardLink || !linkHref) return;
     if (event.key !== 'Enter' && event.key !== ' ') return;
 
     event.preventDefault();
     onCardClick?.('card');
-    window.open(linkHref, '_blank', 'noopener,noreferrer');
+    onNavigate?.();
   },
 });


### PR DESCRIPTION
## 📌 Summary

- close #570 

> 관련 있는 Issue를 태그해주세요. (e.g. > - #1)

_해당 PR에 대한 작업 내용을 요약하여 작성해주세요._

## 📄 Tasks

### **로그인 게이트 SSOT 적용 및 overlay-kit 컨텍스트 충돌 해결**

**작업내용**

1. 로그인 게이트 실행 로직을 SSOT로 관리하기 위해 useLoginGate 훅을 생성함. 비로그인 시 현재 경로를 sessionStorage에 저장하고 로그인 페이지로 이동, 로그인 상태면 전달받은 콜백을 실행하는 구조임.
2. 외부 상품 사이트로 이동하기 전에 로그인 게이트를 거치도록 useProductLink 훅을 생성함. 내부에서 useLoginGate로 로그인 여부를 판단한 뒤, 통과 시 새 탭으로 상품 사이트를 엶.
    
    +) 기존에는 외부 상품 사이트로 이동하는 로직을 여러 컴포넌트에서 별도로 관리했는데, 외부 상품 사이트로 이동하기 전 공통적으로 로그인 게이트 플로우를 거치도록 해야하므로 useProductLink라는 공통 훅을 만들고 이 안에서 useLoginGate로 로그인 게이트 플로우를 거친 뒤 외부 상품 사이트로 이동하도록 추상화/리팩토링함.
    
3. 이미지 생성 플로우 진입 CTA마다 복붙돼 있던 로그인 게이트 로직을 **useLoginGate로 통일**하고, **외부 상품 링크 이동 지점에는 useProductLink를 적용**함.

**문제 발생**

상품 상세보기 팝업(ProductDetailOverlay)을 열면 아래 런타임 에러가 발생함.
`useNavigate() may be used only in the context of a <Router> component.` 

**원인 파악**

- ProductDetailOverlay는 toss overlay-kit으로 띄우는 모달임.
- 현재 Provider 구조상 OverlayProvider가 `<App />`을 감싸고 있고, react-router의 `<RouterProvider>`는 `<App />` 내부에 있음. 즉 OverlayProvider가 RouterProvider 바깥에 위치함.
    
    ```tsx
    <OverlayProvider>
    	<App/> // 이 안에 RouterProvider
    </OverlayProvider>
    ```
    
- ProductDetailOverlay는 내부에서 찜하기(useJjymMutation 실행 시 useLoginGate가 실행되어 로그인 게이트 플로우 진입)와 상품 외부 사이트 이동(useProductLink 실행 시 useLoginGate가 실행되어 로그인 게이트 플로우 진입)을 사용함.
- useLoginGate는 react-router의 useLocation(로그인 후 복귀 주소를 sessionStorage에 저장하는 용도)과 useNavigate(navigate(ROUTES.LOGIN))를 사용함. (첫 구현에서는 복귀 경로를 가져오기 위해 window.location 대신 useLocation을 사용했었음)

⇒ 결국 **overlay-kit이 띄운 컴포넌트는 RouterProvider 바깥에서 렌더**되는데 **그 안에서 react-router 훅을 호출**하므로 에러가 발생함.

**해결 방식 검토**

1. **useLoginGate가 react-router에 의존하지 않도록 변경**
    
    OverlayProvider 위치는 그대로 두고, useLoginGate가 useNavigate/useLocation 대신 다음의 방식을 사용하도록 변경하기
    
    - 페이지 이동: useNavigate 대신 createBrowserRouter가 반환한 router 싱글톤의 router.navigate(ROUTES.LOGIN) 사용하기. 컴포넌트/Router 컨텍스트 밖에서도 호출 가능한 **명령형** navigation API(App.tsx가 RouterProvider에 넘기는 바로 그 router 객체).
    - 경로 읽기: window.location.pathname + window.location.search. 페이지 이동이 아니라 현재 경로를 읽기만 하는 용도라 window.location.href 이동 금지 컨벤션과는 무관함.
    
    **문제점:**
    
    - 다른 useLoginGate/useProductLink 사용처는 react-router 훅 기반인데 이 훅만 다른 방식이 되어 일관성이 떨어짐.
    - useLoginGate가 @routes/router를 import하면 순환 참조가 생김. useLoginGate → router(내부에서 페이지들 import) → useJjymMutation → useLoginGate로 loop 발생. 다만 useLoginGate는 router를 모듈 로드 시점이 아니라 **클릭 콜백(런타임)에서만 접근**하고, ES 모듈 live binding이라 호출 시점에는 router가 이미 초기화돼 있음. 따라서 실제 동작에는 문제가 없지만, 구조적으로는 바람직하지 않음.
    - ProductDetailOverlay에서만 에러가 발생하지 않도록 하기 위한 임시땜빵식 해결..
2. **OverlayProvider를 RouterProvider 내부로 이동**
    
    OverlayProvider를 Router 트리 안(루트 라우트 element인 RootLayout)으로 옮겨, 오버레이가 Router 컨텍스트 안에서 렌더되도록 하는 방식임. 방식 1보다 근본적인 해결이라 판단해 채택함.
    
    단, 옮기기 전에 두 가지 확인이 필요했음.
    
    1. 현재 OverlayProvider를 쓰는 다른 오버레이들의 동작에 영향이 없는지.
    2. 아래 구조에서 OverlayProvider가 App 내부로 들어가면 MainToaster(Sonner)와 stacking context가 달라지는데, 토스트/오버레이 stacking context에 영향이 없는지.
        
        ```tsx
        <QueryClientProvider client={queryClient}>
        	<App />
        	<MainToaster />
        </QueryClientProvider>
        ```
        
    
    이를 위해 다음 세 가지를 알아봄.
    
    - **overlay-kit의 렌더 방식**
        - overlay-kit은 createPortal을 쓰지 않음. overlay.open()에 넘긴 컴포넌트를 OverlayProvider의 자식으로 제자리(in-place)에 렌더함. 그래서 **OverlayProvider의 트리 위치가 곧 오버레이의 DOM 렌더 위치**가 됨.
        - overlay-kit 자체는 position이나 z-index를 지정하지 않음. 화면을 덮는 모달처럼 보이는 건, overlay 안에 넣는 컴포넌트(Popup 등)가 자체 CSS로 position: fixed + dim 배경 + z-index를 갖기 때문임. 즉 overlay-kit은 "언제 마운트/언마운트할지"만 관리하고, "어떻게 떠 보이는지"는 컴포넌트의 CSS가 결정함.
        - 따라서 **OverlayProvider를 옮기면 오버레이의 DOM 위치는 바뀌지만, 떠 보이는 방식 자체는 콘텐츠 CSS(fixed + z-index)가 결정하므로 그 부분은 영향받지 않음**.
    - **RootLayout이 새 stacking context를 만드는가?**
        - `<OverlayProvider>`를 옮긴 위치(RootLayout)가 오버레이의 z-index를 가두는 새 stacking context를 만들면 토스트와의 stacking 비교가 깨질 수 있어 확인이 필요했음. 이를 위해 RootLayout의 container의 display 속성 확인 → 오버레이가 렌더되는 경로상에 z-index를 가두는 stacking context가 없는지 검증
        - → container에는 display: flex만 있으며 이것만으로는 stacking context가 생성되지 않음(position+z-index, transform, opacity < 1, isolation 등이 있어야 생성됨). 따라서 새 stacking context가 생기지 않고, 오버레이/토스트 모두 루트 stacking context에서(같은 z-index stacking context에서) 비교됨.
    - **Sonner(MainToaster)의 위치 결정 방식**
        - Sonner의 <Toaster>는 position: fixed + position/offset prop으로 뷰포트 기준 위치를 자체 결정하고, 내부적으로 매우 높은 z-index(999999999)를 부여함.
        - fixed라 React 트리상 위치와 무관하게 뷰포트 기준으로 뜨고, z-index가 충분히 높아 항상 오버레이 위에 쌓임. 따라서 OverlayProvider가 어디로 옮겨지든 토스트의 위치·쌓임은 영향을 받지 않음.
    
    ⇒ 이를 모두 고려했을 때,
    
    - 오버레이/토스트 모두 fixed + 자체 z-index로 루트 stacking context에서 쌓임이 결정됨
    - 오버레이 렌더 경로상 새 stacking context를 만드는 요소가 없음
    - Sonner z-index(999999999)가 오버레이보다 높아 토스트가 항상 위에 유지됨
    
    ⇒ OverlayProvider 이동으로 DOM 순서는 바뀌지만(기존엔 오버레이가 토스트 뒤, 이동 후엔 앞), 쌓임은 z-index가 결정하므로 시각적 변화가 없음. 따라서 옮겨도 문제없다고 판단
    

**결론**

OverlayProvider를 RootLayout 내부로 이동해 오버레이가 Router 컨텍스트 안에서 렌더되도록 함. 이로써 오버레이에서도 react-router 훅(useNavigate/useLocation)을 정상 사용할 수 있고, useLoginGate/useProductLink 구현을 다른 사용처와 동일하게 유지할 수 있었음

```tsx
function RootLayout() {
	
	...
  
  return (
    <OverlayProvider>
      <div className={styles.container}>
        <Outlet />
      </div>
    </OverlayProvider>
  );
}
```

---

### QA 반영
- 퍼널 Step3에서 주요활동선택 바텀시트가 떠있을 때 뒤로가기 시 바텀시트가 내려가도록 useExitBlocker 적용
- 미로그인 상태에서 찜하기 혹은 외부 상품 사이트로 이동 시 로그인 게이트 플로우 진입
- 도면선택 바텀시트의 도면 이미지 비율 3:2로 수정
    <img width="200" alt="image" src="https://github.com/user-attachments/assets/2c2d2fc6-a460-4fae-a8a1-4327fc9b38f5" />
- 상품탭 바텀시트 maximum update depth 오류 해결


_해당 PR에 수행한 작업을 작성해주세요._

## 🔍 To Reviewer

## ⭐️ B-2 스프린트 코드의 구조적 문제 — 컴포넌트 책임 비대화: 흐름이 effect와 implicit shared state로 흩어지는 문제 ⭐️

이번 변경(로그인 게이트 복귀 시 상품탭/상품상세모달 복원)을 구현하면서 다시 한 번 느낀 점인데, B-2 스프린트를 진행하면서 **가면 갈수록 절차적인 코드가 늘어나고**, 컴포넌트가 **자기 책임을 넘어선 로직**을 떠안아버리고 있어요… 그러면서 하나의 흐름에 관여하는 코드가 여기저기 흩어져버리고 있다는게 이번 스프린트 진행하면서 느끼는 가장 큰 문제점인데, 이 PR에서 해결하지는 못하지만 문제 자체는 기록해두는게 좋을 것 같아 정리해봤습니다.

### **현재 문제(이번 PR 코드 기준)**

- ProductTab이 자기 책임(상품 검색/상품 선택 UI) 밖의 로직을 mount effect로 수행함
    - 기존 ProductTab: useImageFlowStore.preset.productsToBeRestored를 읽어 useState 초기값으로 주입 + mount 직후 clearPreset() → 이미지 생성 플로우의 데이터를 상품 UI 컴포넌트가 consume/정리하는 코드를 ProductTab 컴포넌트에 추가함 (PR #568에서 저지른 만행이고.. 이 PR에서도 state machine 패턴을 도입해 이런 전역상태관리 플로우를 일괄적으로 관리하는 패턴을 B-2 스프린트 이후에 도입하겠다는 내용을 정리했었어요. 기존에도 관심사 측면에서 문제가 있던 컴포넌트라는 의미!)
    - 이번 추가: consumeReopenProduct() 후 overlay.open(ProductDetailOverlay) 하는 코드를 새로 추가 → 로그인 게이트 복귀라는 흐름의 일부를 또 떠안음 (상품 탭에서 ‘찜하기’나 ‘상품 사이트로 이동’ 이벤트가 발생해 로그인 게이트를 거친 후 상품 탭으로 복귀했을 때, 기존에 열어둔 상품 상세 오버레이를 띄우기 위한 로직)
    - 결과: ProductTab 컴포넌트 하나가 "상품 UI" + "이미지 플로우 preset consume" + "로그인 게이트 복귀 모달 재오픈" 세 책임을 동시에 가짐.
- ProductDetailOverlay(상품상세정보 Popup 컴포넌트)가 라우팅·영속·오버레이 수명까지 앎…
    - location.pathname을 감시해 스스로 unmount()
    - 'ROUTES.LOGIN으로 이탈하면 sessionStorage에 상품상세정보 저장' → 상품 상세 모달이 로그인 경로·sessionStorage·overlay-kit 라이프사이클까지 인지
- **하나의 흐름(로그인 게이트 플로우)의 데이터 복원 로직이 4곳에 흩어짐**
    - HomePage: 탭 `?tab` 복원 → 탐색탭 or 상품탭으로 페이지 복원
    - ProductDetailOverlay(로그인 게이트 후 복구할 ProductDetailOverlay 데이터 저장)
    - ProductTab(저장된 ProductDetailOverlay 데이터 consume, overlay 재오픈)
    - productDetailOverlayReopen(ProductDetailOverlay의 데이터 저장 담당)
    
    ⇒ '로그인 게이트에서 돌아오면 무엇이 어떻게 복원되는가'를 한곳에서 읽을 수 없고, sessionStorage 키 + URL 파라미터라는 암묵적인 컨벤션으로만 연결됨.
    
    이렇게 로직이 여러 곳으로 분산된다는게 코드 유지보수를 어렵게 만드는 가장 큰 원인인 것 같아요.
    
- **useEffect 기반의 절차적인 코드 증가**
    
    '마운트되면 읽고→열고→지운다', '경로 바뀌면 저장하고→닫는다' 식의 절차적인 코드가 늘어, 각 effect의 트리거/순서/cleanup을 개발자가 머리속으로 시뮬레이션해야 흐름이 파악됨. 
    
- +) 문제 발생 실제 사례
    
    상품 탭의 DragHandleBottomSheet가 부모의 expanded prop을 내부 state로 미러링하면서 두 useEffect로 부모↔자식을 양방향 동기화했었음(부모→자식 setExpanded, 자식→부모 onExpandedChange). 따라서 마운트 시 내부 초기값과 부모 초기값이 어긋나는 경로('상품 다시 선택하기' → 시트 펼친 채 진입)에서 두 effect가 true↔false로 끊임없이 변경되는 사례가 있었고 → 'Maximum update depth exceeded' 무한 리렌더 문제 발생
    
    컴파일러가 못 잡고, 초기값이 일치하는 일반 진입에선 멀쩡해 특정 진입 경로(ResultPage의 '상품 다시 선택하기' → 상품탭 진입하는 경우)에서만 드러남 → 위에서 말한 '절차적인 useEffect로 상태를 동기화하면 트리거/순서를 직접 머릿속으로 시뮬레이션 돌려야되고, 상황에 따라 초기값 조합에서 버그가 발생할 수 있음'의 실제 사례!
    
    → 임시 수정: 내부 초기값을 부모와 정렬(useState(expandedFromParent ?? !isPersistent)). 근본적으론 controlled prop을 내부 state로 미러링하는 derived-state 양방향 바인딩 구조를 단방향(controlled) 또는 단일 소스로 정리해야 함
    

**이런 문제가 이번 코드 변경사항에만 있는게 아니라 프로젝트 전반적으로 존재하는 상황**


### 원인

- **횡단 관심사(cross-cutting concern)인 흐름이 명시적으로 모델화되어 있지 않음**
    
    '로그인 게이트 플로우', '이미지 생성 플로우', '상품 다시 선택 플로우'는 여러 컴포넌트/스토어를 가로지르는 흐름인데, 이를 표현하는 **명시적 모델이나 소유자(owner)가 없음**. 그 결과 ❗️**흐름의 오케스트레이션(언제 읽고/저장하고/정리하는지)이 각 컴포넌트의 생명주기 훅으로 분산**❗️되고, 제어 흐름(control flow)이 말단 UI 컴포넌트까지 내려옴.
    
    +) Spring AOP가 다루는 횡단 관심사와 비슷한 맥락인 것 같음.
    
- **특정 흐름(ex: 로그인 게이트 후 데이터 복원)에 참여하는 각 코드 단위들이, 공유 저장소 + 실행 타이밍에 의존하는 암묵적 프로토콜(implicit protocol)로 결합됨**
    
    A가 B를 직접 import해서 함수를 부르거나, props/콜백/반환값으로 데이터를 주고받는 **직접 호출 관계**에서는 서로의 의존성이 코드와 타입에 드러나서 흐름을 추적하거나 컴파일 시점에서의 검증이 가능함.
    
    근데 지금 코드는 그렇지 않음. 예를 들어, 위 ‘하나의 흐름의 데이터 복원 로직이 4곳에 흩어짐’에서 얘기한 것처럼 로그인 게이트 후 데이터를 복구하는 로직이 HomePage, ProductDetailOverlay, ProductTab, productDetailOverlayReopen유틸에 나뉘어져있고 이 4개가 합쳐져야 하나의 흐름이 완성됨.
    
    ⇒ 컴포넌트들이 직접 호출 관계가 아니라 sessionStorage 키/URL 파라미터같은 **공유 저장소 의존**(컴포넌트끼리 직접 데이터를 주고받지 않고 sessionStorage, 전역상태같은 공유 공간을 거쳐 데이터를 주고받는 것)을 통해 ‘mount 시점에 읽어서 처리한다’는 암묵적인 관계를 가짐 → 서로 ‘시간적으로 결합’된 상태(**temporal coupling**) ⇒ **타입/컴파일러가 이 관계를 검증해주지 못하고**, 한 파일만 봐서는 전체 흐름을 알 수 없음, temporal coupling 성격이 강해 특정 순서대로 정확히 그 타이밍에 실행되어야만 정상 작동하는 나쁜 결합도를 가짐.
    
- **상태 복원 책임이 컴포넌트 생명주기와 useEffect에 결합됨**
    
    카카오 OAuth + 로그인 게이트때문에 지금 코드가 이모냥이 됐다고 해도 과언이 아닌데.. 
    
    카카오 OAuth 진입 과정에서 window.location.href 기반의 full-page navigation이 발생하면서 React 인메모리 상태가 소멸됨 → sessionStorage/URL에서 rehydrate해야 함.
    이때 현재 구조에서는 데이터 복원을 컴포넌트 mount 시점의 useEffect로 관리하는 것이 당장 가장 빠른 구현 방법이었고, 이런 경우가 반복되며 여러 책임이 컴포넌트 내부로 끌려 들어오는 문제 발생 (ex: 본래 상품 UI의 책임이 아닌 것들이 상품 UI에 들어감)
    
- **상태가 성격이 다른 여러 저장소에 흩어져 있고, 저장소마다 데이터 관리 규칙이 달라 관심사 분리(SoC)/단일 책임(SRP)이 깨짐**
    
    이것도 코드 복잡도를 높이고 흐름 파악을 어렵게 만드는 빅이슈.. 상태가 서로 다른 종류의 여러 저장소에 분산됨 — Zustand store(useImageFlowStore: preset/entryRoute/resultType, useFunnelStore), raw sessionStorage(loginRedirect, productDetailOverlayReopen), URL(?tab). 
    각 저장소가 여러 흐름으로부터 파생되는 데이터를 관리하는데, 흐름에 따라 reactive 여부(구독 시 리렌더되는지), 데이터 유지 여부(reload시에도 유지되는지), 데이터 cleanup 시점 등 데이터 관리 정책이 모두 달라, '어떤 데이터를 언제 누가 set/consume/clear하는지', 즉 각 데이터의 owner와 lifecycle을 한 곳에서 추적할 수 없음. 그 결과 한 컴포넌트가 여러 저장소의 수명까지 알아야 하므로 단일 책임이 무너짐
    

### 해결 방법 (아직 미정)

- **흐름 복원 책임을 라우트 경계로 이동**
    
    현재 mount 시점에 실행되는 read/restore를 컴포넌트가 아니라 React Router에서 수행하고 컴포넌트에 순수 props로 주입 → 컴포넌트 mount effect 제거
    
- **데이터 복원을 관리하는 단일 모듈 선언**
    
    ex: 로그인 게이트 컨텍스트(탭복원+상품모달복원+리다이렉트경로)를 한 모듈로 관리 → 그 모델이 데이트 스키마/저장/복원진입점까지 소유하고 컴포넌트는 선언적 API만 사용 → 암묵적인 관계(sessionStorage key/URL param 흩어짐 문제) 제거
    
- **State Machine 패턴 도입**  (#568 PR의 To Reviewer 참고)

---

> 구현해야될 기능이 많다보니 유지보수성이나 이런저런 원칙을 고려해서 구현하지 못하고 볼륨 쳐내는데 집중하다보니 이런 코드들이 계속 누적되는 문제가 발생했는데, 문제를 인지는 하고있어서 다행인 것 같고ㅎㅎ.. B-2 스프린트 종료 후 로그인 게이트같은 흐름을 이름이 붙은 단위(모듈이든 state machine이든 타입이든)로 만드는 리팩토링을 진행하면 상황이 좀 나아질 듯해요. 지금 코드를 구조적으로 어떻게 개선할지 열심히 고민해볼게요..!

_리뷰어에게 요청하는 내용을 작성해주세요._

## 📸 Screenshot

-

_작업한 내용에 대한 스크린샷을 첨부해주세요._
