### PR TITLE
[fix] QA 3차 반영

### DIFF
--- a/src/pages/generate/v2/apis/queries/useStackDataQuery.ts
+++ b/src/pages/generate/v2/apis/queries/useStackDataQuery.ts
@@ -10,46 +10,46 @@ import { queryKeys } from '@constants/queryKey';
 import type { GetCarouselV2ListResponseDTO } from '@/shared/apis/__generated__/data-contracts';
 
 export const getStackData = async (
-  cursor?: number
+  furnitureIds: number[]
 ): Promise<GetCarouselV2ListResponseDTO> => {
-  const query = cursor === undefined ? undefined : { cursor };
-
   const res = await request<GetCarouselV2ListResponseDTO>({
     method: HTTPMethod.GET,
     url: API_ENDPOINT.GENERATE.CAROUSELS_V2,
-    query: query,
+    query: { furnitureIds },
   });
   return res;
 };
 
 export const useStackDataQuery = (
-  cursor: number | undefined,
+  furnitureIds: number[],
   options: {
     enabled: boolean;
     onSuccess?: (data: GetCarouselV2ListResponseDTO) => void;
     onError?: (err: unknown) => void;
   }
 ) => {
+  const { enabled, onSuccess, onError } = options;
+
   const query = useQuery<GetCarouselV2ListResponseDTO, unknown>({
-    queryKey: queryKeys.generate.stack(cursor),
-    queryFn: () => getStackData(cursor),
-    staleTime: cursor === undefined ? 0 : 2 * 60 * 1000,
-    gcTime: cursor === undefined ? 0 : 1000 * 60 * 60 * 24,
+    queryKey: queryKeys.generate.stack(furnitureIds),
+    queryFn: () => getStackData(furnitureIds),
+    staleTime: 2 * 60 * 1000,
+    gcTime: 1000 * 60 * 60 * 24,
     retry: 2,
-    enabled: options.enabled,
+    enabled,
   });
 
   useEffect(() => {
     if (query.isSuccess && query.data) {
-      options.onSuccess?.(query.data);
+      onSuccess?.(query.data);
     }
-  }, [query.isSuccess, query.data]);
+  }, [onSuccess, query.isSuccess, query.data]);
 
   useEffect(() => {
     if (query.isError) {
-      options.onError?.(query.error);
+      onError?.(query.error);
     }
-  }, [query.isError, query.error]);
+  }, [onError, query.isError, query.error]);
 
   return query;
 };

--- a/src/pages/generate/v2/apis/queries/useStackDataQuery.ts
+++ b/src/pages/generate/v2/apis/queries/useStackDataQuery.ts
@@ -7,21 +7,18 @@ import { queryKeys } from '@constants/queryKey';
 
 import type { GetCarouselV2ListResponseDTO } from '@/shared/apis/__generated__/data-contracts';
 
