### PR TITLE
[feat] ResultPage 뒤로가기 히스토리 꼬임 해결, 네트워크 환경별 이미지 placeholder 정책 결정 및 적용

### DIFF
--- a/src/pages/generate/v2/pages/loading/LoadingPage.tsx
+++ b/src/pages/generate/v2/pages/loading/LoadingPage.tsx
@@ -364,6 +364,7 @@ const LoadingPage = () => {
                               : `다음 가구 이미지`
                           }
                           className={styles.imageStyle}
+                          placeholder="color"
                           loading="eager"
                         />
                       </div>
@@ -379,6 +380,7 @@ const LoadingPage = () => {
                               : `다음 가구 이미지`
                           }
                           className={styles.imageStyle}
+                          placeholder="color"
                           loading="eager"
                         />
                       </div>

--- a/src/pages/generate/v2/pages/result/ResultPage.tsx
+++ b/src/pages/generate/v2/pages/result/ResultPage.tsx
@@ -62,7 +62,8 @@ const ResultPage = () => {
     shouldBlockNavigation: ({ historyAction }) => historyAction === 'POP',
     onBlocked: ({ reset }) => {
       reset();
-      navigate(ROUTES.HOME, { replace: true });
+      // 브라우저 히스토리 꼬임 방지 - 복원 popstate가 처리된 다음 task에서 replace해야 Result 엔트리를 정확히 대체한다
+      setTimeout(() => navigate(ROUTES.HOME, { replace: true }), 0);
     },
   });
 

