### PR TITLE
[feat] Sentry 에러·성능 모니터링 활성화 및 토큰 스크러빙

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "**/*": "prettier --write --ignore-unknown"
   },
   "dependencies": {
-    "@sentry/react": "^10.34.0",
+    "@sentry/react": "^10.63.0",
     "@tanstack/react-query": "^5.81.5",
     "@tanstack/react-query-devtools": "^5.81.5",
     "@use-funnel/browser": "^0.0.15",
@@ -57,6 +57,7 @@
     "@antebudimir/eslint-plugin-vanilla-extract": "^1.16.0",
     "@chromatic-com/storybook": "^5.0.0",
     "@eslint/js": "^9.29.0",
+    "@sentry/vite-plugin": "^5.3.0",
     "@storybook/addon-a11y": "^10.1.11",
     "@storybook/addon-docs": "^10.1.11",
     "@storybook/addon-vitest": "^10.1.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,8 +8,8 @@ importers:
   .:
     dependencies:
       '@sentry/react':
-        specifier: ^10.34.0
-        version: 10.34.0(react@19.2.0)
+        specifier: ^10.63.0
+        version: 10.63.0(react@19.2.0)
       '@tanstack/react-query':
         specifier: ^5.81.5
         version: 5.81.5(react@19.2.0)
@@ -92,6 +92,9 @@ importers:
       '@eslint/js':
         specifier: ^9.29.0
         version: 9.30.0
+      '@sentry/vite-plugin':
+        specifier: ^5.3.0
+        version: 5.3.0(rollup@4.44.1)
       '@storybook/addon-a11y':
         specifier: ^10.1.11
         version: 10.1.11(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.6.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))
@@ -1834,56 +1837,168 @@ packages:
         integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==,
       }
 
-  '@sentry-internal/browser-utils@10.34.0':
+  '@sentry/babel-plugin-component-annotate@5.3.0':
     resolution:
       {
-        integrity: sha512-0YNr60rGHyedmwkO0lbDBjNx2KAmT3kWamjaqu7Aw+jsESoPLgt+fzaTVvUBvkftBDui2PeTSzXm/nqzssctYg==,
+        integrity: sha512-p4q8gn8wcFqZGP/s2MnJCAAd8fTikaU6A0mM97RDHQgStcrYiaS0Sc5zUNfb1V+UOLPuvdEdL6MwyxfzjYJQTA==,
+      }
+    engines: { node: '>= 18' }
+
+  '@sentry/browser-utils@10.63.0':
+    resolution:
+      {
+        integrity: sha512-DhUGNN+CH8fzAs6qAsueKPU70qShyTX3NxLhIP+l5DbGXDSXpYXBT6s8ubZus0/LhxpLvI0iSyNIDvZRD/gZaA==,
       }
     engines: { node: '>=18' }
 
-  '@sentry-internal/feedback@10.34.0':
+  '@sentry/browser@10.63.0':
     resolution:
       {
-        integrity: sha512-wgGnq+iNxsFSOe9WX/FOvtoItSTjgLJJ4dQkVYtcVM6WGBVIg4wgNYfECCnRNztUTPzpZHLjC9r+4Pym451DDQ==,
+        integrity: sha512-0mi56YOkwgyjdLOcN5cB1//EcYzEOt3NZ2GLygE92B3zAAwVM1WgbmibZCXToKFClH7z1uH3VWVfBffmkwIMYw==,
       }
     engines: { node: '>=18' }
 
