### PR TITLE
[feat] 상품/결과 관련 토스트 설정

### DIFF
--- a/src/pages/generate/v2/pages/result/components/curation/CurationResult.tsx
+++ b/src/pages/generate/v2/pages/result/components/curation/CurationResult.tsx
@@ -1,7 +1,11 @@
 import { useEffect, useMemo, useState } from 'react';
 
+import { useNavigate } from 'react-router-dom';
+
 import { useCurationCategoriesQuery } from '@pages/generate/v2/apis/queries/useCurationCategoriesQuery';
 import { useCurationProductsQuery } from '@pages/generate/v2/apis/queries/useCurationProductsQuery';
+
+import { ROUTES } from '@routes/paths';
 
 import { useSavedItemsStore } from '@store/useSavedItemsStore';
 
@@ -107,6 +111,7 @@ const CurationResult = ({
   images,
   onCurrentImgIdChange,
 }: CurationResultProps) => {
+  const navigate = useNavigate();
   const [slideIndex, setSlideIndex] = useState(0);
   const [selectedCategoryId, setSelectedCategoryId] = useState<number | null>(
     null
@@ -170,7 +175,11 @@ const CurationResult = ({
           renderableCount: renderableProducts.length,
         });
 
-  const { mutate: toggleJjym } = useJjymMutation();
+  const { mutate: toggleJjym } = useJjymMutation({
+    onSavedAction: () => {
+      navigate(ROUTES.MYPAGE, { state: { activeTab: 'savedItems' } });
+    },
+  });
   const getSavedState = useSavedItemsStore((s) => s.getSavedState);
 
   return (

--- a/src/pages/generate/v2/pages/result/components/curation/feedbackSection/ImgFeedback.tsx
+++ b/src/pages/generate/v2/pages/result/components/curation/feedbackSection/ImgFeedback.tsx
@@ -6,8 +6,12 @@ import { useFactorPreferenceMutation } from '@pages/generate/v2/apis/mutations/u
 import { useResultPreferenceMutation } from '@pages/generate/v2/apis/mutations/useResultPreferenceMutation';
 import { useFactorsQuery } from '@pages/generate/v2/apis/queries/useFactorsQuery';
 
+import { TOAST_MESSAGE } from '@shared/constants/toastMessage';
+import { TOAST_TYPE, TOASTER_ID } from '@shared/types/toast';
+
 import IconButton from '@components/v2/button/IconButton';
 import Chip from '@components/v2/chip/Chip';
+import { useToast } from '@components/v2/toast/useToast';
 
 import * as styles from './ImgFeedback.css.ts';
 
@@ -32,6 +36,7 @@ const ImgFeedback = memo(({ imageId }: ImgFeedbackProps) => {
   const { mutate: sendPreference } = useResultPreferenceMutation();
   const { mutate: deletePreference } = useDeleteResultPreferenceMutation();
   const { mutate: sendFactorPreference } = useFactorPreferenceMutation();
+  const { notify } = useToast();
   const { data: likeFactorsResponse } = useFactorsQuery(true, {
     enabled: lockedPreference === 'like',
   });
@@ -115,6 +120,13 @@ const ImgFeedback = memo(({ imageId }: ImgFeedbackProps) => {
           if (factorRequestSeqRef.current !== requestSeq) return;
           if (lockedPreferenceRef.current !== expectedPreference) return;
           setSelectedFactorId(isSelected ? null : factorId);
+          if (!isSelected) {
+            notify({
+              text: TOAST_MESSAGE.IMAGE_FEEDBACK_THANKS,
+              type: TOAST_TYPE.INFO,
+              options: { toasterId: TOASTER_ID.BOTTOM_4 },
+            });
+          }
         },
         onSettled: () => {
           if (factorRequestSeqRef.current !== requestSeq) return;

--- a/src/pages/generate/v2/pages/result/components/list/ListResult.tsx
+++ b/src/pages/generate/v2/pages/result/components/list/ListResult.tsx
@@ -213,7 +213,11 @@ const ListResult = ({ image, isProductView }: ListResultProps) => {
     ? EMPTY_VIEW_TEXT.listResult.related.titleWithName(userName)
     : EMPTY_VIEW_TEXT.listResult.related.titleFallback;
 
-  const { mutate: toggleJjym } = useJjymMutation();
+  const { mutate: toggleJjym } = useJjymMutation({
+    onSavedAction: () => {
+      navigate(ROUTES.MYPAGE, { state: { activeTab: 'savedItems' } });
+    },
+  });
   const getSavedState = useSavedItemsStore((s) => s.getSavedState);
 
   const handleReselectProducts = () => {

--- a/src/pages/home/components/product/ProductPopup/ProductDetailOverlay.tsx
+++ b/src/pages/home/components/product/ProductPopup/ProductDetailOverlay.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef } from 'react';
 
-import { useLocation } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 
 import { useProductDetailQuery } from '@pages/home/apis/queries/useProductDetailQuery';
 import { setReopenProduct } from '@pages/home/utils/productDetailOverlayReopen';
@@ -45,10 +45,15 @@ const ProductDetailOverlay = ({
   link,
   shoppingAction,
 }: ProductDetailOverlayProps) => {
+  const navigate = useNavigate();
   const { data } = useProductDetailQuery(id);
   const detail = data?.product;
-  const { mutate: toggleJjym } = useJjymMutation();
-  const savedProductIds = useSavedItemsStore((s) => s.savedProductIds);
+  const { mutate: toggleJjym } = useJjymMutation({
+    onSavedAction: () => {
+      navigate(ROUTES.MYPAGE, { state: { activeTab: 'savedItems' } });
+    },
+  });
+  const getSavedState = useSavedItemsStore((s) => s.getSavedState);
   const location = useLocation();
   const openedPathRef = useRef(location.pathname);
 
@@ -90,7 +95,7 @@ const ProductDetailOverlay = ({
   const mergedRef = useRef(merged);
   mergedRef.current = merged;
 
-  const isSaved = savedProductIds.has(id);
+  const isSaved = getSavedState(id, detail?.isLiked ?? save.isSaved);
 
   const handleSaveToggle = () => {
     toggleJjym(id);

--- a/src/pages/home/hooks/useProductSelection.ts
+++ b/src/pages/home/hooks/useProductSelection.ts
@@ -2,7 +2,10 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 
 import type { SelectedProduct } from '@pages/home/types/productTab';
 
-import { useToast } from '@components/toast/useToast';
+import { TOAST_MESSAGE } from '@shared/constants/toastMessage';
+import { TOAST_TYPE, TOASTER_ID } from '@shared/types/toast';
+
+import { useToast } from '@components/v2/toast/useToast';
 
 /**
  * 상품 선택 상한값 - 최대 6개 선택
@@ -52,7 +55,9 @@ const useProductSelection = ({
       if (currentSelected.some((item) => item.id === product.id)) return;
       if (currentSelected.length >= MAX_SELECTED_PRODUCTS) {
         notify({
-          text: `상품은 최대 ${MAX_SELECTED_PRODUCTS}개까지만 선택할 수 있어요`,
+          text: TOAST_MESSAGE.PRODUCT_SELECT_MAX_LIMIT,
+          type: TOAST_TYPE.INFO,
+          options: { toasterId: TOASTER_ID.TOP_4 },
         });
         return;
       }

--- a/src/pages/home/hooks/useProductTabController.ts
+++ b/src/pages/home/hooks/useProductTabController.ts
@@ -17,7 +17,10 @@ import { ROUTES } from '@routes/paths';
 
 import { ENTRY_ROUTE, useImageFlowStore } from '@store/useImageFlowStore';
 
-import { useToast } from '@components/toast/useToast';
+import { TOAST_MESSAGE } from '@shared/constants/toastMessage';
+import { TOAST_TYPE, TOASTER_ID } from '@shared/types/toast';
+
+import { useToast } from '@components/v2/toast/useToast';
 
 import { useLoginGate } from '@hooks/useLoginGate';
 
@@ -152,7 +155,11 @@ const useProductTabController = ({
    */
   const handleDecorateWithProductsClick = useCallback(() => {
     if (selectedProducts.length === 0) {
-      notify({ text: '상품을 1개 이상 선택해주세요' });
+      notify({
+        text: TOAST_MESSAGE.PRODUCT_SELECT_REQUIRED,
+        type: TOAST_TYPE.INFO,
+        options: { toasterId: TOASTER_ID.TOP_4 },
+      });
       return;
     }
 

--- a/src/shared/constants/toastMessage.ts
+++ b/src/shared/constants/toastMessage.ts
@@ -8,6 +8,9 @@ export const TOAST_MESSAGE = {
   SAVED_ITEM_MOVE: '상품을 찜했어요! 찜한 상품으로 이동할까요?',
   SAVED_ITEM_STORED: '찜한 상품에 저장했어요!',
   SAVED_ITEM_REMOVED: '찜을 취소했어요',
+  PRODUCT_SELECT_REQUIRED: '상품을 1개 이상 선택해주세요',
+  PRODUCT_SELECT_MAX_LIMIT: '상품은 최대 6개까지만 선택할 수 있어요',
+  IMAGE_FEEDBACK_THANKS: '소중한 의견 감사드려요. 더 나은 서비스로 보답할게요!',
 } as const;
 
 export const TOAST_ACTION_LABEL = {


### PR DESCRIPTION
## 📌 Summary

- close #579
- close #556 

> 상품 탭·상품 상세·결과 페이지의 v2 toast 및 찜/피드백 UX를 기획에 맞게 보완했습니다.

## 📄 Tasks

- 상품 탭 CTA/선택 제한 안내를 v2 toast와 토스트 메세지 상수로 통일
  - 선택 0개 CTA 클릭 시
  - 6개 초과 선택 시
- 상품 상세 모달 찜 상태 초기 렌더 수정
- 찜 추가 토스트 이동 클릭 시 마이페이지 찜한 상품 탭 이동
  - `ProductDetailOverlay`, `ListResult`, `CurationResult`
- 추천형 결과 서베이에서 factor 칩 선택 시 감사 토스트표시
  - `IMAGE_FEEDBACK_THANKS` 상수 추가

## 🔍 To Reviewer

> 현재 CardSurvey (이미지 선호도 조사) API에서 500 에러 발생하여 서버 측과 논의 중입니다. 토스트 로직은 추가해놓았으나, 에러 때문에 테스트는 아직 하지 못 한 상황이라 이 부분 확인되면 머지하겠습니다!

## 📸 Screenshot

https://github.com/user-attachments/assets/fa4f9433-3d91-4ccc-a424-0a1fa23864b1


https://github.com/user-attachments/assets/87664b87-dcf5-424e-8e49-091325902024


https://github.com/user-attachments/assets/d0320d33-9de0-4f28-9b5e-9e77f313d6a4

