### PR TITLE
[fix] 5차 QA 반영

### DIFF
--- a/src/pages/generate/v2/pages/loading/LoadingPage.tsx
+++ b/src/pages/generate/v2/pages/loading/LoadingPage.tsx
@@ -14,6 +14,8 @@ import { ROUTES } from '@routes/paths';
 
 import { useImageFlowStore } from '@store/useImageFlowStore';
 
+import { TOASTER_ID, TOAST_TYPE } from '@shared/types/toast';
+
 import type { GetCarouselResponseDTO } from '@apis/__generated__/data-contracts';
 
 import TestImg from '@assets/v2/images/TestImg.png';
@@ -27,8 +29,6 @@ import { useToast } from '@components/v2/toast/useToast';
 import { TOAST_MESSAGE } from '@constants/toastMessage';
 
 import { useExitBlocker } from '@hooks/useExitBlocker';
-
-import { TOASTER_ID, TOAST_TYPE } from '@/shared/types/toast';
 
 import { useExitImageFlow } from './hooks/useExitImageFlow';
 import { useGenerateImageRequest } from './hooks/useGenerateImageRequest';
@@ -177,12 +177,29 @@ const LoadingPage = () => {
     });
   }, [notify]);
 
+  const notifyActionServerError = useCallback(() => {
+    notify({
+      text: TOAST_MESSAGE.ACTION_SERVER_ERROR,
+      type: TOAST_TYPE.ERROR,
+      options: { toasterId: TOASTER_ID.BOTTOM_4 },
+    });
+  }, [notify]);
+
+  const recoverFromImageGenerationError = useCallback(() => {
+    exitImageFlow();
+    navigate(ROUTES.HOME, { replace: true });
+  }, [exitImageFlow, navigate]);
+
   // 진입경로별 mutation 호출 (풀퍼널 / banner / otherStyle / product 분기)
   useEffect(() => {
     const onMutationError = (error: unknown) => {
       if (isImageGenerationServerError(error)) {
         notifyImageGenerationError();
+      } else {
+        notifyActionServerError();
       }
+
+      recoverFromImageGenerationError();
     };
 
     // mutation 응답 시(성공/실패 모두) 퍼널/프리셋 데이터 즉시 정리
@@ -217,7 +234,12 @@ const LoadingPage = () => {
         requestState.mutate(requestState.payload, mutateOptions);
         return;
     }
-  }, [notifyImageGenerationError, requestState]);
+  }, [
+    notifyActionServerError,
+    notifyImageGenerationError,
+    recoverFromImageGenerationError,
+    requestState,
+  ]);
 
   useEffect(() => {
     return () => {

--- a/src/pages/generate/v2/pages/loading/LoadingPage.tsx
+++ b/src/pages/generate/v2/pages/loading/LoadingPage.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
+import { isAxiosError } from 'axios';
 import { overlay } from 'overlay-kit';
 import { ErrorBoundary } from 'react-error-boundary';
 import { Navigate, useNavigate } from 'react-router-dom';
@@ -20,13 +21,14 @@ import TestImg from '@assets/v2/images/TestImg.png';
 import FeatureErrorFallback from '@components/errorFallback/FeatureErrorFallback';
 import OptimizedImage from '@components/image/OptimizedImage';
 import Loading from '@components/loading/Loading';
-import { useToast } from '@components/toast/useToast';
 import Popup from '@components/v2/popup/Popup';
+import { useToast } from '@components/v2/toast/useToast';
 
-import { useErrorHandler } from '@hooks/useErrorHandler';
+import { TOAST_MESSAGE } from '@constants/toastMessage';
+
 import { useExitBlocker } from '@hooks/useExitBlocker';
 
-import { TOAST_TYPE } from '@/shared/types/toastLegacy';
+import { TOASTER_ID, TOAST_TYPE } from '@/shared/types/toast';
 
 import { useExitImageFlow } from './hooks/useExitImageFlow';
 import { useGenerateImageRequest } from './hooks/useGenerateImageRequest';
@@ -36,11 +38,19 @@ import { usePostCarouselLikeMutation } from '../../apis/mutations/useCarouselLik
 import Tooltip from '../../components/tooltip/Tooltip';
 
 const ANIMATION_DURATION = 600; // 캐러셀 애니메이션 지속 시간 (ms)
+const IMAGE_GENERATION_ERROR_CODES = new Set([50013, 50017, 50400]);
+
+const isImageGenerationServerError = (error: unknown) => {
+  if (!isAxiosError(error)) return false;
+
+  const code = error.response?.data?.code;
+
+  return typeof code === 'number' && IMAGE_GENERATION_ERROR_CODES.has(code);
+};
 
 // TODO: 커스텀 훅, 유틸함수로 빼기, 기능 별 커스텀 훅 분할 시급
 const LoadingPage = () => {
   const navigate = useNavigate();
-  const { handleError } = useErrorHandler('generate');
   const { notify } = useToast();
 
   // 툴팁
@@ -150,7 +160,6 @@ const LoadingPage = () => {
     data: currentStack,
     isPending,
     isError,
-    error,
   } = useStackDataQuery(isRequestValid);
 
   const currentImages = currentStack?.carousels ?? [];
@@ -159,11 +168,30 @@ const LoadingPage = () => {
   const { mutate: postLike, isPending: isJjymLoading } =
     usePostCarouselLikeMutation();
 
+  const notifyImageGenerationError = useCallback(() => {
+    notify({
+      text: TOAST_MESSAGE.IMAGE_GENERATION_SERVER_ERROR,
+      type: TOAST_TYPE.ERROR,
+      hasIcon: false,
+      options: { toasterId: TOASTER_ID.BOTTOM_4 },
+    });
+  }, [notify]);
+
+  useEffect(() => {
+    if (!import.meta.env.DEV) return;
+    const searchParams = new URLSearchParams(window.location.search);
+
+    if (searchParams.get('debugImageErrorToast') === 'true') {
+      notifyImageGenerationError();
+    }
+  }, [notifyImageGenerationError]);
+
   // 진입경로별 mutation 호출 (풀퍼널 / banner / otherStyle / product 분기)
   useEffect(() => {
-    const onMutationError = (error: Error) => {
-      console.error('이미지 생성 실패:', error);
-      handleError(error, 'loading');
+    const onMutationError = (error: unknown) => {
+      if (isImageGenerationServerError(error)) {
+        notifyImageGenerationError();
+      }
     };
 
     // mutation 응답 시(성공/실패 모두) 퍼널/프리셋 데이터 즉시 정리
@@ -198,13 +226,7 @@ const LoadingPage = () => {
         requestState.mutate(requestState.payload, mutateOptions);
         return;
     }
-  }, [handleError, requestState]);
-
-  useEffect(() => {
-    if (isError && error) {
-      handleError(error, 'loading');
-    }
-  }, [error, handleError, isError]);
+  }, [notifyImageGenerationError, requestState]);
 
   useEffect(() => {
     return () => {
@@ -276,13 +298,6 @@ const LoadingPage = () => {
       postLike(displayCurrentImage.rawProductId, {
         onSuccess: () => {
           goToNext();
-        },
-        onError: () => {
-          notify({
-            //TODO: 서버 에러 토스트 구현
-            text: '잠시 오류가 발생했어요. 다시 시도해주세요.',
-            type: TOAST_TYPE.WARNING,
-          });
         },
       });
     } else {

--- a/src/pages/generate/v2/pages/loading/LoadingPage.tsx
+++ b/src/pages/generate/v2/pages/loading/LoadingPage.tsx
@@ -173,18 +173,9 @@ const LoadingPage = () => {
       text: TOAST_MESSAGE.IMAGE_GENERATION_SERVER_ERROR,
       type: TOAST_TYPE.ERROR,
       hasIcon: false,
-      options: { toasterId: TOASTER_ID.BOTTOM_4 },
+      options: { toasterId: TOASTER_ID.TOP_4 },
     });
   }, [notify]);
-
-  useEffect(() => {
-    if (!import.meta.env.DEV) return;
-    const searchParams = new URLSearchParams(window.location.search);
-
-    if (searchParams.get('debugImageErrorToast') === 'true') {
-      notifyImageGenerationError();
-    }
-  }, [notifyImageGenerationError]);
 
   // 진입경로별 mutation 호출 (풀퍼널 / banner / otherStyle / product 분기)
   useEffect(() => {

--- a/src/pages/generate/v2/pages/loading/hooks/useExitImageFlow.ts
+++ b/src/pages/generate/v2/pages/loading/hooks/useExitImageFlow.ts
@@ -1,3 +1,5 @@
+import { useCallback } from 'react';
+
 import { useGenerateStore } from '@pages/generate/v2/stores/useGenerateStore';
 import { useFunnelStore } from '@pages/imageSetup/stores/useFunnelStore';
 
@@ -12,9 +14,9 @@ import { useImageFlowStore } from '@store/useImageFlowStore';
 export const useExitImageFlow = () => {
   const resetGenerate = useGenerateStore((s) => s.resetGenerate);
 
-  return () => {
+  return useCallback(() => {
     useFunnelStore.getState().reset();
     useImageFlowStore.getState().reset();
     resetGenerate();
-  };
+  }, [resetGenerate]);
 };

--- a/src/pages/imageSetup/ImageSetupPage.tsx
+++ b/src/pages/imageSetup/ImageSetupPage.tsx
@@ -9,6 +9,7 @@ import { getNextFunnelStep, useImageFlowStore } from '@store/useImageFlowStore';
 
 import FeatureErrorFallback from '@components/errorFallback/FeatureErrorFallback';
 
+import { useCreditGuard } from '@hooks/useCreditGuard';
 import { useLoginGate } from '@hooks/useLoginGate';
 
 import { getLoginRedirect } from '@utils/loginRedirect';
@@ -46,6 +47,7 @@ const ImageSetupPage = () => {
   const funnel = useImageSetup();
   const navigate = useNavigate();
   const { requireLogin } = useLoginGate();
+  const { checkCredit } = useCreditGuard(1);
   const [currentStep, setCurrentStep] = useState<StepType>('FloorPlanSelect');
 
   // 퍼널 데이터 정리 방식
@@ -91,7 +93,7 @@ const ImageSetupPage = () => {
         <funnel.Render
           FloorPlanSelect={funnel.Render.with({
             events: {
-              selectedFloorPlan: (
+              selectedFloorPlan: async (
                 data: CompletedFloorPlanSelect,
                 { history }
               ) => {
@@ -106,6 +108,9 @@ const ImageSetupPage = () => {
                 } else {
                   // 숏퍼널(경로 2, 4, 5): FloorPlanSelect가 마지막 스텝 → 바로 이미지 생성으로 이동
                   // payload는 LoadingPage가 useImageFlowStore.preset + useFunnelStore.floorPlan으로 조립
+                  const hasCredit = await checkCredit();
+                  if (!hasCredit) return;
+
                   navigate(ROUTES.GENERATE);
                 }
               },

--- a/src/pages/mypage/MyPage.tsx
+++ b/src/pages/mypage/MyPage.tsx
@@ -23,13 +23,33 @@ import * as styles from './MyPage.css';
 
 export type MypageMenuTab = 'generatedImages' | 'savedItems';
 
+const DEFAULT_MENU_TAB: MypageMenuTab = 'generatedImages';
+
+const getMypageMenuTab = (tab: unknown) => {
+  if (tab === 'generatedImages' || tab === 'savedItems') {
+    return tab;
+  }
+
+  return undefined;
+};
+
 const MyPage = () => {
   const navigate = useNavigate();
   const location = useLocation();
 
-  const [activeMenuTab, setActiveMenuTab] = useState<MypageMenuTab>(
-    location.state?.activeTab ?? 'generatedImages' // TODO: 결과 페이지에서 수정 필요
-  );
+  const [activeMenuTab, setActiveMenuTab] =
+    useState<MypageMenuTab>(DEFAULT_MENU_TAB);
+
+  useEffect(() => {
+    const nextTab = getMypageMenuTab(location.state?.activeTab);
+
+    if (!nextTab) {
+      return;
+    }
+
+    setActiveMenuTab(nextTab);
+    navigate(location.pathname, { replace: true, state: null });
+  }, [location.key, location.pathname, location.state?.activeTab, navigate]);
 
   // 탭 상태 관리 (찜 토스트로 들어온 경우 찜 탭으로 이동을 위해 추가했었음.)
   // // sessionStorage에서 탭 정보 가져오기

--- a/src/pages/mypage/MyPage.tsx
+++ b/src/pages/mypage/MyPage.tsx
@@ -10,9 +10,8 @@ import { useUserStore } from '@store/useUserStore';
 import FeatureErrorFallback from '@components/errorFallback/FeatureErrorFallback';
 import InlineError from '@components/inlineError/InlineError';
 import Loading from '@components/loading/Loading';
+import MenuTab from '@components/v2/menuTab/MenuTab';
 import TitleNavBar from '@components/v2/navBar/TitleNavBar';
-
-import MenuTab from '@/shared/components/v2/menuTab/MenuTab';
 
 import { useMyPageProfileQuery } from './apis/queries/useEditProfileQuery';
 import { useMyPageUserQuery } from './apis/queries/useMyPageUserQuery';
@@ -37,8 +36,9 @@ const MyPage = () => {
   const navigate = useNavigate();
   const location = useLocation();
 
-  const [activeMenuTab, setActiveMenuTab] =
-    useState<MypageMenuTab>(DEFAULT_MENU_TAB);
+  const [activeMenuTab, setActiveMenuTab] = useState<MypageMenuTab>(
+    () => getMypageMenuTab(location.state?.activeTab) ?? DEFAULT_MENU_TAB
+  );
 
   useEffect(() => {
     const nextTab = getMypageMenuTab(location.state?.activeTab);

--- a/src/pages/mypage/components/card/genImgCard/GenImgCard.tsx
+++ b/src/pages/mypage/components/card/genImgCard/GenImgCard.tsx
@@ -4,6 +4,8 @@ import { logMyPageClickBtnFurnitureCard } from '@pages/mypage/utils/analytics';
 
 import { ROUTES } from '@routes/paths';
 
+import { useSavedItemsStore } from '@store/useSavedItemsStore';
+
 import type { UsedProductResponse } from '@apis/__generated__/data-contracts';
 import { useJjymMutation } from '@apis/mutations/useJjymMutation';
 
@@ -38,6 +40,10 @@ const GenImgCard = ({
 }: GenImgCardProps) => {
   const isListType = cardType === 'list';
   const navigate = useNavigate();
+  const savedProductIds = useSavedItemsStore((state) => state.savedProductIds);
+  const touchedProductIds = useSavedItemsStore(
+    (state) => state.touchedProductIds
+  );
 
   const handleImageLoad = () => {
     onImageLoad?.(imageId, imageUrl);
@@ -97,6 +103,10 @@ const GenImgCard = ({
         <section className={styles.listCardContainer}>
           {usedProducts.map((item) => {
             if (item.rawProductId == null) return null;
+            const isSaved = touchedProductIds.has(item.rawProductId)
+              ? savedProductIds.has(item.rawProductId)
+              : (item.isJjym ?? false);
+
             return (
               <ListProductCard
                 key={item.rawProductId}
@@ -111,7 +121,7 @@ const GenImgCard = ({
                   discountRate: item.discountRate ?? 0,
                 }}
                 save={{
-                  isSaved: item.isJjym ?? false,
+                  isSaved,
                   onToggle: () => handleToggleSave(item.rawProductId!),
                 }}
                 link={{

--- a/src/pages/mypage/components/section/savedItems/SavedItemsSection.tsx
+++ b/src/pages/mypage/components/section/savedItems/SavedItemsSection.tsx
@@ -81,6 +81,12 @@ const SavedItemsSection = () => {
         {savedItems.map((item) => {
           const isTargetItem =
             String(item.rawProductId) === String(focusItemId);
+          const isSaved = isSavedItemsSynced
+            ? savedProductIds.has(item.rawProductId)
+            : true;
+          const jjymCount = isSaved
+            ? item.jjymCount
+            : Math.max(0, item.jjymCount - 1);
 
           return (
             <div
@@ -101,11 +107,9 @@ const SavedItemsSection = () => {
                   discountRate: item.discountRate,
                 }}
                 save={{
-                  isSaved: isSavedItemsSynced
-                    ? savedProductIds.has(item.rawProductId)
-                    : true,
+                  isSaved,
                   onToggle: () => handleToggleSave(item.rawProductId),
-                  count: item.jjymCount,
+                  count: jjymCount,
                 }}
                 link={{
                   href: item.productSiteUrl,

--- a/src/shared/apis/config/globalErrorHandler.test.ts
+++ b/src/shared/apis/config/globalErrorHandler.test.ts
@@ -1,13 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // 외부 의존성 모킹 (실제 모듈 동작과 독립적으로 로직만 검증)
-vi.mock('react-toastify', () => ({ toast: vi.fn() }));
+vi.mock('sonner', () => ({ toast: { custom: vi.fn() } }));
 vi.mock('@routes/paths', () => ({ ROUTES: { LOGIN: '/login' } }));
 vi.mock('@shared/types/toast', () => ({
-  TOAST_TYPE: { WARNING: 'warning' },
-  toastStyle: {},
+  TOAST_TYPE: { ERROR: 'error' },
+  TOASTER_ID: { BOTTOM_4: 'bottom-4' },
 }));
-vi.mock('@components/toast/Toast', () => ({ default: vi.fn() }));
+vi.mock('@components/v2/toast/Toast', () => ({ default: vi.fn() }));
+vi.mock('@components/v2/toast/Toast.css', () => ({ toastStyle: {} }));
 vi.mock('@/routes/router', () => ({ router: { navigate: vi.fn() } }));
 
 import { handleGlobalError, isSessionExpiredError } from './globalErrorHandler';
@@ -33,19 +34,39 @@ describe('isSessionExpiredError', () => {
 describe('handleGlobalError', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    window.history.replaceState(null, '', '/');
   });
 
-  // SESSION_EXPIRED가 아닌 에러는 toast를 띄우지 않아야 함
-  it('SESSION_EXPIRED가 아닌 에러는 toast를 호출하지 않는다', async () => {
-    const { toast } = await import('react-toastify');
+  it('쿼리 실패의 네트워크 에러는 전역 toast를 호출하지 않는다', async () => {
+    const { toast } = await import('sonner');
+
     handleGlobalError(new Error('Network Error'));
-    expect(toast).not.toHaveBeenCalled();
+
+    expect(toast.custom).not.toHaveBeenCalled();
   });
 
-  // SESSION_EXPIRED 에러는 toast를 호출해야 함
-  it('SESSION_EXPIRED 에러는 toast를 호출한다', async () => {
-    const { toast } = await import('react-toastify');
+  it('이미지 생성 예외 코드는 LoadingPage에서만 처리하도록 전역 toast를 호출하지 않는다', async () => {
+    const { toast } = await import('sonner');
+
+    handleGlobalError({
+      isAxiosError: true,
+      response: {
+        status: 500,
+        data: {
+          code: 50013,
+          message: 'GENERATED_IMAGE_EXCEPTION',
+        },
+      },
+    });
+
+    expect(toast.custom).not.toHaveBeenCalled();
+  });
+
+  it('SESSION_EXPIRED 에러는 v2 sonner toast를 호출한다', async () => {
+    const { toast } = await import('sonner');
+
     handleGlobalError(new Error('SESSION_EXPIRED'));
-    expect(toast).toHaveBeenCalledTimes(1);
+
+    expect(toast.custom).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/shared/apis/config/globalErrorHandler.ts
+++ b/src/shared/apis/config/globalErrorHandler.ts
@@ -1,6 +1,5 @@
 import { createElement } from 'react';
 
-import { isAxiosError } from 'axios';
 import { toast } from 'sonner';
 
 import { ROUTES } from '@routes/paths';
@@ -9,10 +8,6 @@ import { TOASTER_ID, TOAST_TYPE } from '@shared/types/toast';
 
 import Toast from '@components/v2/toast/Toast';
 import { toastStyle } from '@components/v2/toast/Toast.css';
-
-import { TOAST_MESSAGE } from '@constants/toastMessage';
-
-const IMAGE_GENERATION_ERROR_CODES = new Set([50013, 50017, 50400]);
 
 // React 외부 toast 유틸 (훅을 쓸 수 없는 모듈 스코프에서 사용)
 const showGlobalToast = (text: string, hasIcon = true) => {
@@ -23,58 +18,6 @@ const showGlobalToast = (text: string, hasIcon = true) => {
       style: toastStyle,
     }
   );
-};
-
-const isNetworkError = (error: unknown) => {
-  if (isAxiosError(error)) {
-    return !error.response;
-  }
-
-  return error instanceof Error && error.message === 'Network Error';
-};
-
-const isServerError = (error: unknown) => {
-  if (!isAxiosError(error)) return false;
-
-  const status = error.response?.status;
-
-  return typeof status === 'number' && status >= 500;
-};
-
-const isImageGenerationServerError = (error: unknown) => {
-  if (!isAxiosError(error)) return false;
-
-  const code = error.response?.data?.code;
-
-  return typeof code === 'number' && IMAGE_GENERATION_ERROR_CODES.has(code);
-};
-
-const isImageGenerationErrorToastDebugMode = () => {
-  if (!import.meta.env.DEV || typeof window === 'undefined') return false;
-
-  return (
-    new URLSearchParams(window.location.search).get('debugImageErrorToast') ===
-    'true'
-  );
-};
-
-const getGlobalErrorToastMessage = (error: unknown) => {
-  if (isImageGenerationServerError(error)) {
-    return null;
-  }
-
-  if (
-    isImageGenerationErrorToastDebugMode() &&
-    (isNetworkError(error) || isServerError(error))
-  ) {
-    return null;
-  }
-
-  if (isNetworkError(error) || isServerError(error)) {
-    return TOAST_MESSAGE.NETWORK_UNSTABLE;
-  }
-
-  return null;
 };
 
 // React 외부 navigate (dynamic import로 순환 참조 방지)
@@ -106,12 +49,5 @@ export const handleGlobalError = (error: unknown) => {
 
   if (isSessionExpiredError(error)) {
     handleSessionExpired();
-    return;
-  }
-
-  const message = getGlobalErrorToastMessage(error);
-
-  if (message) {
-    showGlobalToast(message, false);
   }
 };

--- a/src/shared/apis/config/globalErrorHandler.ts
+++ b/src/shared/apis/config/globalErrorHandler.ts
@@ -1,18 +1,80 @@
 import { createElement } from 'react';
 
-import { toast } from 'react-toastify';
+import { isAxiosError } from 'axios';
+import { toast } from 'sonner';
 
 import { ROUTES } from '@routes/paths';
 
-import Toast from '@components/toast/Toast';
+import { TOASTER_ID, TOAST_TYPE } from '@shared/types/toast';
 
-import { TOAST_TYPE, toastStyle } from '@/shared/types/toastLegacy';
+import Toast from '@components/v2/toast/Toast';
+import { toastStyle } from '@components/v2/toast/Toast.css';
+
+import { TOAST_MESSAGE } from '@constants/toastMessage';
+
+const IMAGE_GENERATION_ERROR_CODES = new Set([50013, 50017, 50400]);
 
 // React 외부 toast 유틸 (훅을 쓸 수 없는 모듈 스코프에서 사용)
-const showGlobalToast = (text: string) => {
-  toast(createElement(Toast, { text, type: TOAST_TYPE.WARNING }), {
-    style: toastStyle,
-  });
+const showGlobalToast = (text: string, hasIcon = true) => {
+  toast.custom(
+    () => createElement(Toast, { text, type: TOAST_TYPE.ERROR, hasIcon }),
+    {
+      toasterId: TOASTER_ID.BOTTOM_4,
+      style: toastStyle,
+    }
+  );
+};
+
+const isNetworkError = (error: unknown) => {
+  if (isAxiosError(error)) {
+    return !error.response;
+  }
+
+  return error instanceof Error && error.message === 'Network Error';
+};
+
+const isServerError = (error: unknown) => {
+  if (!isAxiosError(error)) return false;
+
+  const status = error.response?.status;
+
+  return typeof status === 'number' && status >= 500;
+};
+
+const isImageGenerationServerError = (error: unknown) => {
+  if (!isAxiosError(error)) return false;
+
+  const code = error.response?.data?.code;
+
+  return typeof code === 'number' && IMAGE_GENERATION_ERROR_CODES.has(code);
+};
+
+const isImageGenerationErrorToastDebugMode = () => {
+  if (!import.meta.env.DEV || typeof window === 'undefined') return false;
+
+  return (
+    new URLSearchParams(window.location.search).get('debugImageErrorToast') ===
+    'true'
+  );
+};
+
+const getGlobalErrorToastMessage = (error: unknown) => {
+  if (isImageGenerationServerError(error)) {
+    return null;
+  }
+
+  if (
+    isImageGenerationErrorToastDebugMode() &&
+    (isNetworkError(error) || isServerError(error))
+  ) {
+    return null;
+  }
+
+  if (isNetworkError(error) || isServerError(error)) {
+    return TOAST_MESSAGE.NETWORK_UNSTABLE;
+  }
+
+  return null;
 };
 
 // React 외부 navigate (dynamic import로 순환 참조 방지)
@@ -39,7 +101,17 @@ const handleSessionExpired = () => {
 };
 
 /** QueryCache/MutationCache의 onError에서 호출 */
-export const handleGlobalError = (error: Error) => {
+export const handleGlobalError = (error: unknown) => {
   if (import.meta.env.DEV) console.error('[QueryClient Error]', error);
-  if (isSessionExpiredError(error)) handleSessionExpired();
+
+  if (isSessionExpiredError(error)) {
+    handleSessionExpired();
+    return;
+  }
+
+  const message = getGlobalErrorToastMessage(error);
+
+  if (message) {
+    showGlobalToast(message, false);
+  }
 };

--- a/src/shared/components/v2/popup/CreditRequestPopup.css.ts
+++ b/src/shared/components/v2/popup/CreditRequestPopup.css.ts
@@ -1,0 +1,29 @@
+import { style } from '@vanilla-extract/css';
+
+import { colorVars } from '@styles/tokensV2/color.css';
+import { fontVars } from '@styles/tokensV2/font.css';
+import { unitVars } from '@styles/tokensV2/unit.css';
+
+export const container = style({
+  width: '28.8rem',
+});
+
+export const content = style({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  justifyContent: 'center',
+});
+
+export const title = style({
+  ...fontVars.font.title_sb_16,
+  marginBottom: unitVars.unit.gapPadding['200'],
+  textAlign: 'center',
+  color: colorVars.color.text.primary,
+});
+
+export const detail = style({
+  ...fontVars.font.title_r_15,
+  textAlign: 'center',
+  color: colorVars.color.text.secondary,
+});

--- a/src/shared/components/v2/popup/CreditRequestPopup.css.ts
+++ b/src/shared/components/v2/popup/CreditRequestPopup.css.ts
@@ -4,10 +4,6 @@ import { colorVars } from '@styles/tokensV2/color.css';
 import { fontVars } from '@styles/tokensV2/font.css';
 import { unitVars } from '@styles/tokensV2/unit.css';
 
-export const container = style({
-  width: '28.8rem',
-});
-
 export const content = style({
   display: 'flex',
   flexDirection: 'column',

--- a/src/shared/components/v2/popup/CreditRequestPopup.tsx
+++ b/src/shared/components/v2/popup/CreditRequestPopup.tsx
@@ -19,7 +19,8 @@ const CreditRequestPopup = ({ onClose }: CreditRequestPopupProps) => {
       btnText="크레딧 요청하기"
       weakBtnText="그만 두기"
       topIconName="WarningFillDanger"
-      containerClassName={styles.container}
+      ariaLabel="크레딧 부족 안내"
+      containerSize="creditRequest"
       onClose={onClose}
       onCancel={onClose}
       onConfirm={handleRequestCredit}

--- a/src/shared/components/v2/popup/CreditRequestPopup.tsx
+++ b/src/shared/components/v2/popup/CreditRequestPopup.tsx
@@ -3,23 +3,13 @@ import Popup from './Popup';
 
 const CREDIT_REQUEST_URL = 'https://tally.so/r/gDrdYO';
 
-const buildCreditRequestUrl = (email?: string | null) => {
-  if (!email) return CREDIT_REQUEST_URL;
-
-  const url = new URL(CREDIT_REQUEST_URL);
-  url.searchParams.set('email', email);
-
-  return url.toString();
-};
-
 interface CreditRequestPopupProps {
-  email?: string | null;
   onClose: () => void;
 }
 
-const CreditRequestPopup = ({ email, onClose }: CreditRequestPopupProps) => {
+const CreditRequestPopup = ({ onClose }: CreditRequestPopupProps) => {
   const handleRequestCredit = () => {
-    window.open(buildCreditRequestUrl(email), '_blank', 'noopener,noreferrer');
+    window.open(CREDIT_REQUEST_URL, '_blank', 'noopener,noreferrer');
     onClose();
   };
 

--- a/src/shared/components/v2/popup/CreditRequestPopup.tsx
+++ b/src/shared/components/v2/popup/CreditRequestPopup.tsx
@@ -1,0 +1,50 @@
+import * as styles from './CreditRequestPopup.css';
+import Popup from './Popup';
+
+const CREDIT_REQUEST_URL = 'https://tally.so/r/gDrdYO';
+
+const buildCreditRequestUrl = (email?: string | null) => {
+  if (!email) return CREDIT_REQUEST_URL;
+
+  const url = new URL(CREDIT_REQUEST_URL);
+  url.searchParams.set('email', email);
+
+  return url.toString();
+};
+
+interface CreditRequestPopupProps {
+  email?: string | null;
+  onClose: () => void;
+}
+
+const CreditRequestPopup = ({ email, onClose }: CreditRequestPopupProps) => {
+  const handleRequestCredit = () => {
+    window.open(buildCreditRequestUrl(email), '_blank', 'noopener,noreferrer');
+    onClose();
+  };
+
+  return (
+    <Popup
+      btnStyle="text"
+      btnText="크레딧 요청하기"
+      weakBtnText="그만 두기"
+      topIconName="WarningFillDanger"
+      containerClassName={styles.container}
+      onClose={onClose}
+      onCancel={onClose}
+      onConfirm={handleRequestCredit}
+      content={
+        <div className={styles.content}>
+          <h3 className={styles.title}>크레딧을 모두 소진했어요!</h3>
+          <p className={styles.detail}>
+            크레딧이 더 필요하다면 요청해주세요.
+            <br />
+            개발팀에서 확인 후 지급해드려요.
+          </p>
+        </div>
+      }
+    />
+  );
+};
+
+export default CreditRequestPopup;

--- a/src/shared/components/v2/popup/Popup.css.ts
+++ b/src/shared/components/v2/popup/Popup.css.ts
@@ -65,10 +65,17 @@ export const container = recipe({
     willChange: 'opacity, transform',
     borderRadius: unitVars.unit.radius['700'],
     backgroundColor: colorVars.color.gray000,
-    width: '24rem',
     overflow: 'hidden',
   },
   variants: {
+    containerSize: {
+      default: {
+        width: '24rem',
+      },
+      creditRequest: {
+        width: '28.8rem',
+      },
+    },
     motion: {
       opening: {
         ...motionHidden,
@@ -83,6 +90,7 @@ export const container = recipe({
     },
   },
   defaultVariants: {
+    containerSize: 'default',
     motion: 'opening',
   },
 });

--- a/src/shared/components/v2/popup/Popup.tsx
+++ b/src/shared/components/v2/popup/Popup.tsx
@@ -8,6 +8,7 @@ import Icon from '../icon/Icon';
 import type { IconName } from '../icon/Icon';
 
 export type PopupBtnStyle = 'text' | 'solid';
+type PopupContainerSize = 'default' | 'creditRequest';
 
 interface PopupProps {
   topIconName?: IconName;
@@ -23,7 +24,7 @@ interface PopupProps {
   sideIconName?: IconName;
   ariaLabel?: string;
   confirmDisabled?: boolean;
-  containerClassName?: string;
+  containerSize?: PopupContainerSize;
 }
 
 const Popup = ({
@@ -40,7 +41,7 @@ const Popup = ({
   sideIconName,
   ariaLabel,
   confirmDisabled = false,
-  containerClassName,
+  containerSize = 'default',
 }: PopupProps) => {
   const hasWeak = weakBtnText != null && weakBtnText !== '';
   const [motion, setMotion] = useState<'opening' | 'open'>('opening');
@@ -126,7 +127,7 @@ const Popup = ({
         aria-hidden="true"
       />
       <div
-        className={`${styles.container({ motion })} ${containerClassName ?? ''}`}
+        className={styles.container({ motion, containerSize })}
         role="dialog"
         aria-modal="true"
         aria-label={ariaLabel ?? '안내 팝업'}

--- a/src/shared/components/v2/popup/Popup.tsx
+++ b/src/shared/components/v2/popup/Popup.tsx
@@ -23,6 +23,7 @@ interface PopupProps {
   sideIconName?: IconName;
   ariaLabel?: string;
   confirmDisabled?: boolean;
+  containerClassName?: string;
 }
 
 const Popup = ({
@@ -39,6 +40,7 @@ const Popup = ({
   sideIconName,
   ariaLabel,
   confirmDisabled = false,
+  containerClassName,
 }: PopupProps) => {
   const hasWeak = weakBtnText != null && weakBtnText !== '';
   const [motion, setMotion] = useState<'opening' | 'open'>('opening');
@@ -124,7 +126,7 @@ const Popup = ({
         aria-hidden="true"
       />
       <div
-        className={styles.container({ motion })}
+        className={`${styles.container({ motion })} ${containerClassName ?? ''}`}
         role="dialog"
         aria-modal="true"
         aria-label={ariaLabel ?? '안내 팝업'}

--- a/src/shared/components/v2/toast/Sonner.tsx
+++ b/src/shared/components/v2/toast/Sonner.tsx
@@ -1,12 +1,21 @@
-import type { CSSProperties } from 'react';
+import { useEffect, type CSSProperties } from 'react';
 
 import { Toaster } from 'sonner';
 
-import { TOASTER_CONFIGS, TOASTER_DEFAULTS } from '@shared/types/toast';
+import {
+  TOASTER_CONFIGS,
+  TOASTER_DEFAULTS,
+  TOASTER_ID,
+  TOAST_TYPE,
+} from '@shared/types/toast';
+
+import { TOAST_MESSAGE } from '@constants/toastMessage';
 
 import './Sonner.css';
 
 import { unitVars } from '@styles/tokensV2/unit.css';
+
+import { useToast } from './useToast';
 
 const TOASTER_SIDE_MARGIN = '2rem';
 
@@ -19,6 +28,24 @@ const toasterStyle = {
 } satisfies CSSProperties;
 
 const MainToaster = () => {
+  const { notify } = useToast();
+
+  useEffect(() => {
+    const notifyNetworkError = () => {
+      notify({
+        text: TOAST_MESSAGE.NETWORK_UNSTABLE,
+        type: TOAST_TYPE.ERROR,
+        options: { toasterId: TOASTER_ID.BOTTOM_4 },
+      });
+    };
+
+    window.addEventListener('offline', notifyNetworkError);
+
+    return () => {
+      window.removeEventListener('offline', notifyNetworkError);
+    };
+  }, [notify]);
+
   return (
     <>
       {TOASTER_CONFIGS.map(({ id, position, offset }) => (

--- a/src/shared/components/v2/toast/Sonner.tsx
+++ b/src/shared/components/v2/toast/Sonner.tsx
@@ -35,6 +35,7 @@ const MainToaster = () => {
       notify({
         text: TOAST_MESSAGE.NETWORK_UNSTABLE,
         type: TOAST_TYPE.ERROR,
+        hasIcon: false,
         options: { toasterId: TOASTER_ID.BOTTOM_4 },
       });
     };

--- a/src/shared/components/v2/toast/Toast.tsx
+++ b/src/shared/components/v2/toast/Toast.tsx
@@ -6,9 +6,10 @@ import Icon from '../icon/Icon';
 interface ToastProps {
   text: string;
   type?: Exclude<ToastType, 'action'>;
+  hasIcon?: boolean;
 }
 
-const Toast = ({ text, type = 'info' }: ToastProps) => {
+const Toast = ({ text, type = 'info', hasIcon = true }: ToastProps) => {
   const isError = type === 'error';
 
   return (
@@ -17,7 +18,7 @@ const Toast = ({ text, type = 'info' }: ToastProps) => {
       aria-live={isError ? 'assertive' : 'polite'}
       className={styles.container({ type })}
     >
-      {isError ? <Icon name="CloseFillDanger" size="20" /> : null}
+      {isError && hasIcon ? <Icon name="CloseFillDanger" size="20" /> : null}
       <span className={styles.message({ type: 'default' })}>{text}</span>
     </div>
   );

--- a/src/shared/components/v2/toast/useToast.tsx
+++ b/src/shared/components/v2/toast/useToast.tsx
@@ -12,6 +12,7 @@ import { toastStyle } from './Toast.css';
 interface UseToastParams {
   text: string;
   type?: ToastType;
+  hasIcon?: boolean;
   options?: ExternalToast;
   onClick?: () => void;
   actionLabel?: string;
@@ -26,6 +27,7 @@ export const useToast = () => {
     ({
       text,
       type = TOAST_TYPE.INFO,
+      hasIcon,
       options,
       onClick,
       actionLabel,
@@ -62,14 +64,17 @@ export const useToast = () => {
         return;
       }
 
-      toastId.current = toast.custom(() => <Toast text={text} type={type} />, {
-        ...options,
+      toastId.current = toast.custom(
+        () => <Toast text={text} type={type} hasIcon={hasIcon} />,
+        {
+          ...options,
 
-        style: {
-          ...toastStyle,
-          ...options?.style,
-        },
-      });
+          style: {
+            ...toastStyle,
+            ...options?.style,
+          },
+        }
+      );
     },
     []
   );

--- a/src/shared/constants/toastMessage.ts
+++ b/src/shared/constants/toastMessage.ts
@@ -12,6 +12,9 @@ export const TOAST_MESSAGE = {
   IMAGE_FEEDBACK_THANKS: '소중한 의견 감사드려요. 더 나은 서비스로 보답할게요!',
   PROFILE_EDIT_SUCCESS: '변경 사항을 저장했어요',
   ACTION_SERVER_ERROR: '일시적인 오류로 저장에 실패했어요. 다시 시도해 주세요.',
+  NETWORK_UNSTABLE: '네트워크가 불안정해요. 확인 후 다시 시도해 주세요.',
+  IMAGE_GENERATION_SERVER_ERROR:
+    '이미지 생성에 문제가 발생했어요. 잠시 후에 다시 시도해 주세요.',
 } as const;
 
 export const TOAST_ACTION_LABEL = {

--- a/src/shared/hooks/useCreditGuard.ts
+++ b/src/shared/hooks/useCreditGuard.ts
@@ -1,10 +1,13 @@
-import { useCallback, useState } from 'react';
+import { createElement, useCallback, useState } from 'react';
+
+import { overlay } from 'overlay-kit';
 
 import { useMyPageUserQuery } from '@pages/mypage/apis/queries/useMyPageUserQuery';
 
 import { TOAST_TYPE } from '@shared/types/toastLegacy';
 
 import { useToast } from '@components/toast/useToast';
+import CreditRequestPopup from '@components/v2/popup/CreditRequestPopup';
 
 interface CreditGuardReturn {
   checkCredit: () => Promise<boolean>;
@@ -18,7 +21,7 @@ interface CreditGuardReturn {
  * 크레딧 확인 및 가드 처리 훅
  *
  * 이미지 생성 등 크레딧이 필요한 작업 전에 사용자의 크레딧을 확인하고,
- * 크레딧이 부족할 경우 토스트 알림을 표시합니다.
+ * 크레딧이 부족할 경우 요청 팝업을 표시합니다.
  *
  * @param requiredCredits 필요한 크레딧 수 (기본값: 1)
  * @returns 크레딧 확인 함수와 상태 정보
@@ -38,6 +41,14 @@ export const useCreditGuard = (
   // 현재 크레딧 수
   const creditCount = userData?.CreditCount;
 
+  const openCreditRequestPopup = useCallback(() => {
+    overlay.open(({ unmount }) => {
+      return createElement(CreditRequestPopup, {
+        onClose: unmount,
+      });
+    });
+  }, []);
+
   // 크레딧 충분 여부
   const hasEnoughCredit =
     creditCount !== undefined ? creditCount >= requiredCredits : undefined;
@@ -47,7 +58,7 @@ export const useCreditGuard = (
    *
    * 1. 최신 사용자 데이터를 다시 조회
    * 2. 크레딧 충분 여부 확인
-   * 3. 부족 시 토스트 알림 표시
+   * 3. 부족 시 크레딧 요청 팝업 표시
    *
    * @returns 크레딧이 충분한지 여부
    */
@@ -72,11 +83,7 @@ export const useCreditGuard = (
       if (currentCredit >= requiredCredits) {
         return true;
       } else {
-        // 크레딧 부족 시 토스트 알림
-        notify({
-          text: `크레딧이 부족합니다.`,
-          type: TOAST_TYPE.WARNING,
-        });
+        openCreditRequestPopup();
         return false;
       }
     } catch (error) {
@@ -89,7 +96,7 @@ export const useCreditGuard = (
     } finally {
       setIsChecking(false);
     }
-  }, [isChecking, requiredCredits, refetch, notify]);
+  }, [isChecking, openCreditRequestPopup, requiredCredits, refetch, notify]);
 
   return {
     checkCredit,


### PR DESCRIPTION
## 📌 Summary

- close #605 


- [x] 찜하기/해제 했을 때 찜 개수가 바뀌지 않음
- [x] 찜한 상품 스낵바 클릭 시 화면 라우팅 오류
- [x] 서버 에러시 toast 노출
- [x] 크레딧 부족시 popup + tally 링크 연결


## 📄 Tasks

### 1. 서버 에러 토스트 처리

- 네트워크 불안정 상태에서 v2 sonner 토스트가 노출되도록 처리했습니다.
  - `Sonner`에서 브라우저 `offline` 이벤트를 감지합니다.
  - 메시지: `네트워크가 불안정해요. 확인 후 다시 시도해 주세요.`
 
- 이미지 생성 예외 토스트는 `LoadingPage`에서만 처리하도록 범위를 제한했습니다.
  - 대상 에러 코드: `50013`, `50017`, `50400`
  - 메시지: `이미지 생성에 문제가 발생했어요. 잠시 후에 다시 시도해 주세요.`

- 전역 API 에러 핸들러에서는 네트워크/서버 에러 토스트를 제거했습니다.
  - 기존처럼 모든 Query/Mutation 에러에서 네트워크 토스트가 뜨지 않도록 정리했습니다.
  - 전역 핸들러는 세션 만료 처리만 담당하도록 유지했습니다.

### 2. 크레딧 부족 팝업 추가

- 크레딧이 부족할 때 기존 토스트 대신 v2 `Popup` 기반 크레딧 요청 팝업이 뜨도록 변경했습니다.
- `크레딧 요청하기` 클릭 시 Tally 링크를 새 탭으로 엽니다.

- 풀퍼널뿐 아니라 상품/배너/다른 스타일 진입처럼 도면 선택이 마지막 단계인 숏퍼널에서도 `/generate` 진입 전 크레딧 체크를 수행하도록 추가했습니다.
  - 크레딧 부족 시 로딩페이지로 진입하지 않고 팝업을 먼저 노출합니다.

- `Popup` 공통 컴포넌트에 `containerClassName` optional prop을 추가했습니다.
  - width가 고정되어있어서 기존 넓이를 기본 옵션으로 두고 '28.8rem' 넓이를 가질 수 있도록 props를 추가했습니다.

### 3. 마이페이지 찜 관련 QA 수정

- 찜 토스트의 `보러가기` 클릭 시 마이페이지의 `찜한 가구` 탭으로 이동하도록 라우팅 상태를 반영했습니다.
  - `location.state.activeTab`을 읽어 탭을 전환합니다.
  - 처리 후 `replace`로 state를 제거해 새로고침 시 기본 탭인 `생성된 이미지`로 돌아가도록 했습니다.

- 생성 이미지 하단 상품 리스트에서 찜/해제 시 하트 상태가 즉시 반영되도록 수정했습니다.
  - 서버 응답의 `isJjym`만 보지 않고, 사용자가 터치한 상품은 `useSavedItemsStore`의 상태를 우선 반영합니다.

- 마이페이지 찜한 가구 목록에서 해제 시 찜 개수가 즉시 1 감소해 보이도록 처리했습니다.
  - 되돌리기 UX 때문에 목록에서 즉시 제거하지 않는 기존 동작은 유지했습니다.
  - 대신 해제 상태일 때 `jjymCount - 1`로 표시해 사용자 액션이 바로 반영되도록 했습니다.


## 🔍 To Reviewer

- Tally 이메일 파라미터는 제외했습니다.
  - 현재 응답/토큰/전역 상태에서 카카오 이메일을 안정적으로 얻을 수 없어, 추측성 저장/파싱 로직을 넣지 않았습니다.
- Lodaing 페이지에서 이미지 생성 중 발생한 서버 error를 재현하기 힘들어서 toast를 제대로 확인하지 못 했습니다......... 


## 📸 Screenshot

https://github.com/user-attachments/assets/e41a9953-7d69-4003-9674-8039b89d6f3f

https://github.com/user-attachments/assets/019d6935-393f-4b84-947c-6da22e2cc7c2

<img width="375" height="660" alt="스크린샷 2026-07-07 오후 12 47 47" src="https://github.com/user-attachments/assets/96cffdc6-ec3d-4281-9f7a-23853e3c53ee" />