-  '@sentry-internal/replay-canvas@10.34.0':
+  '@sentry/bundler-plugin-core@5.3.0':
     resolution:
       {
-        integrity: sha512-XWH/9njtgMD+LLWjc4KKgBpb+dTCkoUEIFDxcvzG/87d+jirmzf0+r8EfpLwKG+GrqNiiGRV39zIqu0SfPl+cw==,
+        integrity: sha512-L5T60sWdAI3qWwdg3Ptwek/0TY59PERrxyqp4XMUkroayQvGd9r5dIW9Q1kSeXX9iJ442nXbFZKAOyCKV4Z13Q==,
+      }
+    engines: { node: '>= 18' }
+
+  '@sentry/cli-darwin@2.58.6':
+    resolution:
+      {
+        integrity: sha512-udAVvcyfNa0R+95GvPz/+43/N3TC0TYKdkQ7D7jhPSzbcMc7l2fxRNN5yB3UpCA5fWFnW4toeaqwDBhb/Wh3LA==,
+      }
+    engines: { node: '>=10' }
+    os: [darwin]
+
+  '@sentry/cli-linux-arm64@2.58.6':
+    resolution:
+      {
+        integrity: sha512-q8mEcNNmeXMy5i+jWT30TVpH7LcP4HD21CD5XRSPAd/a912HF6EpK0ybf/1USO14WOhoXbAGi9txwaWabSe33g==,
+      }
+    engines: { node: '>=10' }
+    cpu: [arm64]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-linux-arm@2.58.6':
+    resolution:
+      {
+        integrity: sha512-pD0LAt5PcUzAinBwvDqc66x9+2CabHEv486yP0gRjWO7SakbaxmfVq/EXd8VLq/Tzi39LAu422UYK1lpW3MILw==,
+      }
+    engines: { node: '>=10' }
+    cpu: [arm]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-linux-i686@2.58.6':
+    resolution:
+      {
+        integrity: sha512-q8vNJi1eOV/4vxAFWBsEwLHoSYapaZHIf4j76KJGJXFKTkEbsjCOOsKbwUIBTQQhRgV4DFWh3ryfsPS/que4Kg==,
+      }
+    engines: { node: '>=10' }
+    cpu: [x86, ia32]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-linux-x64@2.58.6':
+    resolution:
+      {
+        integrity: sha512-DZu956Mhi3ZRjTBe1WdbGV46ldVbA8d2rgp/fh51GsI25zjBHah4wZnPTSzpc+YqxU6pJpg579B/r3jrIK530Q==,
+      }
+    engines: { node: '>=10' }
+    cpu: [x64]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-win32-arm64@2.58.6':
+    resolution:
+      {
+        integrity: sha512-nj0Ff/kmAB73EPDhR8B4O9r+NUHK5GkPCkGWC+kXVemqAJWL5jcJ5KdxG0l/S0z6RoEoltID8/43/B+TaMlT7A==,
+      }
+    engines: { node: '>=10' }
+    cpu: [arm64]
+    os: [win32]
+
+  '@sentry/cli-win32-i686@2.58.6':
+    resolution:
+      {
+        integrity: sha512-WNZiDzPbgsEMQWq4avsQ391v/xWKJDIWWWo9GYl+N/w5qcYKkoDW7wQG7T9FasI6ENn68phChTOAPXXxbfAdOg==,
+      }
+    engines: { node: '>=10' }
+    cpu: [x86, ia32]
+    os: [win32]
+
+  '@sentry/cli-win32-x64@2.58.6':
+    resolution:
+      {
+        integrity: sha512-R35WJ17oF4D2eqI1DR2sQQqr0fjRTt5xoP16WrTu91XM2lndRMFsnjh+/GttbxapLCBNlrjzia99MJ0PZHZpgA==,
+      }
+    engines: { node: '>=10' }
+    cpu: [x64]
+    os: [win32]
+
+  '@sentry/cli@2.58.6':
+    resolution:
+      {
+        integrity: sha512-baBcNPLLfUi9WuL+Tpri9BFaAdvugZIKelC5X0tt0Zdy+K0K+PCVSrnNmwMWU/HyaF/SEv6b6UHnXIdqanBlcg==,
+      }
+    engines: { node: '>= 10' }
+    hasBin: true
+
+  '@sentry/core@10.63.0':
+    resolution:
+      {
+        integrity: sha512-OtUbsrnbEHffOF2S2+M5zXa3HIM0U2b4CDVLKMY1dgS0J3ivRF8XvkjvyIcEG/y8JXnwXbnprLyjhG+AqMdUZQ==,
       }
     engines: { node: '>=18' }
 
