### PR TITLE
[feat] 이미지 확대 기능 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "react-markdown": "^10.1.0",
     "react-router-dom": "^7.6.3",
     "react-toastify": "^11.0.5",
+    "react-zoom-pan-pinch": "^4.0.3",
     "remark-gfm": "^4.0.1",
     "sonner": "^2.0.7",
     "swiper": "^12.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -70,6 +70,9 @@ importers:
       react-toastify:
         specifier: ^11.0.5
         version: 11.0.5(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      react-zoom-pan-pinch:
+        specifier: ^4.0.3
+        version: 4.0.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       remark-gfm:
         specifier: ^4.0.1
         version: 4.0.1
@@ -6511,6 +6514,16 @@ packages:
       react: ^18 || ^19
       react-dom: ^18 || ^19
 
+  react-zoom-pan-pinch@4.0.3:
+    resolution:
+      {
+        integrity: sha512-N2Hi6L78fFmhRra+ORpFSW7WST5x6kxpOPplIvtB0b7b+U2anpo1z1wLgaWRPS2kUSqcraRG+JgBCIlDJnqqAg==,
+      }
+    engines: { node: '>=8', npm: '>=5' }
+    peerDependencies:
+      react: '*'
+      react-dom: '*'
+
   react@19.2.0:
     resolution:
       {
@@ -12238,6 +12251,11 @@ snapshots:
   react-toastify@11.0.5(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
     dependencies:
       clsx: 2.1.1
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+
+  react-zoom-pan-pinch@4.0.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
+    dependencies:
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 

--- a/src/pages/generate/v2/pages/result/components/curation/imgSection/GeneratedImg.css.ts
+++ b/src/pages/generate/v2/pages/result/components/curation/imgSection/GeneratedImg.css.ts
@@ -36,6 +36,13 @@ export const swiperSlide = style({
   overflow: 'hidden',
 });
 
+export const zoomTrigger = style({
+  position: 'relative',
+  cursor: 'zoom-in',
+  width: '100%',
+  height: '100%',
+});
+
 export const imgArea = recipe({
   base: {
     objectFit: 'cover',

--- a/src/pages/generate/v2/pages/result/components/curation/imgSection/GeneratedImg.tsx
+++ b/src/pages/generate/v2/pages/result/components/curation/imgSection/GeneratedImg.tsx
@@ -13,6 +13,7 @@ import OptimizedImage from '@components/image/OptimizedImage';
 import CommunityComingSoonModal from '@components/overlay/modal/CommunityComingSoonModal';
 import ActionButton from '@components/v2/button/actionButton/ActionButton';
 import IconButton from '@components/v2/button/IconButton';
+import { openImageZoom } from '@components/v2/imageZoom/openImageZoom';
 
 import * as styles from './GeneratedImg.css';
 
@@ -58,6 +59,11 @@ const GeneratedImg = ({
     ));
   };
 
+  const handleOpenZoom = (target: ResultImageMeta) => {
+    if (!target.imageUrl) return;
+    openImageZoom({ src: target.imageUrl, isMirror: target.isMirror });
+  };
+
   if (images.length === 0) {
     return null;
   }
@@ -89,14 +95,28 @@ const GeneratedImg = ({
               key={`${image.imageId}-${index}`}
               className={styles.swiperSlide}
             >
-              <OptimizedImage
-                src={image.imageUrl}
-                alt=""
-                placeholder="color"
-                loading={index === 0 ? 'eager' : 'lazy'}
-                decoding="async"
-                className={styles.imgArea({ mirrored: image.isMirror })}
-              />
+              <div
+                className={styles.zoomTrigger}
+                role="button"
+                tabIndex={0}
+                aria-label="생성된 이미지 확대해서 보기"
+                onClick={() => handleOpenZoom(image)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    handleOpenZoom(image);
+                  }
+                }}
+              >
+                <OptimizedImage
+                  src={image.imageUrl}
+                  alt=""
+                  placeholder="color"
+                  loading={index === 0 ? 'eager' : 'lazy'}
+                  decoding="async"
+                  className={styles.imgArea({ mirrored: image.isMirror })}
+                />
+              </div>
             </SwiperSlide>
           ))}
           {lastImage && (

--- a/src/pages/generate/v2/pages/result/components/list/imgSection/GeneratedImg.css.ts
+++ b/src/pages/generate/v2/pages/result/components/list/imgSection/GeneratedImg.css.ts
@@ -35,6 +35,7 @@ export const swiperSlide = style({
 
 export const listImageFrame = style({
   position: 'relative', // OptimizedImage placeholder(absolute)의 기준
+  cursor: 'zoom-in',
   width: '100%',
   height: '26rem',
   overflow: 'hidden',

--- a/src/pages/generate/v2/pages/result/components/list/imgSection/GeneratedImg.tsx
+++ b/src/pages/generate/v2/pages/result/components/list/imgSection/GeneratedImg.tsx
@@ -1,4 +1,5 @@
 import OptimizedImage from '@components/image/OptimizedImage';
+import { openImageZoom } from '@components/v2/imageZoom/openImageZoom';
 
 import * as styles from './GeneratedImg.css';
 
@@ -13,9 +14,26 @@ export interface GeneratedImgListProps {
  * 목록형 결과
  */
 const GeneratedImg = ({ image }: GeneratedImgListProps) => {
+  const handleOpenZoom = () => {
+    if (!image.imageUrl) return;
+    openImageZoom({ src: image.imageUrl, isMirror: image.isMirror });
+  };
+
   return (
     <div className={styles.container}>
-      <div className={styles.listImageFrame}>
+      <div
+        className={styles.listImageFrame}
+        role="button"
+        tabIndex={0}
+        aria-label="생성된 이미지 확대해서 보기"
+        onClick={handleOpenZoom}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            handleOpenZoom();
+          }
+        }}
+      >
         <OptimizedImage
           src={image.imageUrl}
           alt=""

--- a/src/shared/components/v2/imageZoom/ImageZoomViewer.css.ts
+++ b/src/shared/components/v2/imageZoom/ImageZoomViewer.css.ts
@@ -49,6 +49,7 @@ export const content = recipe({
     position: 'absolute',
     inset: 0,
     willChange: 'opacity',
+    outline: 'none',
   },
   variants: {
     motion: {

--- a/src/shared/components/v2/imageZoom/ImageZoomViewer.css.ts
+++ b/src/shared/components/v2/imageZoom/ImageZoomViewer.css.ts
@@ -1,0 +1,97 @@
+import { style } from '@vanilla-extract/css';
+import { recipe } from '@vanilla-extract/recipes';
+
+import { zIndex } from '@styles/tokens/zIndex';
+import { colorVars } from '@styles/tokensV2/color.css';
+import {
+  popupFadeInInteraction,
+  popupFadeInOpacityInteraction,
+} from '@styles/tokensV2/interaction/presets';
+import { unitVars } from '@styles/tokensV2/unit.css';
+
+const motionHidden = { opacity: 0 } as const;
+
+// 앱의 모바일 프레임을 덮는 최상위 레이어 (v2 Popup과 동일한 프레임 폭 규칙)
+export const viewportLayer = style({
+  position: 'fixed',
+  zIndex: zIndex.popup,
+  top: 0,
+  bottom: 0,
+  left: '50%',
+  transform: 'translateX(-50%)',
+  width: '100%',
+  minWidth: unitVars.unit.dimension.wMin,
+  maxWidth: unitVars.unit.dimension.wMax,
+  overflow: 'hidden',
+  overscrollBehavior: 'none',
+});
+
+// 배경 오버레이 (닫기는 이미지 여백 탭에서 처리)
+export const backdrop = recipe({
+  base: {
+    position: 'absolute',
+    inset: 0,
+    willChange: 'opacity',
+    background: colorVars.color.gray999_a80,
+  },
+  variants: {
+    motion: {
+      opening: { ...motionHidden, transition: 'none' },
+      open: { transition: popupFadeInOpacityInteraction, opacity: 1 },
+    },
+  },
+  defaultVariants: { motion: 'opening' },
+});
+
+// 이미지/버튼 레이어 (프레임 전체) — 확대 뷰포트가 이 위에 얹힘
+export const content = recipe({
+  base: {
+    position: 'absolute',
+    inset: 0,
+    willChange: 'opacity',
+  },
+  variants: {
+    motion: {
+      opening: { ...motionHidden, transition: 'none' },
+      open: { transition: popupFadeInInteraction, opacity: 1 },
+    },
+  },
+  defaultVariants: { motion: 'opening' },
+});
+
+// react-zoom-pan-pinch 래퍼 (wrapperStyle로 프레임 전체 크기) — 드래그 커서
+export const zoomWrapper = style({
+  cursor: 'grab',
+  ':active': { cursor: 'grabbing' },
+});
+
+// 확대 뷰포트 내부 스테이지(프레임 전체) — 이미지 중앙 정렬, 배경 여백 탭 = 닫기
+export const imageStage = style({
+  boxSizing: 'border-box',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  width: '100%',
+  height: '100%',
+});
+
+export const image = recipe({
+  base: {
+    display: 'block',
+    // generatedImg_imgArea와 동일: 화면 너비 꽉 채우고 같은 비율·크롭(cover, 26rem)으로
+    objectFit: 'cover',
+    objectPosition: 'center center',
+    width: '100%',
+    height: '26rem',
+    userSelect: 'none',
+    WebkitUserSelect: 'none',
+    WebkitTouchCallout: 'none',
+  },
+  variants: {
+    mirrored: {
+      true: { transform: 'scaleX(-1)' },
+      false: { transform: 'none' },
+    },
+  },
+  defaultVariants: { mirrored: false },
+});

--- a/src/shared/components/v2/imageZoom/ImageZoomViewer.tsx
+++ b/src/shared/components/v2/imageZoom/ImageZoomViewer.tsx
@@ -1,0 +1,133 @@
+import {
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type MouseEvent,
+  type PointerEvent,
+} from 'react';
+
+import { TransformComponent, TransformWrapper } from 'react-zoom-pan-pinch';
+
+import OptimizedImage from '@components/image/OptimizedImage';
+
+import * as styles from './ImageZoomViewer.css';
+
+// TransformComponent 래퍼/콘텐츠를 프레임 전체로 → 뷰어(뷰포트) 자체가 확대되는 방식
+const FILL_STYLE = { width: '100%', height: '100%' } as const;
+
+// 탭 vs 드래그(팬) 판별 임계값(px)
+const TAP_MOVE_THRESHOLD = 10;
+
+export interface ImageZoomViewerProps {
+  /** 확대해서 볼 이미지 원본 URL */
+  src: string;
+  /** 좌우 반전 여부 (결과 이미지의 isMirror) */
+  isMirror?: boolean;
+  alt?: string;
+  /** backdrop 탭 시 호출 (overlay unmount) */
+  onClose: () => void;
+}
+
+/**
+ * 이미지 확대/축소 라이트박스 (뷰어/뷰포트 확대 방식).
+ * - 앱 프레임 전체가 확대 뷰포트 → 확대하면 이미지가 화면에서 실제로 더 커진다
+ * - 핀치/더블탭/휠로 확대·축소, 드래그로 팬(경계에서 하드 스톱)
+ * - 이미지 밖 어두운 여백 탭 시 닫힘
+ *
+ * overlay.open으로 띄우며 onClose에 unmount를 연결한다. ([[openImageZoom]])
+ */
+const ImageZoomViewer = ({
+  src,
+  isMirror = false,
+  alt = '',
+  onClose,
+}: ImageZoomViewerProps) => {
+  const [motion, setMotion] = useState<'opening' | 'open'>('opening');
+
+  // 첫 프레임 hidden → rAF×2 후 open (enter fade 트리거) — v2 Popup과 동일 패턴
+  useLayoutEffect(() => {
+    let raf2: number | null = null;
+    const raf1 = requestAnimationFrame(() => {
+      raf2 = requestAnimationFrame(() => setMotion('open'));
+    });
+
+    return () => {
+      cancelAnimationFrame(raf1);
+      if (raf2 !== null) cancelAnimationFrame(raf2);
+    };
+  }, []);
+
+  // 열려 있는 동안 body 스크롤 잠금 (이전 값 복원)
+  useEffect(() => {
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+
+    return () => {
+      document.body.style.overflow = previousOverflow;
+    };
+  }, []);
+
+  // 이미지 밖 어두운 여백(stage 배경) 탭 시 닫힘 — 이미지 위 탭/제스처는 유지
+  const pointerDownRef = useRef<{ x: number; y: number } | null>(null);
+
+  const handleStagePointerDown = (e: PointerEvent<HTMLDivElement>) => {
+    pointerDownRef.current = { x: e.clientX, y: e.clientY };
+  };
+
+  const handleStageClick = (e: MouseEvent<HTMLDivElement>) => {
+    if (e.target !== e.currentTarget) return; // 이미지·버튼이 아닌 여백만
+    const start = pointerDownRef.current;
+    if (start) {
+      const moved = Math.hypot(e.clientX - start.x, e.clientY - start.y);
+      if (moved > TAP_MOVE_THRESHOLD) return; // 팬(드래그)이면 닫지 않음
+    }
+    onClose();
+  };
+
+  return (
+    <div className={styles.viewportLayer}>
+      <div className={styles.backdrop({ motion })} aria-hidden="true" />
+      <div
+        className={styles.content({ motion })}
+        role="dialog"
+        aria-modal="true"
+        aria-label="이미지 확대 보기"
+      >
+        {/* 하드 스톱 팬(limitToBounds+disablePadding) + 래퍼/콘텐츠를 프레임 전체로 늘려(FILL_STYLE) 이미지 뷰어 자체가 확대되도록 한다 */}
+        <TransformWrapper
+          initialScale={1}
+          minScale={1}
+          maxScale={4}
+          centerOnInit
+          limitToBounds
+          disablePadding
+          doubleClick={{ mode: 'toggle' }}
+        >
+          <TransformComponent
+            wrapperClass={styles.zoomWrapper}
+            wrapperStyle={FILL_STYLE}
+            contentStyle={FILL_STYLE}
+          >
+            <div
+              className={styles.imageStage}
+              onPointerDown={handleStagePointerDown}
+              onClick={handleStageClick}
+            >
+              <OptimizedImage
+                src={src}
+                alt={alt}
+                loading="eager"
+                decoding="async"
+                draggable={false}
+                className={styles.image({ mirrored: isMirror })}
+              />
+            </div>
+          </TransformComponent>
+        </TransformWrapper>
+      </div>
+    </div>
+  );
+};
+
+export default ImageZoomViewer;

--- a/src/shared/components/v2/imageZoom/ImageZoomViewer.tsx
+++ b/src/shared/components/v2/imageZoom/ImageZoomViewer.tsx
@@ -44,6 +44,7 @@ const ImageZoomViewer = ({
   onClose,
 }: ImageZoomViewerProps) => {
   const [motion, setMotion] = useState<'opening' | 'open'>('opening');
+  const dialogRef = useRef<HTMLDivElement>(null);
 
   // 첫 프레임 hidden → rAF×2 후 open (enter fade 트리거) — v2 Popup과 동일 패턴
   useLayoutEffect(() => {
@@ -58,15 +59,28 @@ const ImageZoomViewer = ({
     };
   }, []);
 
-  // 열려 있는 동안 body 스크롤 잠금 (이전 값 복원)
+  // 열려 있는 동안 body 스크롤 잠금 + dialog로 포커스 이동, 닫힐 때 이전 값·포커스 복원
   useEffect(() => {
     const previousOverflow = document.body.style.overflow;
+    const previouslyFocused = document.activeElement as HTMLElement | null;
     document.body.style.overflow = 'hidden';
+    dialogRef.current?.focus({ preventScroll: true });
 
     return () => {
       document.body.style.overflow = previousOverflow;
+      previouslyFocused?.focus?.();
     };
   }, []);
+
+  // Escape로 닫기 (키보드 접근성)
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', handleKeyDown);
+
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [onClose]);
 
   // 이미지 밖 어두운 여백(stage 배경) 탭 시 닫힘 — 이미지 위 탭/제스처는 유지
   const pointerDownRef = useRef<{ x: number; y: number } | null>(null);
@@ -89,10 +103,12 @@ const ImageZoomViewer = ({
     <div className={styles.viewportLayer}>
       <div className={styles.backdrop({ motion })} aria-hidden="true" />
       <div
+        ref={dialogRef}
         className={styles.content({ motion })}
         role="dialog"
         aria-modal="true"
         aria-label="이미지 확대 보기"
+        tabIndex={-1}
       >
         {/* 하드 스톱 팬(limitToBounds+disablePadding) + 래퍼/콘텐츠를 프레임 전체로 늘려(FILL_STYLE) 이미지 뷰어 자체가 확대되도록 한다 */}
         <TransformWrapper

--- a/src/shared/components/v2/imageZoom/openImageZoom.tsx
+++ b/src/shared/components/v2/imageZoom/openImageZoom.tsx
@@ -1,0 +1,29 @@
+import { Suspense, lazy } from 'react';
+
+import { overlay } from 'overlay-kit';
+
+import type { ImageZoomViewerProps } from './ImageZoomViewer';
+
+// 첫 호출 시점에만 로드 → react-zoom-pan-pinch가 호출부 화면의 초기 번들에 안 실린다
+const ImageZoomViewer = lazy(() => import('./ImageZoomViewer'));
+
+type OpenImageZoomOptions = Pick<
+  ImageZoomViewerProps,
+  'src' | 'isMirror' | 'alt'
+>;
+
+/**
+ * 이미지 확대/축소 라이트박스를 띄운다.
+ * 어두운 backdrop 위 세로 중앙 이미지 + 핀치/버튼 확대·축소, backdrop 탭 시 닫힘.
+ */
+export const openImageZoom = ({ src, isMirror, alt }: OpenImageZoomOptions) =>
+  overlay.open(({ unmount }) => (
+    <Suspense fallback={null}>
+      <ImageZoomViewer
+        src={src}
+        isMirror={isMirror}
+        alt={alt}
+        onClose={unmount}
+      />
+    </Suspense>
+  ));

--- a/src/shared/styles/tokensV2/color.css.ts
+++ b/src/shared/styles/tokensV2/color.css.ts
@@ -10,6 +10,7 @@ import { createGlobalTheme } from '@vanilla-extract/css';
 const primitives = createGlobalTheme(':root', {
   color: {
     gray999: '#000000',
+    gray999_a80: 'rgba(0, 0, 0, 0.8)',
     gray999_a50: 'rgba(0, 0, 0, 0.5)',
     gray999_a30: 'rgba(0, 0, 0, 0.3)',
     gray999_a10: 'rgba(0, 0, 0, 0.1)',


### PR DESCRIPTION
## 📌 Summary

- close #610 

- **문제**: 유저인터뷰 → 결과 페이지에서 생성 이미지를 크게 볼 방법 X
- **구현**: 노션 이미지 뷰어처럼 탭하면 어두운 배경 위에 이미지가 뜨고 확대/축소·이동할 수 있어야 함. 핀치/팬 줌 엔진만 `react-zoom-pan-pinch`로 얹고, 오버레이(배경/dim/애니메이션/스크롤 잠금/닫기)는 기존 `overlay-kit` + v2 `Popup` 패턴 재사용


## 📄 Tasks

```plaintext
결과 페이지 이미지(imgArea) 탭
  └─ openImageZoom()        → overlay.open으로 오버레이 마운트 (lazy import)
     └─ ImageZoomViewer     → v2 Popup 패턴 재사용 (dim + rAF fade + body 스크롤 잠금)
        ├─ backdrop         → 배경 오버레이
        └─ TransformWrapper → react-zoom-pan-pinch, 프레임 전체를 확대 뷰포트로
           └─ imageStage    → 이미지(imgArea와 동일 cover/26rem) + 배경 여백 탭 = 닫기
```

**의존성 — `react-zoom-pan-pinch` (줌 엔진만)**

핀치/팬/더블탭 줌은 `react-zoom-pan-pinch@4.0.3`(0 deps, gzip ~12.7KB)에 맡기고, 오버레이는 기존 `overlay.open` + v2 `Popup` 패턴으로 직접 구성.
직접 구현 어려운 핀치 줌 관련 로직(두 손가락 초점 고정 줌 계산, 경계 clamping, 확다한 상태에서의 이동 관성, `pointercancel` 처리)은 라이브러리 사용, 배경 dim·fade·스크롤 잠금·닫기는 기존에 레포에서 사용하던 패턴(overlay-kit + Popup) 재사용

**성능**

- 핀치 줌은 `transform: scale()/translate()`라 CPU 담당 X, 브라우저 레이아웃/페인트 과정 없이 GPU 처리 + 리렌더링 관련 최적화는 라이브러리에서 처리 -> 별도 최적화 필요 X
- 라이브러리가 추가되어 번들 크기가 더 커짐 -> `ImageZoomViewer`를 lazy import로 분리, `react-zoom-pan-pinch`가 결과이미지 첫 탭 시점에 로드돼 초기 번들에 포함 X. 

**이미지 확대 구현 방식**

디자인 요청사항: 네이티브 사진 뷰어 방식처럼 이미지가 확대되도록 동작명세 지정. `TransformComponent`의 wrapper/content를 프레임 전체(`FILL_STYLE = 100%×100%`)로 설정 => 정해진 영역 내에서 이미지가 확대되는 방식 X, 확대 시 **화면 전체 뷰포트**에서 이미지가 커지고 더 많은 화면을 차지하도록 구현


## 🔍 To Reviewer

-

_리뷰어에게 요청하는 내용을 작성해주세요._

## 📸 Screenshot

https://github.com/user-attachments/assets/c4601f4b-950b-4154-aa4a-3c5815dc3505


_작업한 내용에 대한 스크린샷을 첨부해주세요._

