### PR TITLE
[fix] 6차 QA 반영

### DIFF
--- a/src/pages/imageSetup/v2/apis/queries/useRecentFloorPlanQuery.ts
+++ b/src/pages/imageSetup/v2/apis/queries/useRecentFloorPlanQuery.ts
@@ -18,5 +18,12 @@ export const useRecentFloorPlanQuery = () => {
   return useQuery({
     queryKey: queryKeys.imageSetup.recentFloorPlan(),
     queryFn: getRecentFloorPlan,
+    // 이미지 생성 성공 후 '최근 생성한 도면'이 즉시 반영되어야 하므로 전역 staleTime(5분)을 override.
+    // 기존 invalidate 로직의 간헐적 실패 원인:
+    // 여러 페이지(HomePage, Style, Banner 등)가 이 쿼리를 observe하는데, 이미지 생성 후 재생성 플로우에서 사용자가 Home을 먼저 거치므로,
+    // Home이 채운 fresh 캐시를 /imageSetup이 5분간 신뢰 → 진입 시 재요청이 스킵되어 간헐적 stale이 발생하는 것으로 예상..됨
+    // => mount마다 무조건 재요청해 이를 원천 차단
+    staleTime: 0,
+    refetchOnMount: 'always',
   });
 };

--- a/src/shared/components/v2/roomTypeCard/RoomTypeCard.tsx
+++ b/src/shared/components/v2/roomTypeCard/RoomTypeCard.tsx
@@ -77,7 +77,9 @@ const RoomTypeOptionCard = ({
     >
       <OptimizedImage
         src={initialImageSrc}
-        sizes={IMAGE_SIZES.grid}
+        // 1:1 비율일 때는 도면 너비가 약 200px, 3:2 비율일 때는 거의 full-width
+        // 따라서 1:1 비율일 때와 3:2 비율일 때 OptimizedImage 컴포넌트에 보내는 sizes를 적절히 분기처리해야 각 너비에 알맞은 최적화 이미지를 가져옴
+        sizes={ratio === '3:2' ? IMAGE_SIZES.full : IMAGE_SIZES.grid}
         fallbackSrc={emptyImage}
         alt=""
         aria-hidden="true"


### PR DESCRIPTION
## 📌 Summary

- close #620

> 관련 있는 Issue를 태그해주세요. (e.g. > - #1)

## 📄 Tasks

- **도면 3:2 비율 화질저하 이슈**
  - `OptimizedImage` 컴포넌트의 `sizes` props에 넘기는 이미지 너비를 도면이 1:1 비율일 때와 3:2 비율일 때 서로 다른 값으로 분기처리 해줘야 각 이미지 너비에 알맞은 최적화본을 S3에 요청함. 분기처리 코드 추가로 수정 완
- **일부 스타일 이미지 최적화 미적용 이슈**
  - HOUME-SERVER측 코드 수정으로 해결 - [이 PR](https://github.com/TEAM-HOUME/HOUME-SERVER/pull/587)
  - 서버측 최적화 코드를 수정해두면 FE측에서는 자동으로 최적화된 이미지를 가져오므로 수정할 부분 X
- **일부 lottie 렌더링 완료가 느린 이슈**
  - **문제1**: 로그인 lottie의 크기가 6.44MB -> 파일 자체가 너무 컸었음
  - **문제2**: Vite는 4KB가 넘는 파일은 해당 파일이 필요할 때, 즉 런타임에 fetch해옴 => 브라우저가 로그인 페이지에 진입할 때 6.44MB짜리 별도 에셋 파일을 네트워크로 fetch해오므로 다운로드+압축해제 완료+렌더링까지 시간이 더 오래 걸렸던 것
  - **해결**: 디자인측에 전달 후 크기가 줄어든 새 lottie 파일 핸드오프 완료 (성하가 적용해줌 @earl9rey 고마워용)
- **최근도면 GET 쿼리 invalidate 이슈**
  - 도면 페이지 mount마다 항상 쿼리를 요청하도록 전역 staleTime 설정 override

_해당 PR에 수행한 작업을 작성해주세요._

## 🔍 To Reviewer

-

_리뷰어에게 요청하는 내용을 작성해주세요._

## 📸 Screenshot

-

_작업한 내용에 대한 스크린샷을 첨부해주세요._