-  '@sentry-internal/replay@10.34.0':
+  '@sentry/feedback@10.63.0':
     resolution:
       {
-        integrity: sha512-Vmea0GcOg57z/S1bVSj3saFcRvDqdLzdy4wd9fQMpMgy5OCbTlo7lxVUndKzbcZnanma6zF6VxwnWER1WuN9RA==,
+        integrity: sha512-If/+72xFg9ylz4twUo3U9gUpZ+Ys+T/3Y09WH7r2gGhWEOF9bp+ta94+Pg7Lb0M2nVD7waz4OxIvB49GEvtLDA==,
       }
     engines: { node: '>=18' }
 
-  '@sentry/browser@10.34.0':
+  '@sentry/react@10.63.0':
     resolution:
       {
-        integrity: sha512-8WCsAXli5Z+eIN8dMY8KGQjrS3XgUp1np/pjdeWNrVPVR8q8XpS34qc+f+y/LFrYQC9bs2Of5aIBwRtDCIvRsg==,
-      }
-    engines: { node: '>=18' }
-
-  '@sentry/core@10.34.0':
-    resolution:
-      {
-        integrity: sha512-4FFpYBMf0VFdPcsr4grDYDOR87mRu6oCfb51oQjU/Pndmty7UgYo0Bst3LEC/8v0SpytBtzXq+Wx/fkwulBesg==,
-      }
-    engines: { node: '>=18' }
-
-  '@sentry/react@10.34.0':
-    resolution:
-      {
-        integrity: sha512-LDpg9WDrEwo6lr/YOAA54id/g5D1PGKEIiOGxqRZbBVyjzrsquwzhSG2CMqnp+YO6lz/r96LWuqm2cvfpht2zA==,
+        integrity: sha512-+/Y0dd4EMqyqYBJ1D3bAYYuG+ccIx5+IFcbTZ9p+XWnW6nNIVjy5zttVftYo6xOmtTQbzRuPT/vO4dqDHKKmfw==,
       }
     engines: { node: '>=18' }
     peerDependencies:
       react: ^16.14.0 || 17.x || 18.x || 19.x
+
+  '@sentry/replay-canvas@10.63.0':
+    resolution:
+      {
+        integrity: sha512-1Dg6yo+KDNZcE9M6V2EP4DGgTDJMcUgg5ui69w/E96ZZPWErS/bibK2bGj20H3qwpJXlnEwXB5YAJ2fZ620T1A==,
+      }
+    engines: { node: '>=18' }
+
+  '@sentry/replay@10.63.0':
+    resolution:
+      {
+        integrity: sha512-u4fDaLbd4QmJbU0qGzV5g2B2hjw5utdeZzpTrmq565AS5o6mfaZdCz30zF9R2Unkn0g9SJr90piTN2RMwvDrkw==,
+      }
+    engines: { node: '>=18' }
+
+  '@sentry/rollup-plugin@5.3.0':
+    resolution:
+      {
+        integrity: sha512-hgPGPYdQJ/G1cGYOxAb7d4z3V+/k/E5/P/5TFPEEBLuIbFFk+JG0CISUDJdzXJjO382Lb99PBJuXGbueBmO79w==,
+      }
+    engines: { node: '>= 18' }
+    peerDependencies:
+      rollup: '>=3.2.0'
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+
+  '@sentry/vite-plugin@5.3.0':
+    resolution:
+      {
+        integrity: sha512-qcoSzo4n2MulVQ70UUPLq6dTleb2a2HwL2wuwvAgWhPChrYTuk6A6mDg6aQb9fairPAwFPiU9PzOANpoDJcz1A==,
+      }
+    engines: { node: '>= 18' }
 
   '@storybook/addon-a11y@10.1.11':
     resolution:
@@ -2787,6 +2902,13 @@ packages:
     engines: { node: '>=0.4.0' }
     hasBin: true
 
