### PR TITLE
[fix] QA 4차 반영

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
     />
     <meta
       name="viewport"
-      content="width=device-width, initial-scale=1.0, maximum-scale=1.0"
+      content="width=device-width, initial-scale=1.0, maximum-scale=1.0, viewport-fit=cover"
     />
     <!-- 모바일 브라우저 툴바 색상 고정(흰색). 미지정 시 Safari/Edge가 페이지를 샘플링해 dim/html 배경(회색)을 따라가 툴바가 회색으로 변함 -->
     <meta name="theme-color" content="#FFFFFF" />

--- a/src/pages/home/components/product/ProductPopup/ProductDetailCard.css.ts
+++ b/src/pages/home/components/product/ProductPopup/ProductDetailCard.css.ts
@@ -5,7 +5,17 @@ import { colorVars } from '@shared/styles/tokensV2/color.css';
 import { fontVars } from '@shared/styles/tokensV2/font.css';
 import { unitVars } from '@shared/styles/tokensV2/unit.css';
 
+import {
+  SKELETON_GRADIENT,
+  animationTokens,
+} from '@styles/tokens/animation.css';
 import { zIndex } from '@styles/tokens/zIndex';
+
+const skeletonShimmer = style({
+  background: SKELETON_GRADIENT,
+  backgroundSize: '200% 100%',
+  animation: `${animationTokens.skeletonWave} 2s linear infinite`,
+});
 
 export const card = style({
   display: 'flex',
@@ -16,6 +26,7 @@ export const card = style({
 export const imageWrap = style({
   aspectRatio: '1 / 1',
   position: 'relative',
+  flexShrink: 0,
   borderTopLeftRadius: unitVars.unit.radius['300'],
   borderTopRightRadius: unitVars.unit.radius['300'],
   width: '100%',
@@ -52,6 +63,7 @@ export const metaRow = style({
   alignItems: 'center',
   justifyContent: 'space-between',
   width: '100%',
+  minHeight: '1.4rem',
 });
 
 export const colorRow = style({
@@ -139,3 +151,33 @@ export const discountPrice = style({
   ...fontVars.font.title_sb_15,
   color: colorVars.color.text.primary,
 });
+
+export const skeletonBrand = style([
+  skeletonShimmer,
+  brand,
+  {
+    display: 'block',
+    width: '30%',
+    color: 'transparent',
+  },
+]);
+
+export const skeletonOriginalPrice = style([
+  skeletonShimmer,
+  originalPrice,
+  {
+    display: 'block',
+    width: '28%',
+    color: 'transparent',
+  },
+]);
+
+export const skeletonDiscountPrice = style([
+  skeletonShimmer,
+  discountPrice,
+  {
+    display: 'block',
+    width: '40%',
+    color: 'transparent',
+  },
+]);

--- a/src/pages/home/components/product/ProductPopup/ProductDetailCard.css.ts
+++ b/src/pages/home/components/product/ProductPopup/ProductDetailCard.css.ts
@@ -158,6 +158,7 @@ export const skeletonBrand = style([
   {
     display: 'block',
     width: '30%',
+    minHeight: '1.56rem',
     color: 'transparent',
   },
 ]);
@@ -168,6 +169,7 @@ export const skeletonOriginalPrice = style([
   {
     display: 'block',
     width: '28%',
+    minHeight: '1.43rem',
     color: 'transparent',
   },
 ]);
@@ -178,6 +180,7 @@ export const skeletonDiscountPrice = style([
   {
     display: 'block',
     width: '40%',
+    minHeight: '2.25rem',
     color: 'transparent',
   },
 ]);

--- a/src/pages/home/components/product/ProductPopup/ProductDetailCard.tsx
+++ b/src/pages/home/components/product/ProductPopup/ProductDetailCard.tsx
@@ -22,6 +22,7 @@ export interface ProductDetailCardProps {
   saveCount?: number;
   link?: LinkInfo;
   linkHrefOverride?: string;
+  isLoading?: boolean;
 }
 
 const ProductDetailCard = ({
@@ -30,6 +31,7 @@ const ProductDetailCard = ({
   saveCount,
   link,
   linkHrefOverride,
+  isLoading = false,
 }: ProductDetailCardProps) => {
   const { openProductLink } = useProductLink();
   const { visibleColors, extraColorCount } = getColorChips(product.colorHexes);
@@ -42,15 +44,26 @@ const ProductDetailCard = ({
     Number.isFinite(price.discountRate) &&
     price.discountRate > 0;
 
+  const hasColors = visibleColors.length > 0 || extraColorCount > 0;
+  const hasSaveCount =
+    typeof saveCount === 'number' && Number.isFinite(saveCount);
+  const hasMetaRow = hasColors || hasSaveCount;
+  const reserveMetaRow = isLoading && !hasMetaRow;
+
+  const hasPrice = Boolean(originalPriceText || discountPriceText);
+  const showBrandSkeleton = isLoading && !product.brand;
+  const showPriceSkeleton = isLoading && !hasPrice;
+
   return (
-    <div className={styles.card}>
+    <div className={styles.card} aria-busy={isLoading}>
       <div className={styles.imageWrap}>
         <OptimizedImage
           className={styles.image}
           src={product.imageUrl || emptyImage}
           fallbackSrc={emptyImage}
           alt={product.title}
-          placeholder="color"
+          placeholder="skeleton"
+          loading="eager"
         />
         {linkHref ? (
           <div className={styles.linkBtnContainer()}>
@@ -68,11 +81,9 @@ const ProductDetailCard = ({
         ) : null}
       </div>
       <div className={styles.info}>
-        {visibleColors.length > 0 ||
-        extraColorCount > 0 ||
-        (typeof saveCount === 'number' && Number.isFinite(saveCount)) ? (
-          <div className={styles.metaRow}>
-            {visibleColors.length > 0 || extraColorCount > 0 ? (
+        {(hasMetaRow || reserveMetaRow) && (
+          <div className={styles.metaRow} aria-hidden={reserveMetaRow}>
+            {hasColors ? (
               <div className={styles.colorRow}>
                 {visibleColors.map((hex, index) => (
                   <div
@@ -93,7 +104,7 @@ const ProductDetailCard = ({
                 ) : null}
               </div>
             ) : null}
-            {typeof saveCount === 'number' && Number.isFinite(saveCount) ? (
+            {hasSaveCount ? (
               <div className={styles.likeRow}>
                 <Icon name="HeartFillGray" size="14" />
                 <span className={styles.likeCount}>
@@ -102,10 +113,14 @@ const ProductDetailCard = ({
               </div>
             ) : null}
           </div>
+        )}
+        {product.brand ? (
+          <p className={styles.brand}>{product.brand}</p>
+        ) : showBrandSkeleton ? (
+          <span className={styles.skeletonBrand} aria-hidden />
         ) : null}
-        {!!product.brand && <p className={styles.brand}>{product.brand}</p>}
         <p className={styles.title}>{product.title}</p>
-        {(originalPriceText || discountPriceText) && (
+        {hasPrice ? (
           <div className={styles.priceSection}>
             {hasDiscount && originalPriceText ? (
               <p className={styles.originalPrice}>{originalPriceText}</p>
@@ -121,7 +136,14 @@ const ProductDetailCard = ({
               )}
             </div>
           </div>
-        )}
+        ) : showPriceSkeleton ? (
+          <div className={styles.priceSection} aria-hidden>
+            {hasDiscount ? (
+              <span className={styles.skeletonOriginalPrice} />
+            ) : null}
+            <span className={styles.skeletonDiscountPrice} />
+          </div>
+        ) : null}
       </div>
     </div>
   );

--- a/src/pages/home/components/product/ProductPopup/ProductDetailOverlay.tsx
+++ b/src/pages/home/components/product/ProductPopup/ProductDetailOverlay.tsx
@@ -46,7 +46,7 @@ const ProductDetailOverlay = ({
   shoppingAction,
 }: ProductDetailOverlayProps) => {
   const navigate = useNavigate();
-  const { data } = useProductDetailQuery(id);
+  const { data, isPending } = useProductDetailQuery(id);
   const detail = data?.product;
   const { mutate: toggleJjym } = useJjymMutation({
     onSavedAction: () => {
@@ -134,6 +134,7 @@ const ProductDetailOverlay = ({
           saveCount={merged.saveCount}
           link={link}
           linkHrefOverride={merged.linkHrefOverride}
+          isLoading={isPending}
         />
       }
     />

--- a/src/pages/home/components/product/SearchSection/SearchSection.css.ts
+++ b/src/pages/home/components/product/SearchSection/SearchSection.css.ts
@@ -132,13 +132,28 @@ export const scrollTopFloatingLayer = style({
 });
 
 export const scrollTopFloatingWrap = style({
+  boxSizing: 'border-box',
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center',
   transform: 'translateY(0.8rem)',
   transition: 'opacity 240ms ease, transform 240ms ease',
   opacity: 0,
-  border: `1px solid ${colorVars.color.border.tertiary}`,
+  border: `1px solid ${colorVars.color.border.secondary}`,
   borderRadius: unitVars.unit.radius['full'],
-  backgroundColor: colorVars.color.bg.primary,
+  backgroundColor: colorVars.color.fill.inverse,
   pointerEvents: 'none',
+  width: '4rem',
+  height: '4rem',
+});
+
+export const scrollTopFloatingButton = style({
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  padding: 0,
+  width: '100%',
+  height: '100%',
 });
 
 export const scrollTopFloatingWrapVisible = style({

--- a/src/pages/home/components/product/SearchSection/SearchSection.css.ts
+++ b/src/pages/home/components/product/SearchSection/SearchSection.css.ts
@@ -28,7 +28,7 @@ export const searchHeader = style({
 export const stickyHeader = style({
   position: 'fixed',
   zIndex: zIndex.navigation,
-  top: 0,
+  top: 'env(safe-area-inset-top, 0px)',
   margin: '0 auto',
   background: colorVars.color.bg.primary,
   width: '100%',

--- a/src/pages/home/components/product/SearchSection/SearchSection.tsx
+++ b/src/pages/home/components/product/SearchSection/SearchSection.tsx
@@ -278,6 +278,7 @@ const SearchSection = ({
           <IconButton
             name="ArrowUp"
             size="S"
+            className={styles.scrollTopFloatingButton}
             aria-label="페이지 상단으로 이동"
             onClick={handleScrollToTopClick}
           />

--- a/src/shared/components/v2/menuTab/MenuTab.css.ts
+++ b/src/shared/components/v2/menuTab/MenuTab.css.ts
@@ -22,7 +22,7 @@ export const menuTabBar = recipe({
       true: {
         position: 'sticky',
         zIndex: zIndex.sticky,
-        top: 0,
+        top: 'env(safe-area-inset-top, 0px)',
       },
       false: {
         position: 'static',

--- a/src/shared/components/v2/navBar/LogoNavBar.css.ts
+++ b/src/shared/components/v2/navBar/LogoNavBar.css.ts
@@ -6,15 +6,19 @@ import { colorVars } from '@styles/tokensV2/color.css';
 import { fontVars } from '@styles/tokensV2/font.css';
 import { unitVars } from '@styles/tokensV2/unit.css';
 
+const NAV_BAR_CONTENT_HEIGHT = '4.8rem';
+
 export const container = style({
+  boxSizing: 'border-box',
   zIndex: zIndex.navBar,
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'space-between',
+  paddingTop: 'env(safe-area-inset-top, 0px)',
   width: '100%',
   minWidth: unitVars.unit.dimension.wMin,
   maxWidth: unitVars.unit.dimension.wMax,
-  height: '4.8rem',
+  height: `calc(${NAV_BAR_CONTENT_HEIGHT} + env(safe-area-inset-top, 0px))`,
 });
 
 export const leftContainer = style({

--- a/src/shared/components/v2/navBar/TitleNavBar.css.ts
+++ b/src/shared/components/v2/navBar/TitleNavBar.css.ts
@@ -7,30 +7,35 @@ import { unitVars } from '@styles/tokensV2/unit.css';
 
 import { zIndex } from '@/shared/styles/tokens/zIndex';
 
+const NAV_BAR_CONTENT_HEIGHT = '4.8rem';
+const SAFE_AREA_INSET_TOP = 'env(safe-area-inset-top, 0px)';
+
 export const container = recipe({
   base: {
+    boxSizing: 'border-box',
     zIndex: zIndex.navBar,
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'space-between',
+    paddingTop: SAFE_AREA_INSET_TOP,
     paddingRight: unitVars.unit.gapPadding['400'],
     paddingLeft: unitVars.unit.gapPadding['300'],
     width: '100%',
     minWidth: unitVars.unit.dimension.wMin,
     maxWidth: unitVars.unit.dimension.wMax,
-    height: '4.8rem',
+    height: `calc(${NAV_BAR_CONTENT_HEIGHT} + ${SAFE_AREA_INSET_TOP})`,
   },
   variants: {
     placement: {
       /** 일반 페이지: 문서 흐름 + 상단 고정 */
       sticky: {
         position: 'sticky',
-        top: 'env(safe-area-inset-top, 0px)',
+        top: 0,
       },
       /** 풀블리드 콘텐츠 위 오버레이(부모는 `position: relative` 권장) */
       overContent: {
         position: 'absolute',
-        top: 'env(safe-area-inset-top, 0px)',
+        top: 0,
         right: 0,
         left: 0,
         marginRight: 'auto',
@@ -96,7 +101,7 @@ export const label = style({
 
 export const title = style({
   position: 'absolute',
-  top: '50%',
+  top: `calc(${SAFE_AREA_INSET_TOP} + ${NAV_BAR_CONTENT_HEIGHT} / 2)`,
   left: '50%',
   transform: 'translate(-50%, -50%)',
   margin: 0,

--- a/src/shared/components/v2/navBar/TitleNavBar.css.ts
+++ b/src/shared/components/v2/navBar/TitleNavBar.css.ts
@@ -25,12 +25,12 @@ export const container = recipe({
       /** 일반 페이지: 문서 흐름 + 상단 고정 */
       sticky: {
         position: 'sticky',
-        top: 0,
+        top: 'env(safe-area-inset-top, 0px)',
       },
       /** 풀블리드 콘텐츠 위 오버레이(부모는 `position: relative` 권장) */
       overContent: {
         position: 'absolute',
-        top: 0,
+        top: 'env(safe-area-inset-top, 0px)',
         right: 0,
         left: 0,
         marginRight: 'auto',


### PR DESCRIPTION
## 📌 Summary

- close #594

QA 사항을 4차로 반영했어요. 상품 모달 레이아웃 시프트, iOS 상단 UI 가림, 상품 탭 scroll-to-top 버튼 스타일 이슈를 수정했습니다.

## 📄 Tasks

- 상품 상세 모달 레이아웃 시프트 문제 해결
   - 상품 모달 이미지 영역 CLS 개선 
   - 상세 API 로딩 중 리스트 데이터 우선 표시 + 없는 필드만 인라인 스켈레톤
   - 색상/찜수 메타 행 로딩 중 높이 확보
- iOS 일부 환경에서 상단 탭 UI 가려지는 문제 해결
  - index.html에 viewport-fit=cover 추가
   sticky/fixed 헤더 top에 env(safe-area-inset-top, 0px) 적용 (MenuTab, TitleNavBar, 상품 필터)
- scroll-to-top 버튼 4rem × 4rem 고정 및 아이콘 중앙 정렬

## 🔍 To Reviewer

#### 상품 모달 레이아웃 시프트 개선
상품 상세 팝업이 열릴 때 이미지·텍스트 영역이 순간적으로 밀리는 문제를 수정했습니다. 
이미지 영역은 flexShrink와 skeleton placeholder로 크기를 먼저 잡고, 텍스트는 리스트에서 이미 가진 데이터를 바로 보여주도록 합니다. 상세 API 응답 전에는 없는 필드만 스켈레톤으로 채우고, 컬러/찜수 행은 로딩 중 높이만 확보합니다. 모달이 열릴 때 콘텐츠가 갑자기 늘어나거나 줄어드는 현상을 줄이기 위해 적용했어요.

#### iOS safe-area 적용
스크롤 시 상단 탭·네비바·필터 헤더가 상태바(시간/와이파이/배터리)에 가려지는 문제를 수정했어요. 
safe-area는 노치·상태바 아래부터 콘텐츠를 그려야 하는 안전 영역이고, CSS `env(safe-area-inset-top)`으로 그 여백만큼 sticky/fixed 요소의 top을 내립니다. 그래서 index.html에 `viewport-fit=cover`를 추가해 iOS가 이 값을 인식하게 했어요. 

> 참고로 CSS env()는 개발용 .env 파일과는 무관합니다. 스크롤해도 상단 UI가 상태바 뒤로 들어가지 않게 하기 위해 사용됩니다!


## 📸 Screenshot