-export const getStackData = async (
-  furnitureIds: number[]
-): Promise<GetCarouselV2ListResponseDTO> => {
+export const getStackData = async (): Promise<GetCarouselV2ListResponseDTO> => {
   const res = await request<GetCarouselV2ListResponseDTO>({
     method: HTTPMethod.GET,
     url: API_ENDPOINT.GENERATE.CAROUSELS_V2,
-    query: { furnitureIds },
   });
   return res;
 };
 
-export const useStackDataQuery = (furnitureIds: number[], enabled: boolean) => {
+export const useStackDataQuery = (enabled: boolean) => {
   return useQuery<GetCarouselV2ListResponseDTO, unknown>({
-    queryKey: queryKeys.generate.stack(furnitureIds),
-    queryFn: () => getStackData(furnitureIds),
+    queryKey: queryKeys.generate.stack(),
+    queryFn: () => getStackData(),
     staleTime: 2 * 60 * 1000,
     gcTime: 1000 * 60 * 60 * 24,
     retry: 2,

--- a/src/pages/generate/v2/apis/queries/useStackDataQuery.ts
+++ b/src/pages/generate/v2/apis/queries/useStackDataQuery.ts
@@ -1,5 +1,3 @@
-import { useEffect } from 'react';
-
 import { useQuery } from '@tanstack/react-query';
 
 import { HTTPMethod, request } from '@apis/config/request';
@@ -20,17 +18,8 @@ export const getStackData = async (
   return res;
 };
 
-export const useStackDataQuery = (
-  furnitureIds: number[],
-  options: {
-    enabled: boolean;
-    onSuccess?: (data: GetCarouselV2ListResponseDTO) => void;
-    onError?: (err: unknown) => void;
-  }
-) => {
-  const { enabled, onSuccess, onError } = options;
-
-  const query = useQuery<GetCarouselV2ListResponseDTO, unknown>({
+export const useStackDataQuery = (furnitureIds: number[], enabled: boolean) => {
+  return useQuery<GetCarouselV2ListResponseDTO, unknown>({
     queryKey: queryKeys.generate.stack(furnitureIds),
     queryFn: () => getStackData(furnitureIds),
     staleTime: 2 * 60 * 1000,
@@ -38,18 +27,4 @@ export const useStackDataQuery = (
     retry: 2,
     enabled,
   });
-
-  useEffect(() => {
-    if (query.isSuccess && query.data) {
-      onSuccess?.(query.data);
-    }
-  }, [onSuccess, query.isSuccess, query.data]);
-
-  useEffect(() => {
-    if (query.isError) {
-      onError?.(query.error);
-    }
-  }, [onError, query.isError, query.error]);
-
-  return query;
 };

--- a/src/pages/generate/v2/pages/loading/LoadingPage.tsx
+++ b/src/pages/generate/v2/pages/loading/LoadingPage.tsx
@@ -368,8 +368,8 @@ const LoadingPage = () => {
                           src={slotAImage.url}
                           alt={
                             frontSlot === 'A'
-                              ? `현재 가구 이미지 ${slotAImage.rawProductId}`
-                              : `다음 가구 이미지 ${slotAImage.rawProductId}`
+                              ? `현재 가구 이미지`
+                              : `다음 가구 이미지`
                           }
                           className={styles.imageStyle}
                         />
@@ -382,8 +382,8 @@ const LoadingPage = () => {
                           src={slotBImage.url}
                           alt={
                             frontSlot === 'B'
-                              ? `현재 가구 이미지 ${slotBImage.rawProductId}`
-                              : `다음 가구 이미지 ${slotBImage.rawProductId}`
+                              ? `현재 가구 이미지`
+                              : `다음 가구 이미지`
                           }
                           className={styles.imageStyle}
                         />

--- a/src/pages/generate/v2/pages/loading/LoadingPage.tsx
+++ b/src/pages/generate/v2/pages/loading/LoadingPage.tsx
@@ -130,12 +130,6 @@ const LoadingPage = () => {
   // 이미지 생성 payload에 필요한 데이터가 정상적으로 구성되어 있으면 true
   const isRequestValid = requestState.kind !== 'invalid';
 
-  // 생성 요청이 시작되면 funnel store가 reset되므로, 캐러셀 조회용 가구 선택값은 첫 진입 시점 스냅샷으로 유지
-  const furnitureIdsRef = useRef<number[]>(
-    useFunnelStore.getState().activityInfo?.furnitureIds ?? []
-  );
-
-  const furnitureIds = furnitureIdsRef.current;
   const [currentIndex, setCurrentIndex] = useState(0);
 
   // 캐러셀 애니메이션 상태 - 스택 UI
@@ -156,7 +150,7 @@ const LoadingPage = () => {
     isPending,
     isError,
     error,
-  } = useStackDataQuery(furnitureIds, isRequestValid);
+  } = useStackDataQuery(isRequestValid);
 
   const currentImages = currentStack?.carousels ?? [];
 

--- a/src/pages/generate/v2/pages/loading/LoadingPage.tsx
+++ b/src/pages/generate/v2/pages/loading/LoadingPage.tsx
@@ -155,13 +155,8 @@ const LoadingPage = () => {
     data: currentStack,
     isPending,
     isError,
-  } = useStackDataQuery(furnitureIds, {
-    enabled: isRequestValid,
-    onSuccess: () => {
-      setCurrentIndex(0);
-    },
-    onError: (err) => handleError(err, 'loading'),
-  });
+    error,
+  } = useStackDataQuery(furnitureIds, isRequestValid);
 
   const currentImages = currentStack?.carousels ?? [];
 
@@ -209,6 +204,12 @@ const LoadingPage = () => {
         return;
     }
   }, [handleError, requestState]);
+
+  useEffect(() => {
+    if (isError && error) {
+      handleError(error, 'loading');
+    }
+  }, [error, handleError, isError]);
 
   useEffect(() => {
     return () => {

--- a/src/pages/generate/v2/pages/loading/LoadingPage.tsx
+++ b/src/pages/generate/v2/pages/loading/LoadingPage.tsx
@@ -130,9 +130,12 @@ const LoadingPage = () => {
   // 이미지 생성 payload에 필요한 데이터가 정상적으로 구성되어 있으면 true
   const isRequestValid = requestState.kind !== 'invalid';
 
-  // 캐러셀 페이지네이션 (무한 스크롤) - 스택 UI
-  const [currentPage, setCurrentPage] = useState<number | undefined>(undefined);
-  const [nextCursor, setNextCursor] = useState<number | undefined>(undefined);
+  // 생성 요청이 시작되면 funnel store가 reset되므로, 캐러셀 조회용 가구 선택값은 첫 진입 시점 스냅샷으로 유지
+  const furnitureIdsRef = useRef<number[]>(
+    useFunnelStore.getState().activityInfo?.furnitureIds ?? []
+  );
+
+  const furnitureIds = furnitureIdsRef.current;
   const [currentIndex, setCurrentIndex] = useState(0);
 
   // 캐러셀 애니메이션 상태 - 스택 UI
@@ -152,21 +155,15 @@ const LoadingPage = () => {
     data: currentStack,
     isPending,
     isError,
-  } = useStackDataQuery(currentPage, {
+  } = useStackDataQuery(furnitureIds, {
     enabled: isRequestValid,
-    onSuccess: (data) => {
+    onSuccess: () => {
       setCurrentIndex(0);
-      setNextCursor(data.nextCursor ?? undefined);
     },
     onError: (err) => handleError(err, 'loading'),
   });
 
-  const { data: nextStack } = useStackDataQuery(nextCursor, {
-    enabled: nextCursor !== undefined && isRequestValid,
-  });
-
   const currentImages = currentStack?.carousels ?? [];
-  const nextImages = nextStack?.carousels ?? [];
 
   // 스택 UI 좋아요 (찜하기 연동됨)
   const { mutate: postLike, isPending: isJjymLoading } =
@@ -227,18 +224,14 @@ const LoadingPage = () => {
     !currentImages ||
     currentImages.length === 0;
 
-  // 정상 데이터(normal data)일 때 현재/다음 이미지 계산
+  // 정상 데이터일 때 현재/다음 이미지 계산
   const currentImage = hasError ? null : currentImages[currentIndex];
-
-  const isLast = hasError ? false : currentIndex === currentImages.length - 1;
 
   const nextImage = hasError
     ? null
-    : !isLast
+    : currentImages.length > 1
       ? currentImages[currentIndex + 1]
-      : nextImages && nextImages.length > 0
-        ? nextImages[0]
-        : undefined;
+      : undefined;
 
   useEffect(() => {
     if (animating) return;
@@ -286,13 +279,14 @@ const LoadingPage = () => {
     setIsTooltipOpen(false);
 
     if (isLike) {
-      if (displayCurrentImage?.carouselId == null) return;
-      postLike(displayCurrentImage.carouselId, {
+      if (displayCurrentImage?.rawProductId == null) return;
+      postLike(displayCurrentImage.rawProductId, {
         onSuccess: () => {
           goToNext();
         },
         onError: () => {
           notify({
+            //TODO: 서버 에러 토스트 구현
             text: '잠시 오류가 발생했어요. 다시 시도해주세요.',
             type: TOAST_TYPE.WARNING,
           });
@@ -319,18 +313,8 @@ const LoadingPage = () => {
     transitionTimeoutRef.current = window.setTimeout(() => {
       setFrontSlot((prev) => (prev === 'A' ? 'B' : 'A'));
 
-      // 현재 페이지에 다음 이미지가 있으면 인덱스 증가
-      if (!isLast) {
+      if (currentImages.length > 1) {
         setCurrentIndex((prev) => prev + 1);
-      }
-      // 마지막 이미지면 다음 페이지로 이동
-      else {
-        if (nextImages && nextImages.length > 0 && nextCursor !== undefined) {
-          setCurrentPage(nextCursor);
-          setCurrentIndex(0);
-        } else {
-          // console.log('마지막 페이지 도달');
-        }
       }
 
       setAnimating(false);
@@ -383,8 +367,8 @@ const LoadingPage = () => {
                           src={slotAImage.url}
                           alt={
                             frontSlot === 'A'
-                              ? `현재 가구 이미지 ${slotAImage.carouselId}`
-                              : `다음 가구 이미지 ${slotAImage.carouselId}`
+                              ? `현재 가구 이미지 ${slotAImage.rawProductId}`
+                              : `다음 가구 이미지 ${slotAImage.rawProductId}`
                           }
                           className={styles.imageStyle}
                         />
@@ -397,8 +381,8 @@ const LoadingPage = () => {
                           src={slotBImage.url}
                           alt={
                             frontSlot === 'B'
-                              ? `현재 가구 이미지 ${slotBImage.carouselId}`
-                              : `다음 가구 이미지 ${slotBImage.carouselId}`
+                              ? `현재 가구 이미지 ${slotBImage.rawProductId}`
+                              : `다음 가구 이미지 ${slotBImage.rawProductId}`
                           }
                           className={styles.imageStyle}
                         />

--- a/src/pages/mypage/apis/queries/useGetJjymListQuery.ts
+++ b/src/pages/mypage/apis/queries/useGetJjymListQuery.ts
@@ -17,9 +17,12 @@ export const getJjymList = async (): Promise<JjymsResponse> => {
   });
 };
 
-export const useGetJjymListQuery = (
-  options?: UseQueryOptions<JjymsResponse, unknown, FurnitureItem[]>
-) => {
+type GetJjymListQueryOptions = Omit<
+  UseQueryOptions<JjymsResponse, unknown, FurnitureItem[]>,
+  'queryKey' | 'queryFn' | 'select'
+>;
+
+export const useGetJjymListQuery = (options?: GetJjymListQueryOptions) => {
   return useQuery({
     queryKey: queryKeys.mypage.jjymList(),
     queryFn: getJjymList,

--- a/src/pages/mypage/components/card/genImgCard/GenImgCard.css.ts
+++ b/src/pages/mypage/components/card/genImgCard/GenImgCard.css.ts
@@ -22,6 +22,7 @@ export const textContainer = style({
   display: 'flex',
   justifyContent: 'space-between',
   gap: unitVars.unit.gapPadding['200'],
+  cursor: 'pointer',
   width: '100%',
 });
 
@@ -46,6 +47,7 @@ export const imgContainer = style({
   transition: 'transform 100ms ease',
   border: 0,
   borderRadius: unitVars.unit.radius['300'],
+  cursor: 'pointer',
   width: '100%',
   overflow: 'hidden',
 });

--- a/src/pages/mypage/components/card/genImgCard/GenImgCard.tsx
+++ b/src/pages/mypage/components/card/genImgCard/GenImgCard.tsx
@@ -62,7 +62,18 @@ const GenImgCard = ({
 
   return (
     <div className={styles.wrapper}>
-      <section className={styles.textContainer} onClick={onCurationClick}>
+      <section
+        className={styles.textContainer}
+        role="button"
+        tabIndex={0}
+        onClick={onCurationClick}
+        onKeyDown={(e) => {
+          if ((e.key === 'Enter' || e.key === ' ') && onCurationClick) {
+            e.preventDefault();
+            onCurationClick();
+          }
+        }}
+      >
         <span className={styles.headingText}>{productSummaryText}</span>
         <TextButton
           color="secondary"

--- a/src/pages/mypage/components/card/genImgCard/GenImgCard.tsx
+++ b/src/pages/mypage/components/card/genImgCard/GenImgCard.tsx
@@ -76,7 +76,7 @@ const GenImgCard = ({
           더보기
         </TextButton>
       </section>
-      <section className={styles.imgContainer}>
+      <section className={styles.imgContainer} onClick={onCurationClick}>
         {/* 이미지 로드 완료 전에는 skeleton, 완료 시 실제 이미지 렌더링 */}
         {!isImageReady && <div className={styles.skeleton} />}
         <img

--- a/src/pages/mypage/components/section/savedItems/SavedItemsSection.tsx
+++ b/src/pages/mypage/components/section/savedItems/SavedItemsSection.tsx
@@ -26,7 +26,10 @@ const SavedItemsSection = () => {
   );
 
   // 찜한 목록 조회
-  const { data: savedItems = [], isFetched } = useGetJjymListQuery();
+  const { data: savedItems = [], isFetched } = useGetJjymListQuery({
+    gcTime: 0,
+    refetchOnMount: 'always',
+  });
 
   // 찜 해제 토글
   const { mutate: toggleJjym } = useJjymMutation({

--- a/src/pages/style/StyleDetailPage.css.ts
+++ b/src/pages/style/StyleDetailPage.css.ts
@@ -27,6 +27,7 @@ export const productList = style({
 export const sectionTitle = style({
   ...fontVars.font.title_sb_16,
   marginBottom: unitVars.unit.gapPadding['400'],
+  padding: `${unitVars.unit.gapPadding['000']} ${unitVars.unit.gapPadding['100']}`,
 });
 
 export const products = style({

--- a/src/shared/apis/__generated__/data-contracts.ts
+++ b/src/shared/apis/__generated__/data-contracts.ts
@@ -953,9 +953,10 @@ export interface ApiResponseRecentFloorPlanResponse {
   data?: RecentFloorPlanResponse;
 }
 
-export interface ExploreHouseTemplateDetailItemResponse {
+export interface RecentFloorPlanItemResponse {
   imageUrl?: string;
   view?: string;
+  isRecentUsedView?: boolean;
 }
 
 export interface RecentFloorPlanResponse {
@@ -964,7 +965,7 @@ export interface RecentFloorPlanResponse {
   floorPlanId?: number;
   floorPlanName?: string;
   equilibrium?: string;
-  floorPlans?: ExploreHouseTemplateDetailItemResponse[];
+  floorPlans?: RecentFloorPlanItemResponse[];
 }
 
 export interface ApiResponseMyPageGeneratedImageV2Response {
@@ -1068,6 +1069,11 @@ export interface ApiResponseExploreHouseTemplateDetailResponse {
   code?: number;
   msg?: string;
   data?: ExploreHouseTemplateDetailResponse;
+}
+
+export interface ExploreHouseTemplateDetailItemResponse {
+  imageUrl?: string;
+  view?: string;
 }
 
 export interface ExploreHouseTemplateDetailResponse {

--- a/src/shared/apis/__generated__/data-contracts.ts
+++ b/src/shared/apis/__generated__/data-contracts.ts
@@ -1203,14 +1203,12 @@ export interface ApiResponseGetCarouselV2ListResponseDTO {
 
 export interface GetCarouselResponseDTO {
   /** @format int64 */
-  carouselId?: number;
+  rawProductId?: number;
   url?: string;
 }
 
 export interface GetCarouselV2ListResponseDTO {
   carousels?: GetCarouselResponseDTO[];
-  /** @format int64 */
-  nextCursor?: number;
 }
 
 export interface ApiResponseOtherStyleListResponse {

--- a/src/shared/components/v2/button/actionButton/ActionButton.css.ts
+++ b/src/shared/components/v2/button/actionButton/ActionButton.css.ts
@@ -111,6 +111,14 @@ export const button = recipe({
       },
     },
     {
+      variants: { disabled: true, variant: 'outlined' },
+      style: {
+        background: colorVars.color.fill.inverseSecondary,
+        border: `1px solid ${colorVars.color.border.tertiary}`,
+        color: colorVars.color.text.disabled,
+      },
+    },
+    {
       variants: { variant: 'ghost' },
       style: {
         background: `rgba(255, 255, 255, 0.10)`,

--- a/src/shared/components/v2/menuTab/MenuTab.css.ts
+++ b/src/shared/components/v2/menuTab/MenuTab.css.ts
@@ -44,7 +44,7 @@ export const tabButton = recipe({
     marginBottom: '-0.4rem',
     borderBottom: `0.2rem solid transparent`,
     padding: unitVars.unit.gapPadding['200'],
-    ...fontVars.font.title_sb_16,
+
     height: '100%',
   },
   variants: {
@@ -56,9 +56,11 @@ export const tabButton = recipe({
       active: {
         borderBottomColor: colorVars.color.fill.primary,
         color: colorVars.color.text.primary,
+        ...fontVars.font.title_sb_16,
       },
       inactive: {
         color: colorVars.color.text.tertiary,
+        ...fontVars.font.title_m_16,
       },
     },
   },

--- a/src/shared/constants/queryKey.ts
+++ b/src/shared/constants/queryKey.ts
@@ -80,8 +80,8 @@ export const queryKeys = {
   // 이미지 생성
   generate: {
     all: ['generate'] as const,
-    stack: (cursor?: number) =>
-      [...queryKeys.generate.all, 'stack', cursor ?? 'initial'] as const,
+    stack: (param?: number | number[]) =>
+      [...queryKeys.generate.all, 'stack', param ?? 'initial'] as const,
     meta: (imageId: number) =>
       [...queryKeys.generate.all, 'meta', imageId] as const,
     result: (houseId: number) =>

--- a/src/store/useSavedItemsStore.ts
+++ b/src/store/useSavedItemsStore.ts
@@ -51,7 +51,10 @@ export const useSavedItemsStore = create<SavedItemsState>((set, get) => ({
     // 현재와 가져온 set 비교 (크기, 원소)
     const isEqual =
       prev.size === next.size && [...next].every((id) => prev.has(id));
-    if (isEqual) return; // no-op (아무 동작 X)
-    set({ savedProductIds: next }); // 내용이 달라진 경우에만 새로운 set으로 갱신
+    if (isEqual && get().touchedProductIds.size === 0) return; // no-op (아무 동작 X)
+    set({
+      savedProductIds: next,
+      touchedProductIds: new Set(),
+    }); // 서버 스냅샷으로 재동기화되면 임시 토글 상태는 초기화
   },
 }));


### PR DESCRIPTION
## 📌 Summary

- close #585 

로딩페이지, 마이페이지 관련해 변경된 서버 api 스펙에 맞게 수정하고 QA 3차 반영했습니다.
기타 공통컴포넌트 스타일 수정도 추가되었습니다.


## 📄 Tasks

- [x] ProductCard Button disabled시 border, text 컬러 상이 → actionButton의 disabled, outlined일 때 스타일 추가
- [x] 스타일 디테일 페이지 TextHeading 좌측 패딩 추가
- [x] [TabItem] status=default일 때, 텍스트 굵기 수정
- [x] `GenImgCard`에 이미지 영역 클릭 시에도 결과 페이지로 이동할 수 있도록 클릭 이벤트를 연결했습니다.
- [x] 마이페이지에서 title이 서버에서 null로 받고 있었는데, 필드는 원래 연결이 되어있어 서버 수정 후 확인했을 때 정상이었습니다. 
- [x] 이미지 로딩 페이지 스택 UI API 스펙 변경 반영

기존에는 cursor 기반으로 이미지를 10개씩 조회하고, nextCursor를 이용해 다음 페이지를 이어서 불러오는 구조였습니다.
변경 후에는 서버에서 이미지를 한 번에 최대 100개까지 내려주므로, cursor/nextCursor 기반 페이지네이션 로직을 제거하고 단일 응답의 carousels 배열만으로 스택 UI를 구성하도록 변경했습니다.
이미지 조회 시 전달하는 쿼리를 서버 api 스펙에 맞게 제거했습니다. 

+) 추가 발생했던 문제 
기존에는 stack UI query success 처리에서 `currentIndex`를 반복 초기화할 수 있는 구조여서, 같은 이미지 두 장만 반복 노출되고 화면이 깜빡이는 문제가 있었습니다. 이를 해결하기 위해 query hook을 순수 조회 역할로 단순화하고, success 시점의 index 초기화 로직을 제거했습니다.


즉 변경사항은, 다음과 같습니다.
- v2/carousels 조회를 cursor 방식 제거
- nextCursor, nextStack, 페이지 이동 상태 제거
- 단일 carousels 응답 배열 기반으로 스택 UI 렌더링
- api 스펙에 맞게 캐러셀 아이템 식별자 변경 (carouselId → rawProductId)
- query hook의 success/error callback 패턴 제거로 불필요한 index reset 방지


- [x] 상품 찜하기를 취소해도 찜하기 리스트에 상품이 남아있는 문제 해결

찜한 상품 탭에서 찜 해제 후 섹션 이동이나 페이지 이동 시, 이전 React Query 캐시가 재사용되면서 해제한 상품이 다시 찜된 것처럼 복구되던 문제를 수정했습니다.
찜 목록 쿼리에 `refetchOnMount: 'always'`와 `gcTime: 0`을 적용해 탭 재진입 시 항상 서버 기준으로 다시 조회하고, inactive 된 캐시는 즉시 제거되도록 변경했습니다.

추가로 전역 찜 상태 스토어는 서버 목록으로 재동기화될 때 임시 토글 흔적도 함께 초기화하도록 정리했습니다. 
현재 찜 전역 스토에는 두 가지가 있습니다. 
- `savedProductIds` : 현재 로컬에서 찜으로 보고 있는 상품 ID들
- `touchedProductIds` : 사용자가 한 번이라도 찜 토글을 눌러서, 서버값 대신 로컬 임시 상태를 우선해서 봐야 하는 상품 ID들 (되돌리기 적용 전)
원래는 `setSavedProductIds(...)`가 서버에서 새 찜 목록을 받아와도 savedProductIds만 바꾸고 touchedProductIds는 남겨뒀었는데, 이는 “전에 한 번 눌렀던 임시 상태”가 계속 살아남을 여지가 있습니다. 그래서 서버 목록으로 다시 동기화할 때 다음과 같이 수정했습니다.
```ts
set({
  savedProductIds: next,
  touchedProductIds: new Set(),
});
```
서버에서 찜 목록을 재조회해 동기화할 때, 로컬의 임시 찜 토글 상태도 함께 초기화하도록 정리했습니다. 이를 통해 이전 낙관 업데이트 흔적이 이후 렌더에 남지 않고, 재진입 시 서버 기준 상태만 반영되도록 했습니다.


## 🔍 To Reviewer

-

_리뷰어에게 요청하는 내용을 작성해주세요._

## 📸 Screenshot

<img width="374" height="587" alt="스크린샷 2026-06-07 오후 4 06 06" src="https://github.com/user-attachments/assets/29593fb5-7632-42ec-b36a-f5ec404f4484" />
<img width="418" height="170" alt="스크린샷 2026-06-11 오후 6 04 57" src="https://github.com/user-attachments/assets/ddbd9bd2-1424-4455-bc44-7b43317cd20b" />
<img width="414" height="152" alt="스크린샷 2026-06-11 오후 5 55 16" src="https://github.com/user-attachments/assets/4756eb29-d83d-4565-a79b-ac78a7766310" />
<img width="153" height="77" alt="image" src="https://github.com/user-attachments/assets/80f717f5-2b32-46f8-bbbc-5f53e0d59051" />



- 로딩페이지
https://github.com/user-attachments/assets/2cc8336c-8c36-45fc-ba44-b2f2ca79a734

- 찜 동작

https://github.com/user-attachments/assets/50d627e2-1ddc-4c0d-907f-8b5e6d35844d