+  agent-base@6.0.2:
+    resolution:
+      {
+        integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==,
+      }
+    engines: { node: '>= 6.0.0' }
+
   agent-base@7.1.4:
     resolution:
       {
@@ -3012,6 +3134,13 @@ packages:
         integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==,
       }
 
+  balanced-match@4.0.4:
+    resolution:
+      {
+        integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==,
+      }
+    engines: { node: 18 || 20 || >=22 }
+
   bidi-js@1.0.3:
     resolution:
       {
@@ -3035,6 +3164,13 @@ packages:
       {
         integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==,
       }
+
+  brace-expansion@5.0.7:
+    resolution:
+      {
+        integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==,
+      }
+    engines: { node: 18 || 20 || >=22 }
 
   braces@3.0.3:
     resolution:
@@ -3662,6 +3798,13 @@ packages:
       {
         integrity: sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==,
       }
+
+  dotenv@16.6.1:
+    resolution:
+      {
+        integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==,
+      }
+    engines: { node: '>=12' }
 
   dotenv@17.4.2:
     resolution:
@@ -4416,6 +4559,13 @@ packages:
     engines: { node: 20 || >=22 }
     hasBin: true
 
+  glob@13.0.6:
+    resolution:
+      {
+        integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==,
+      }
+    engines: { node: 18 || 20 || >=22 }
+
   globals@11.12.0:
     resolution:
       {
@@ -4579,6 +4729,13 @@ packages:
       {
         integrity: sha512-EC2utToWl4RKfs5zd36Mxq7nzHHBuomZboI0yYL6Y0RmBgT7Sgkq4rQ0ezFTYoIsSs7Tm9SJe+o2FcAg6GBhGA==,
       }
+
+  https-proxy-agent@5.0.1:
+    resolution:
+      {
+        integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==,
+      }
+    engines: { node: '>= 6' }
 
   https-proxy-agent@7.0.6:
     resolution:
@@ -5621,6 +5778,13 @@ packages:
       }
     engines: { node: 20 || >=22 }
 
+  minimatch@10.2.5:
+    resolution:
+      {
+        integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==,
+      }
+    engines: { node: 18 || 20 || >=22 }
+
   minimatch@3.1.2:
     resolution:
       {
@@ -5644,6 +5808,13 @@ packages:
     resolution:
       {
         integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==,
+      }
+    engines: { node: '>=16 || 14 >=14.17' }
+
+  minipass@7.1.3:
+    resolution:
+      {
+        integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==,
       }
     engines: { node: '>=16 || 14 >=14.17' }
 
@@ -6026,6 +6197,13 @@ packages:
       }
     engines: { node: 20 || >=22 }
 
+  path-scurry@2.0.2:
+    resolution:
+      {
+        integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==,
+      }
+    engines: { node: 18 || 20 || >=22 }
+
   path-to-regexp@6.3.0:
     resolution:
       {
@@ -6169,6 +6347,13 @@ packages:
         integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==,
       }
     engines: { node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0 }
+
+  progress@2.0.3:
+    resolution:
+      {
+        integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==,
+      }
+    engines: { node: '>=0.4.0' }
 
   prop-types@15.8.1:
     resolution:
@@ -8779,39 +8964,117 @@ snapshots:
 
   '@rtsao/scc@1.1.0': {}
 
-  '@sentry-internal/browser-utils@10.34.0':
-    dependencies:
-      '@sentry/core': 10.34.0
+  '@sentry/babel-plugin-component-annotate@5.3.0': {}
 
-  '@sentry-internal/feedback@10.34.0':
+  '@sentry/browser-utils@10.63.0':
     dependencies:
-      '@sentry/core': 10.34.0
+      '@sentry/core': 10.63.0
 
-  '@sentry-internal/replay-canvas@10.34.0':
+  '@sentry/browser@10.63.0':
     dependencies:
-      '@sentry-internal/replay': 10.34.0
-      '@sentry/core': 10.34.0
+      '@sentry/browser-utils': 10.63.0
+      '@sentry/core': 10.63.0
+      '@sentry/feedback': 10.63.0
+      '@sentry/replay': 10.63.0
+      '@sentry/replay-canvas': 10.63.0
 
-  '@sentry-internal/replay@10.34.0':
+  '@sentry/bundler-plugin-core@5.3.0':
     dependencies:
-      '@sentry-internal/browser-utils': 10.34.0
-      '@sentry/core': 10.34.0
+      '@babel/core': 7.28.6
+      '@sentry/babel-plugin-component-annotate': 5.3.0
+      '@sentry/cli': 2.58.6
+      dotenv: 16.6.1
+      find-up: 5.0.0
+      glob: 13.0.6
+      magic-string: 0.30.17
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
 
-  '@sentry/browser@10.34.0':
+  '@sentry/cli-darwin@2.58.6':
+    optional: true
+
+  '@sentry/cli-linux-arm64@2.58.6':
+    optional: true
+
+  '@sentry/cli-linux-arm@2.58.6':
+    optional: true
+
+  '@sentry/cli-linux-i686@2.58.6':
+    optional: true
+
+  '@sentry/cli-linux-x64@2.58.6':
+    optional: true
+
+  '@sentry/cli-win32-arm64@2.58.6':
+    optional: true
+
+  '@sentry/cli-win32-i686@2.58.6':
+    optional: true
+
+  '@sentry/cli-win32-x64@2.58.6':
+    optional: true
+
+  '@sentry/cli@2.58.6':
     dependencies:
-      '@sentry-internal/browser-utils': 10.34.0
-      '@sentry-internal/feedback': 10.34.0
-      '@sentry-internal/replay': 10.34.0
-      '@sentry-internal/replay-canvas': 10.34.0
-      '@sentry/core': 10.34.0
+      https-proxy-agent: 5.0.1
+      node-fetch: 2.7.0
+      progress: 2.0.3
+      proxy-from-env: 1.1.0
+      which: 2.0.2
+    optionalDependencies:
+      '@sentry/cli-darwin': 2.58.6
+      '@sentry/cli-linux-arm': 2.58.6
+      '@sentry/cli-linux-arm64': 2.58.6
+      '@sentry/cli-linux-i686': 2.58.6
+      '@sentry/cli-linux-x64': 2.58.6
+      '@sentry/cli-win32-arm64': 2.58.6
+      '@sentry/cli-win32-i686': 2.58.6
+      '@sentry/cli-win32-x64': 2.58.6
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
 
-  '@sentry/core@10.34.0': {}
+  '@sentry/core@10.63.0': {}
 
-  '@sentry/react@10.34.0(react@19.2.0)':
+  '@sentry/feedback@10.63.0':
     dependencies:
-      '@sentry/browser': 10.34.0
-      '@sentry/core': 10.34.0
+      '@sentry/core': 10.63.0
+
+  '@sentry/react@10.63.0(react@19.2.0)':
+    dependencies:
+      '@sentry/browser': 10.63.0
+      '@sentry/core': 10.63.0
       react: 19.2.0
+
+  '@sentry/replay-canvas@10.63.0':
+    dependencies:
+      '@sentry/core': 10.63.0
+      '@sentry/replay': 10.63.0
+
+  '@sentry/replay@10.63.0':
+    dependencies:
+      '@sentry/browser-utils': 10.63.0
+      '@sentry/core': 10.63.0
+
+  '@sentry/rollup-plugin@5.3.0(rollup@4.44.1)':
+    dependencies:
+      '@sentry/bundler-plugin-core': 5.3.0
+      magic-string: 0.30.17
+    optionalDependencies:
+      rollup: 4.44.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  '@sentry/vite-plugin@5.3.0(rollup@4.44.1)':
+    dependencies:
+      '@sentry/bundler-plugin-core': 5.3.0
+      '@sentry/rollup-plugin': 5.3.0(rollup@4.44.1)
+    transitivePeerDependencies:
+      - encoding
+      - rollup
+      - supports-color
 
   '@storybook/addon-a11y@10.1.11(storybook@10.1.11(@testing-library/dom@10.4.0)(prettier@3.6.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))':
     dependencies:
@@ -9500,6 +9763,12 @@ snapshots:
 
   acorn@8.15.0: {}
 
+  agent-base@6.0.2:
+    dependencies:
+      debug: 4.4.1
+    transitivePeerDependencies:
+      - supports-color
+
   agent-base@7.1.4: {}
 
   ajv-draft-04@1.0.0(ajv@8.18.0):
@@ -9649,6 +9918,8 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
+  balanced-match@4.0.4: {}
+
   bidi-js@1.0.3:
     dependencies:
       require-from-string: 2.0.2
@@ -9663,6 +9934,10 @@ snapshots:
   brace-expansion@2.0.2:
     dependencies:
       balanced-match: 1.0.2
+
+  brace-expansion@5.0.7:
+    dependencies:
+      balanced-match: 4.0.4
 
   braces@3.0.3:
     dependencies:
@@ -9992,6 +10267,8 @@ snapshots:
     dependencies:
       no-case: 3.0.4
       tslib: 2.8.1
+
+  dotenv@16.6.1: {}
 
   dotenv@17.4.2: {}
 
@@ -10601,6 +10878,12 @@ snapshots:
       package-json-from-dist: 1.0.1
       path-scurry: 2.0.1
 
+  glob@13.0.6:
+    dependencies:
+      minimatch: 10.2.5
+      minipass: 7.1.3
+      path-scurry: 2.0.2
+
   globals@11.12.0: {}
 
   globals@14.0.0: {}
@@ -10691,6 +10974,13 @@ snapshots:
       - supports-color
 
   http2-client@1.3.5: {}
+
+  https-proxy-agent@5.0.1:
+    dependencies:
+      agent-base: 6.0.2
+      debug: 4.4.1
+    transitivePeerDependencies:
+      - supports-color
 
   https-proxy-agent@7.0.6:
     dependencies:
@@ -11476,6 +11766,10 @@ snapshots:
     dependencies:
       '@isaacs/brace-expansion': 5.0.0
 
+  minimatch@10.2.5:
+    dependencies:
+      brace-expansion: 5.0.7
+
   minimatch@3.1.2:
     dependencies:
       brace-expansion: 1.1.12
@@ -11487,6 +11781,8 @@ snapshots:
   minimist@1.2.8: {}
 
   minipass@7.1.2: {}
+
+  minipass@7.1.3: {}
 
   mlly@1.7.4:
     dependencies:
@@ -11744,6 +12040,11 @@ snapshots:
       lru-cache: 11.2.4
       minipass: 7.1.2
 
+  path-scurry@2.0.2:
+    dependencies:
+      lru-cache: 11.2.6
+      minipass: 7.1.3
+
   path-to-regexp@6.3.0: {}
 
   path-type@4.0.0: {}
@@ -11807,6 +12108,8 @@ snapshots:
       ansi-regex: 5.0.1
       ansi-styles: 5.2.0
       react-is: 17.0.2
+
+  progress@2.0.3: {}
 
   prop-types@15.8.1:
     dependencies:

--- a/src/shared/config/sentry.ts
+++ b/src/shared/config/sentry.ts
@@ -5,6 +5,21 @@ const SENTRY_ENVIRONMENT =
   import.meta.env.VITE_SENTRY_ENVIRONMENT ?? import.meta.env.MODE;
 const SENTRY_RELEASE =
   import.meta.env.VITE_SENTRY_RELEASE ?? `houme-client@${__APP_VERSION__}`;
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
+
+// 에러 리포트에서 토큰·민감 헤더를 제거
+function scrubSensitiveData(event: Sentry.ErrorEvent): Sentry.ErrorEvent {
+  const headers = event.request?.headers;
+  if (headers) {
+    delete headers['Authorization'];
+    delete headers['authorization'];
+  }
+  // withCredentials: true라 쿠키에 refresh token이 있을 수 있어 통째로 제거
+  if (event.request?.cookies) {
+    delete event.request.cookies;
+  }
+  return event;
+}
 
 export function initSentry() {
   if (!SENTRY_DSN) return;
@@ -13,6 +28,22 @@ export function initSentry() {
     dsn: SENTRY_DSN,
     environment: SENTRY_ENVIRONMENT,
     release: SENTRY_RELEASE,
+    // 로컬 개발(pnpm dev)에서는 이벤트를 전송하지 않음
+    enabled: !import.meta.env.DEV,
+
+    // ── 성능 추적 (tracing) ──
+    integrations: [Sentry.browserTracingIntegration()],
+    // 프로덕션은 10%만 샘플링(무료 플랜 quota라 한도 고려), 그 외 환경은 전량 수집
+    tracesSampleRate: import.meta.env.PROD ? 0.1 : 1.0,
+    // trace 헤더(sentry-trace/baggage)를 전파할 대상 — API 도메인
+    tracePropagationTargets: API_BASE_URL ? [API_BASE_URL] : [],
+
+    // ── 개인정보·토큰 보호 ──
+    sendDefaultPii: false,
+    // SESSION_EXPIRED는 정상 로그아웃 플로우라 리포트에서 제외
+    ignoreErrors: [/SESSION_EXPIRED/],
+    beforeSend: scrubSensitiveData,
+
     initialScope: {
       tags: {
         app: 'houme-client',

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,6 +2,7 @@
 import { fileURLToPath } from 'node:url';
 import path from 'path';
 
+import { sentryVitePlugin } from '@sentry/vite-plugin';
 import { storybookTest } from '@storybook/addon-vitest/vitest-plugin';
 import { vanillaExtractPlugin } from '@vanilla-extract/vite-plugin';
 import react from '@vitejs/plugin-react';
@@ -26,9 +27,20 @@ export default defineConfig({
         },
       },
     }),
+    // 프로덕션 빌드 시 source map을 Sentry에 업로드 (auth token이 있을 때만 동작)
+    sentryVitePlugin({
+      org: 'jstar',
+      project: process.env.SENTRY_PROJECT,
+      authToken: process.env.SENTRY_AUTH_TOKEN,
+      disable: !process.env.SENTRY_AUTH_TOKEN,
+    }),
   ],
   define: {
     __APP_VERSION__: JSON.stringify(process.env.npm_package_version ?? '0.0.0'),
+  },
+  build: {
+    // source map은 Sentry auth token이 있을 때만 생성 → 업로드 후 플러그인이 삭제(원본 노출 방지)
+    sourcemap: process.env.SENTRY_AUTH_TOKEN ? 'hidden' : false,
   },
   server: {
     host: true,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -29,10 +29,14 @@ export default defineConfig({
     }),
     // 프로덕션 빌드 시 source map을 Sentry에 업로드 (auth token이 있을 때만 동작)
     sentryVitePlugin({
-      org: 'jstar',
+      org: process.env.SENTRY_ORG,
       project: process.env.SENTRY_PROJECT,
       authToken: process.env.SENTRY_AUTH_TOKEN,
       disable: !process.env.SENTRY_AUTH_TOKEN,
+      // 업로드 후 dist에 남은 .map 삭제 → 배포물에 원본 소스 노출 방지
+      sourcemaps: {
+        filesToDeleteAfterUpload: ['./dist/**/*.map'],
+      },
     }),
   ],
   define: {


### PR DESCRIPTION
## Summary

- **문제**: Sentry 뼈대(`initSentry()`)는 있었지만 DSN 미설정으로 early 리턴돼 사실상 꺼져 있었고, 성능 추적·토큰 보호가 없었음 
- **진행사항**: 성능 추적(tracing) 활성화 + 에러 리포트 토큰 스크러빙 + 노이즈 필터 + source map 업로드 설정 추가
- **리뷰 포인트**: `beforeSend`의 토큰 제거 로직과 `tracePropagationTargets`의 서버 CORS 의존성.

## 배경

- 기존 `sentry.ts`는 `initSentry()` 골격만 있고 DSN이 없어 `if (!SENTRY_DSN) return`으로 early 리턴 → 이벤트가 전혀 전송되지 않는 상태 
- 이번 PR에서 **에러 + 성능 추적**을 켜되, 카카오 OAuth·JWT 인증 특성상 **토큰이 리포트에 유출되지 않도록** 방어 로직 적용

## 구현 내용

### 성능 추적(tracing) 활성화

- `browserTracingIntegration()` 추가 → 실사용자 Web Vitals·라우트 전환·fetch/XHR timing 수집
- `tracesSampleRate`: 프로덕션 10%(무료 플랜 quota 고려), 그 외 100%
  - 프로덕션 환경에서 생셩되는 성능 데이터 중 10%만 기록 및 Sentry에 전송 - 무료 플랜이라 한도를 고려해 이렇게 설정해뒀고, 트래픽이 많이 발생하면 유료 플랜으로 업그레이드 할 예정
- `tracePropagationTargets`: API 도메인(`VITE_API_BASE_URL`)만

### 토큰·개인정보 보호

- `beforeSend`(`scrubSensitiveData`): 에러 이벤트에서 `Authorization` 헤더·쿠키 제거 → `axiosInstance`의 Bearer 토큰이 리포트에 실리는 것 차단
- `sendDefaultPii: false`

### 노이즈 필터 / 전송 제어

- `ignoreErrors: [/SESSION_EXPIRED/]`: 정상 로그아웃 플로우(`axiosInstance` 토큰 재발급 실패)는 에러 리포트에서 제외
- `enabled: !import.meta.env.DEV`: 로컬 개발(`pnpm dev`) 이벤트 전송 차단

### source map 업로드 설정

- `@sentry/vite-plugin` 추가 → 프로덕션의 압축된 스택을 원본 코드 위치로 표시
  - 배포용 JS는 압축된 상태라 에러가 나면 에러 발생 위치가 `chunk-4f2a.js:1:88213`처럼 뜨는 문제가 있음 -> source map으로 압축된 코드와 원본 코드를 매핑시켜 원본 위치를 파악하이 용이함.
- `SENTRY_AUTH_TOKEN`이 있을 때만 동작(`disable`), `build.sourcemap`도 token 있을 때만 `'hidden'` 생성 → 원본 코드 공개 방지

### SDK 업데이트

- `@sentry/react` 10.34 → 10.63 (메이저 동일, React 19 지원)

## 이번 PR에서 하지 않은 것 (범위)

- **Vercel 환경변수 주입(`VITE_SENTRY_DSN` 등)**: `if (!SENTRY_DSN) return`으로 no-op이라 **머지해도 문제 X**
- **source map 실제 업로드**: `SENTRY_AUTH_TOKEN`·`SENTRY_PROJECT`를 Vercel env에 넣어야 동작
- **TanStack Query 에러 선별 전송**: 예상된 API 에러가 대부분이라 노이즈 우려로 이번엔 제외(uncaught + route 에러만). 필요 시 후속에서 5xx만 선별 추가.

## To Reviewer

- `tracePropagationTargets`가 API 요청에 `sentry-trace`/`baggage` 헤더를 붙여요. **서버가 CORS에서 이 헤더를 허용하지 않으면 요청이 깨질 수 있어** — 배포 후 확인이 필요하고, 문제 생기면 이 옵션만 임시로 빼면 돼요.
- 번들 크기: Sentry SDK + tracing이 메인 번들에 포함되며 gzip 약 35~40KB 증가해요. 최종 번들 크기가 몇백KB가 넘었던 것 같은데 확인해보고 조만간 번들 크기 최적화도 진행해야될 것 같아요