--- a/src/pages/generate/v2/pages/result/components/curation/imgSection/GeneratedImg.tsx
+++ b/src/pages/generate/v2/pages/result/components/curation/imgSection/GeneratedImg.tsx
@@ -92,7 +92,8 @@ const GeneratedImg = ({
               <OptimizedImage
                 src={image.imageUrl}
                 alt=""
-                loading="lazy"
+                placeholder="color"
+                loading={index === 0 ? 'eager' : 'lazy'}
                 decoding="async"
                 className={styles.imgArea({ mirrored: image.isMirror })}
               />

--- a/src/pages/generate/v2/pages/result/components/list/imgSection/GeneratedImg.css.ts
+++ b/src/pages/generate/v2/pages/result/components/list/imgSection/GeneratedImg.css.ts
@@ -34,6 +34,7 @@ export const swiperSlide = style({
 });
 
 export const listImageFrame = style({
+  position: 'relative', // OptimizedImage placeholder(absolute)의 기준
   width: '100%',
   height: '26rem',
   overflow: 'hidden',

--- a/src/pages/generate/v2/pages/result/components/list/imgSection/GeneratedImg.tsx
+++ b/src/pages/generate/v2/pages/result/components/list/imgSection/GeneratedImg.tsx
@@ -19,6 +19,7 @@ const GeneratedImg = ({ image }: GeneratedImgListProps) => {
         <OptimizedImage
           src={image.imageUrl}
           alt=""
+          placeholder="color"
           fetchPriority="high"
           loading="eager"
           decoding="async"

--- a/src/pages/home/components/explore/banner/Banner.tsx
+++ b/src/pages/home/components/explore/banner/Banner.tsx
@@ -92,6 +92,7 @@ const Banner = ({ seedBannerId, onSlideClick }: BannerProps) => {
                       sizes={IMAGE_SIZES.full}
                       alt={slide.title}
                       className={styles.image}
+                      placeholder="color"
                       draggable={false}
                       loading={index === 0 ? 'eager' : 'lazy'}
                       decoding="async"

--- a/src/pages/home/components/product/ProductPopup/ProductDetailCard.tsx
+++ b/src/pages/home/components/product/ProductPopup/ProductDetailCard.tsx
@@ -50,6 +50,7 @@ const ProductDetailCard = ({
           src={product.imageUrl || emptyImage}
           fallbackSrc={emptyImage}
           alt={product.title}
+          placeholder="color"
         />
         {linkHref ? (
           <div className={styles.linkBtnContainer()}>

--- a/src/pages/home/components/product/SelectedProductSheet/SelectedProductSheet.tsx
+++ b/src/pages/home/components/product/SelectedProductSheet/SelectedProductSheet.tsx
@@ -109,6 +109,7 @@ const SelectedProductSheet = ({
                       src={product.imageUrl}
                       fallbackSrc={emptyImage}
                       alt={product.title}
+                      placeholder="color"
                     />
                   ) : (
                     <div className={styles.selectedImageFallback} aria-hidden>
@@ -174,6 +175,7 @@ const SelectedProductSheet = ({
                       src={product.imageUrl}
                       fallbackSrc={emptyImage}
                       alt=""
+                      placeholder="color"
                     />
                   ) : (
                     <div className={styles.compactImageFallback} aria-hidden>

--- a/src/pages/imageSetup/steps/interiorStyle/MoodboardCard.tsx
+++ b/src/pages/imageSetup/steps/interiorStyle/MoodboardCard.tsx
@@ -39,6 +39,7 @@ const MoodboardCard = ({
         sizes={IMAGE_SIZES.grid}
         alt={alt}
         className={styles.image}
+        placeholder="skeleton"
         draggable={false}
         decoding="async"
       />

--- a/src/pages/imageSetup/v2/steps/floorPlanSelect/FloorPlanSheet.css.ts
+++ b/src/pages/imageSetup/v2/steps/floorPlanSelect/FloorPlanSheet.css.ts
@@ -59,6 +59,10 @@ export const swiperContainer = style({
   overflow: 'hidden',
 });
 
+export const slide = style({
+  position: 'relative', // OptimizedImage placeholder(absolute)의 기준
+});
+
 export const slideImage = style({
   aspectRatio: '3 / 2',
   objectFit: 'cover',

--- a/src/pages/imageSetup/v2/steps/floorPlanSelect/FloorPlanSheet.tsx
+++ b/src/pages/imageSetup/v2/steps/floorPlanSelect/FloorPlanSheet.tsx
@@ -98,7 +98,7 @@ const FloorPlanSheet = ({
                 }}
               >
                 {detailViews.map((view, index) => (
-                  <SwiperSlide key={`view-${index}`}>
+                  <SwiperSlide key={`view-${index}`} className={styles.slide}>
                     <OptimizedImage
                       src={view.imageUrl ?? emptyImage}
                       sizes={IMAGE_SIZES.full}
@@ -108,6 +108,7 @@ const FloorPlanSheet = ({
                         styles.slideImage,
                         isMirror && styles.mirrored
                       )}
+                      placeholder="color"
                       draggable={false}
                       decoding="async"
                     />

--- a/src/pages/landing/LandingPage.css.ts
+++ b/src/pages/landing/LandingPage.css.ts
@@ -8,6 +8,8 @@ export const page = style({
   position: 'relative',
   display: 'flex',
   flexDirection: 'column',
+  // 배경 이미지 로드 전 단색. 텍스트가 흰색이므로 배경은 gray900(어두운 회색)
+  backgroundColor: colorVars.color.gray900,
   padding: `${unitVars.unit.gapPadding['300']} ${unitVars.unit.gapPadding['000']}`,
   width: '100%',
   minHeight: '100vh',

--- a/src/pages/mypage/components/card/genImgCard/GenImgCard.css.ts
+++ b/src/pages/mypage/components/card/genImgCard/GenImgCard.css.ts
@@ -1,11 +1,6 @@
 import { style } from '@vanilla-extract/css';
 import { recipe } from '@vanilla-extract/recipes';
 
-import {
-  animationTokens,
-  SKELETON_GRADIENT,
-} from '@styles/tokens/animation.css';
-
 import { colorVars } from '@/shared/styles/tokensV2/color.css';
 import { fontVars } from '@/shared/styles/tokensV2/font.css';
 import { unitVars } from '@/shared/styles/tokensV2/unit.css';
@@ -70,6 +65,7 @@ export const cardImg = recipe({
   },
 });
 
+// 가로 스크롤되는 상품 카드 리스트 (list 타입 카드 하단)
 export const listCardContainer = style({
   display: 'flex',
   alignItems: 'center',
@@ -91,13 +87,4 @@ export const listCardContainer = style({
       display: 'none',
     },
   },
-});
-
-export const skeleton = style({
-  position: 'absolute',
-  inset: 0,
-  borderRadius: '0.8rem',
-  background: SKELETON_GRADIENT,
-  backgroundSize: '200% 100%',
-  animation: `${animationTokens.skeletonWave} 2s linear infinite`,
 });

--- a/src/pages/mypage/components/card/genImgCard/GenImgCard.tsx
+++ b/src/pages/mypage/components/card/genImgCard/GenImgCard.tsx
@@ -1,5 +1,3 @@
-import { useState } from 'react';
-
 import { useNavigate } from 'react-router-dom';
 
 import { logMyPageClickBtnFurnitureCard } from '@pages/mypage/utils/analytics';
@@ -24,7 +22,6 @@ interface GenImgCardProps {
   imageUrl?: string;
   isMirror?: boolean;
   usedProducts?: UsedProductResponse[];
-  isLoaded?: boolean;
   onCurationClick?: () => void;
   onImageLoad?: (imageId: number, imageUrl?: string) => void;
 }
@@ -36,16 +33,13 @@ const GenImgCard = ({
   imageUrl,
   isMirror = false,
   usedProducts = [],
-  isLoaded = false,
   onCurationClick,
   onImageLoad,
 }: GenImgCardProps) => {
   const isListType = cardType === 'list';
-  const [isImageReady, setIsImageReady] = useState(isLoaded); // 이미지 로드 완료 여부
   const navigate = useNavigate();
 
   const handleImageLoad = () => {
-    setIsImageReady(true);
     onImageLoad?.(imageId, imageUrl);
   };
 
@@ -89,13 +83,12 @@ const GenImgCard = ({
         </TextButton>
       </section>
       <section className={styles.imgContainer} onClick={onCurationClick}>
-        {/* 이미지 로드 완료 전에는 skeleton, 완료 시 실제 이미지 렌더링 */}
-        {!isImageReady && <div className={styles.skeleton} />}
         <OptimizedImage
           src={imageUrl || emptyImage}
           fallbackSrc={emptyImage}
           alt={productSummaryText ?? '생성 이미지'}
           className={styles.cardImg({ mirrored: isMirror })}
+          placeholder="skeleton"
           onLoad={handleImageLoad}
         />
       </section>

--- a/src/pages/mypage/components/section/generatedImages/GeneratedImagesSection.tsx
+++ b/src/pages/mypage/components/section/generatedImages/GeneratedImagesSection.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 
 import { useNavigate } from 'react-router-dom';
 
@@ -34,17 +34,6 @@ const GeneratedImagesSection = () => {
 
   const { prefetchDetection } = useDetectionPrefetch();
   const prefetchedImageIdsRef = useRef<Set<number>>(new Set<number>());
-  const [loadedImages, setLoadedImages] = useState<Record<number, boolean>>(
-    () => {
-      if (typeof window === 'undefined') return {};
-      try {
-        const stored = sessionStorage.getItem('mypage-image-loaded');
-        return stored ? (JSON.parse(stored) as Record<number, boolean>) : {};
-      } catch {
-        return {};
-      }
-    }
-  );
 
   const primaryImageId =
     imagesListData?.groups?.[0]?.items?.[0]?.imageId ?? null;
@@ -133,18 +122,10 @@ const GeneratedImagesSection = () => {
   };
 
   /**
-   * 이미지 로드 완료 시 로컬 캐시를 갱신하고 프리패치 스케줄
+   * 이미지 로드 완료 시 감지 데이터 프리패치 스케줄
    */
   const handleImageLoad = useCallback(
     (imageId: number, imageUrl?: string) => {
-      setLoadedImages((prev) => {
-        if (prev[imageId]) return prev;
-        const next = { ...prev, [imageId]: true };
-        if (typeof window !== 'undefined') {
-          sessionStorage.setItem('mypage-image-loaded', JSON.stringify(next));
-        }
-        return next;
-      });
       if (imageUrl) {
         scheduleDetectionPrefetch(imageId, imageUrl, {
           immediate: primaryImageId === imageId,
@@ -192,7 +173,6 @@ const GeneratedImagesSection = () => {
                     imageUrl={item.generatedImageUrl}
                     isMirror={item.isMirror}
                     usedProducts={item.usedProducts}
-                    isLoaded={loadedImages[item.imageId]}
                     onCurationClick={() => handleViewResult(item)}
                     onImageLoad={() =>
                       handleImageLoad(item.imageId!, item.generatedImageUrl)

--- a/src/shared/components/card/floorCard/FloorCard.tsx
+++ b/src/shared/components/card/floorCard/FloorCard.tsx
@@ -17,6 +17,7 @@ const FloorPlanItem = ({ src, selected = false }: FloorPlanItemProps) => {
         sizes={IMAGE_SIZES.grid}
         className={styles.floorimg}
         alt="카드 이미지"
+        placeholder="skeleton"
         decoding="async"
       />
     </div>

--- a/src/shared/components/image/OptimizedImage.tsx
+++ b/src/shared/components/image/OptimizedImage.tsx
@@ -79,7 +79,12 @@ const OptimizedImage = ({
   // skeleton일 때만 delay 후 단색 → shimmer로 전환.
   // 그 안에 로드되면 isLoaded=true가 되어 shimmer 없이 단색만 보이고 끝난다.
   useEffect(() => {
-    if (placeholder !== 'skeleton' || placeholderDelay <= 0) return;
+    if (placeholder !== 'skeleton') return;
+    // delay가 0 이하면 단색 단계 없이 즉시 shimmer (delay가 양수→0으로 바뀌어도 보장)
+    if (placeholderDelay <= 0) {
+      setDelayPassed(true);
+      return;
+    }
     setDelayPassed(false);
     const timer = window.setTimeout(
       () => setDelayPassed(true),

--- a/src/shared/components/image/OptimizedImage.tsx
+++ b/src/shared/components/image/OptimizedImage.tsx
@@ -1,5 +1,5 @@
 import type { ComponentProps, ReactEventHandler } from 'react';
-import { useLayoutEffect, useRef, useState } from 'react';
+import { useEffect, useLayoutEffect, useRef, useState } from 'react';
 
 import clsx from 'clsx';
 
@@ -17,10 +17,17 @@ type OptimizedImageProps = Omit<ComponentProps<'img'>, 'src' | 'srcSet'> & {
   /** variant·원본이 모두 실패했을 때 마지막으로 보여줄 정적 이미지 */
   fallbackSrc?: string;
   /**
-   * 로딩 중 표시: 'skeleton'(shimmer) | 'color'(중립 단색) | 'none'(없음, 기본).
+   * 로딩 중 표시: 'skeleton'(단색 → shimmer) | 'color'(단색만) | 'none'(없음, 기본).
+   * 'none'이 아니면 로드 전까지 항상 단색이 깔려 이미지 영역 배경이 통일되고,
+   * 로드 완료 시 이미지 전체가 한 번에 페이드인되어 이미지가 위에서부터 아래로 끊기며 렌더링되지 않음
    * 'none'이 아니면 부모가 position: relative 여야 한다(placeholder가 absolute로 덮음).
    */
   placeholder?: Placeholder;
+  /**
+   * skeleton의 shimmer를 켜기까지의 지연(ms, 기본 200). 이 시간 안에 로드되면 shimmer 없이 단색만 보였다가 이미지가 페이드인되어, 빠른 네트워크에서 shimmer 깜빡임이 안 생긴다.
+   * color 모드엔 영향이 없다(항상 단색). 0이면 shimmer를 즉시 표시.
+   */
+  placeholderDelay?: number;
 };
 
 /**
@@ -40,6 +47,7 @@ const OptimizedImage = ({
   sizes,
   fallbackSrc,
   placeholder = 'none',
+  placeholderDelay = 200,
   className,
   onLoad,
   ...rest
@@ -51,6 +59,8 @@ const OptimizedImage = ({
   );
   const [currentSrc, setCurrentSrc] = useState(src);
   const [isLoaded, setIsLoaded] = useState(false);
+  // skeleton의 shimmer는 delay 후에만 켠다(빠른 네트워크에서 shimmer flash 방지)
+  const [delayPassed, setDelayPassed] = useState(placeholderDelay <= 0);
 
   // 부모가 새 src를 내려주면 페인트 전에 동기화 (옛 이미지가 한 프레임 노출되는 것 방지)
   useLayoutEffect(() => {
@@ -65,6 +75,18 @@ const OptimizedImage = ({
     const img = ref.current;
     setIsLoaded(Boolean(img?.complete && img.naturalWidth > 0));
   }, [currentSrc, srcSet, hasPlaceholder]);
+
+  // skeleton일 때만 delay 후 단색 → shimmer로 전환.
+  // 그 안에 로드되면 isLoaded=true가 되어 shimmer 없이 단색만 보이고 끝난다.
+  useEffect(() => {
+    if (placeholder !== 'skeleton' || placeholderDelay <= 0) return;
+    setDelayPassed(false);
+    const timer = window.setTimeout(
+      () => setDelayPassed(true),
+      placeholderDelay
+    );
+    return () => window.clearTimeout(timer);
+  }, [currentSrc, srcSet, placeholder, placeholderDelay]);
 
   const handleLoad: ReactEventHandler<HTMLImageElement> = (event) => {
     if (hasPlaceholder) setIsLoaded(true);
@@ -87,7 +109,7 @@ const OptimizedImage = ({
         <span
           aria-hidden
           className={
-            placeholder === 'skeleton'
+            placeholder === 'skeleton' && delayPassed
               ? styles.skeletonPlaceholder
               : styles.colorPlaceholder
           }

--- a/src/shared/components/v2/roomTypeCard/RoomTypeCard.tsx
+++ b/src/shared/components/v2/roomTypeCard/RoomTypeCard.tsx
@@ -51,8 +51,6 @@ type RoomTypeCardProps =
   | RoomTypePreviewCardProps
   | RoomTypeMoreCardProps;
 
-// TODO: API 연동 시 skeleton 등 적용
-
 const RoomTypeOptionCard = ({
   type: _variant,
   className,
@@ -79,6 +77,7 @@ const RoomTypeOptionCard = ({
         alt=""
         aria-hidden="true"
         className={styles.image}
+        placeholder="skeleton"
         loading={imageLoading}
         decoding="async" // 브라우저 이미지 디코딩 비동기 처리 -> 렌더링 성능. UX 개선
         draggable={false}
@@ -117,6 +116,7 @@ const RoomTypePreviewCard = ({
         fallbackSrc={emptyImage}
         alt={imageAlt}
         className={styles.image}
+        placeholder="color"
         loading={imageLoading}
         decoding="async"
         draggable={false}

--- a/src/shared/components/v2/styleCard/StyleCard.tsx
+++ b/src/shared/components/v2/styleCard/StyleCard.tsx
@@ -65,6 +65,7 @@ const StyleCard = ({
         alt=""
         aria-hidden
         className={styles.image}
+        placeholder={isLarge ? 'color' : 'skeleton'}
         loading={imageLoading}
         decoding="async"
         draggable={false}


### PR DESCRIPTION
## 📌 Summary

- close #599 

## 📄 Tasks

### 결과 페이지 뒤로가기 히스토리 꼬임 해결

**문제상황:**

ResultPage는 LoadingPage를 경유해 진입한 경우, 뒤로가기(POP)를 useExitBlocker(React Router useBlocker를 래핑한 커스텀 훅)로 막고 HOME으로 redirect함. 이 onBlocked 처리에서 React Router의 비동기 history 복원과 useBlocker의 onBlocked 콜백(동기 replace)이 브라우저 history를 거의 동시에 건들이는데, 실행 순서가 어긋나 브라우저 주소창에 뜬 주소와 사용자에게 렌더링된 페이지가 일치하지 않는 문제 발생

**문제 해결 전 로직 실행 흐름:**

1. **[React Router] 차단된 뒤로가기를 history 복원으로 되돌림 — 비동기**
    
    ResultPage에서 뒤로가기를 누르면 blocker가 POP을 차단하는데, 이때 React Router는 이미 바뀐 history 위치를 ResultPage로 되돌림. 이 복원은 history.go()로 일어나고, 그 popstate는 **다음 task에 비동기로 처리**됨
    
2. **[onBlocked 콜백] 복원을 기다리지 않고 동기로 replace**
    
    기존 코드는 reset()(blocker 해제) 직후 동기적으로 navigate(HOME, { replace: true })를 호출했음. 즉 1의 복원 popstate가 처리되기 전에 replace가 실행됨
    
3. **[결과] 브라우저 주소창과 React Router의 location이 어긋남**
    
    replace가 복원 완료된 Result 엔트리가 아니라 그 직전 엔트리를 HOME으로 덮어써 React Router의 location은 HOME이 됨. 뒤이어 도착한 복원 popstate는 브라우저 포인터를 옛 Result 엔트리(URL=/generate/result)로 옮기지만 React Router는 이 popstate를 복원용으로 인식해 무시함. → 브라우저 주소창(result)과 React가 렌더한 화면(home)이 불일치
    

**해결:**

replace를 `setTimeout(…,0)`으로 **현재 task 이후로 미뤄**, 이미 큐에 등록돼 있던 React Router의 복원 traversal(history.go)이 먼저 실행돼 포인터가 Result로 돌아온 뒤 replace가 실행되도록 함 → replace가 복원된 Result 엔트리를 대체

```tsx
// Before — 복원 popstate 전에 replace가 실행되어 history가 꼬임
onBlocked: ({ reset }) => {
	reset();
	navigate(ROUTES.HOME, { replace: true });
},

// After — replace를 현재 task 이후로 미뤄, 먼저 큐잉돼 있던 복원 traversal이 실행된 뒤 replace되도록 보장
onBlocked: ({ reset }) => {
	reset();
	// 복원 popstate가 처리된 다음 task에서 replace해야 Result 엔트리를 정확히 대체
	setTimeout(() => navigate(ROUTES.HOME, { replace: true }), 0);
},
```

---

### 네트워크 환경별 이미지 placeholder 정책

+) `OptimizedImage` 컴포넌트는 [이 PR](https://github.com/TEAM-HOUME/HOUME-CLIENT/pull/587)에서 하우미의 모든 이미지 컴포넌트(LoadingPage 캐러셀 제외)에 적용했었어요

**배경/목적:** `OptimizedImage` 이미지 컴포넌트의 placeholder·폴백 정책 설정 및 적용

1. 네트워크가 느린 환경에서 로딩 UX 개선
2. 이미지가 위→아래로 뚝뚝 끊기며 렌더링되는 점진적 렌더링(progressive rendering) 방지

**정책 (이미지 성격에 따라 3분류):**

| **유형** | **placeholder** | **로딩 중 표시** |
| --- | --- | --- |
| 히어로 (LCP급 큰 단일 이미지) | color | 단색(gray200) → 이미지 로드 완료 시 fade-in |
| 그리드/리스트 썸네일 | skeleton | 단색(gray200) → 이미지 로드에 200ms 초과 시 shimmer 스켈레톤 애니메이션 → 이미지 로드 완료 시 fade-in |
| 기타 (상품상세팝업, 일부 바텀시트 등 캐시를 재사용하는 컴포넌트) | color | 단색(gray200) → 이미지 로드 완료 시 fade-in |

**핵심 구현 — OptimizedImage:**
placeholder('none' | 'skeleton' | 'color')와 placeholderDelay(기본 200ms)로 제어함.

```tsx
// 로드 전엔 항상 단색을 깔고(영역 배경 통일 + progressive rendering 과정 숨김),
// skeleton은 로딩 delay(200ms)를 넘겨야 shimmer로 전환. 로드 완료 시 이미지를 fade-in.
{hasPlaceholder && !isLoaded && (
	<span className={
		placeholder === 'skeleton' && delayPassed
		? styles.skeletonPlaceholder   // shimmer
		: styles.colorPlaceholder      // 단색
	} />
)}
```

- 이미지 로드 전에는 항상 단색(gray200) 을 띄움 → 이미지 영역 배경 통일 + onLoad 전 opacity를 0으로 두어 progressive rendering을 가림
- 이미지가 200ms 안에 로드되면 shimmer 없이 단색만 보였다가 실제 이미지 fade-in (네트워크가 빠른 환경에서 shimmer로 인해 불필요한 깜빡임이 생기는 현상 방지)
- 이미지 로드에 200ms 이상 걸리면, 200ms 전까지는 단색(gray200)을 띄우다가 200ms부터 shimmer 스켈레톤 애니메이션 시작
- 캐시된 이미지: `OptimizedImage` 컴포넌트에서 img.complete 상태를 이미지 paint 전에 `useLayoutEffect`로 확인해 placeholder를 아예 띄우지 않음 → 페이지 재방문 혹은 캐시 재사용 시 깜빡임 없이 바로 이미지 렌더링
    
    예시)
    
    - 도면 선택 페이지의 `도면 상세 바텀시트(FloorPlanSheet)`의 Swiper 첫번째 이미지는 도면 선택 페이지 로드 시점에 이미 로드가 완료된 이미지이므로, `FloorPlanSheet`에서는 그 이미지를 렌더링하기만 하면 됨 ⇒ 캐시된 이미지를 바로 재사용하면 됨.
        
        캐시된 이미지이므로 즉시 렌더링되어 사실 별도의 placeholder가 필요없지만, 나머지 이미지 컴포넌트와의 통일성과 혹시 모를 상황을 대비해 `color` placeholder 적용
        
        
        <img width="230" alt="image" src="https://github.com/user-attachments/assets/ac6c0614-efcd-440b-9aa8-421d1c595e36" />

        
    - 상품 탭의 상품 상세 Popup 컴포넌트도 마찬가지로, 상품탭에서 이미 로드한 이미지를 상품 상세 Popup 컴포넌트에서 다시 띄우는 것이므로 위와 같은 이유로 color 적용
        
        
        <img width="230" alt="image" src="https://github.com/user-attachments/assets/fe764b16-b73c-42c3-851d-c3c9453bc7ba" />

        

**정책 설정 근거:**

- 이미지가 이미 WebP·리사이즈로 최적화돼 5G·Fast 4G에선 수백 ms 내에 로드+렌더가 끝남. 무조건 skeleton을 띄우면 오히려 shimmer 깜빡임이 더 눈에 띄어서, 로드가 200ms(평균 로드 시간 수준)를 넘을 때만 shimmer가 뜨도록 설정
- 이미지 특정에 따라 placeholder를 다르게 설정
    - 히어로 이미지는 페이지에서 가장 큰 LCP급 이미지라 풀스크린 shimmer가 오히려 난잡하게 느껴질 수 있음 → shimmer 스켈레톤 애니메이션 대신 단색 color로 처리
        
        ex) HOME과 RESULT 페이지에서, 가장 큰 영역을 차지하면서 단일 이미지를 렌더링하는 다음과 같은 컴포넌트에는 shimmer 대신 color 적용
        
        - HOME 페이지의 banner
                <img width="230" alt="image" src="https://github.com/user-attachments/assets/077b738d-d9c0-41b6-814a-0c8ddd52e295" />

        
        - RESULT 페이지의 결과이미지
                <img width="230" alt="image" src="https://github.com/user-attachments/assets/3f028e49-33d7-42da-8cbc-5a56f6c7b066" />

        
    - 그리드·리스트는 여러 장이 동시에 로드되므로 shimmer 적용, ‘이 이미지 영역이 곧 채워진다’는 신호를 자연스럽게 나타냄
        
        ex) 마이페이지 이미지 리스트를 포함해 그리드/리스트 형식으로 이미지를 띄우는 `OptimizedImage` 컴포넌트들에는 shimmer 적용
        
        
        <img width="230" alt="image" src="https://github.com/user-attachments/assets/e9f8939c-938d-46ac-b528-0fc70e715e4b" />

        
- color는 gray200으로 통일
- aspectRatio로 이미지 자리가 이미 확보돼 있어 placeholder가 CLS를 유발하지 않음

**함께 정리한 리팩토링:**

- ResultPage에서 히어로 이미지를 띄우는 컴포넌트인 `GenImgCard`가 직접 관리하던 skeleton <div> + isImageReady 상태를 OptimizedImage의 placeholder="skeleton"으로 일원화함 + 이에 따라 불필요해진 GeneratedImagesSection의 loadedImages·sessionStorage 캐시도 제거(ONNX의 감지 데이터 prefetch 로직은 혹시 몰라서 유지)

**이번 PR에서 placeholder를 적용하지 않은 컴포넌트:**

- LandingPage: 자체 dissolve 크로스페이드(이미지 전환 애니메이션)가 <img>의 opacity를 직접 제어해서 OptimizedImage의 fade와 충돌함 → placeholder 대신 page 루트에 단색 배경(gray900 — 흰 텍스트 대비 확보)만 깔아 첫 진입 시 빈 화면 방지. 첫 이미지의 progressive paint까지 잡으려면 dissolve 로직 수정이 필요한데, LandingPage의 이미지 4장 모두 약 100KB정도라 크게 체감되지 않아 우선 그대로 유지함.

## 🔍 To Reviewer

- 네트워크가 정상 환경(5G)일 때는 페이지 진입 즉시 이미지 로드가 완료되고, Fast 4G까지도 나쁘지 않은 속도(몇백ms정도)로 이미지 로드돼요. 이번 PR은 Slow 4G급의 네트워크 환경을 고려한 수정이라고 보시면 될 것 같습니다~

_리뷰어에게 요청하는 내용을 작성해주세요._

## 📸 Screenshot

-

_작업한 내용에 대한 스크린샷을 첨부해주세요._
