### PR TITLE
[feat] Microsoft Clarity 설정 고도화

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,7 +6,7 @@ import { ErrorBoundary } from 'react-error-boundary';
 import { HelmetProvider } from 'react-helmet-async';
 import 'sonner/dist/styles.css';
 
-import { initClarity } from '@shared/config/clarity';
+import { initClarity, upgradeClaritySession } from '@shared/config/clarity';
 import {
   getSentryReactErrorHandlerOptions,
   initSentry,
@@ -47,7 +47,10 @@ if (!rootElement) {
 
 createRoot(rootElement, getSentryReactErrorHandlerOptions()).render(
   // <StrictMode>
-  <ErrorBoundary FallbackComponent={AppErrorFallback}>
+  <ErrorBoundary
+    FallbackComponent={AppErrorFallback}
+    onError={() => upgradeClaritySession('error')}
+  >
     <HelmetProvider>
       <QueryClientProvider client={queryClient}>
         <App />

--- a/src/pages/generate/v2/pages/result/ResultPage.tsx
+++ b/src/pages/generate/v2/pages/result/ResultPage.tsx
@@ -1,3 +1,5 @@
+import { useEffect } from 'react';
+
 import {
   Navigate,
   useLocation,
@@ -24,6 +26,7 @@ import {
   buildResultListPageViewParams,
   buildResultRecPageViewParams,
 } from '@shared/analytics/utils/imageFlow';
+import { clarityEvent } from '@shared/config/clarity';
 
 import InlineError from '@components/inlineError/InlineError';
 import Loading from '@components/loading/Loading';
@@ -113,6 +116,14 @@ const ResultPage = () => {
       enabled: parsedImageId !== null && isListView,
     }
   );
+
+  // 이미지 생성 완료(로딩→결과 진입) 시 Clarity 전환 이벤트 1회 — Smart Events/Funnels용
+  // 마이페이지·연관 이미지 재진입(isFromLoading=false)에선 미발화
+  useEffect(() => {
+    if (isFromLoading && parsedImageId !== null) {
+      clarityEvent('image_generated');
+    }
+  }, [isFromLoading, parsedImageId]);
 
   const handleBackClick = () => {
     if (isListView) {

--- a/src/routes/RootLayout.tsx
+++ b/src/routes/RootLayout.tsx
@@ -4,6 +4,7 @@ import { Outlet } from 'react-router-dom';
 import { useGenerateWarmup } from '@pages/generate/hooks/useGenerateWarmup';
 
 import { useScreenNavigation } from '@shared/analytics/hooks';
+import { useClaritySync } from '@shared/hooks/useClaritySync';
 import { useScrollToTop } from '@shared/hooks/useScrollToTop';
 
 import * as styles from './RootLayout.css';
@@ -13,6 +14,7 @@ function RootLayout() {
   useScrollToTop();
   useGenerateWarmup();
   useScreenNavigation();
+  useClaritySync();
 
   return (
     <OverlayProvider>

--- a/src/shared/config/clarity.ts
+++ b/src/shared/config/clarity.ts
@@ -33,3 +33,31 @@ export function initClarity() {
 
   document.head.appendChild(script);
 }
+
+/**
+ * Clarity 고급 API 래퍼
+ *
+ * - `window.clarity`는 `initClarity()`가 render 전에 큐 shim으로 동기 할당
+ *   env(`VITE_CLARITY_PROJECT_ID`) 미설정 시엔 할당되지 않으므로 `?.` 로 안전하게 no-op 처리됨
+ * - 스크립트 로드 전 호출은 shim의 큐(`window.clarity.q`)에 버퍼링됐다가 로드 후 재생됨
+ */
+
+/** 커스텀 태그: Clarity 세션에 key-value를 붙여 Filters/Segments에서 필터링 (value는 문자열 또는 문자열 배열) */
+export function setClarityTag(key: string, value: string | string[]): void {
+  window.clarity?.('set', key, value);
+}
+
+/** 커스텀 이벤트: 핵심 전환을 마킹 → Smart Events/Funnels에 노출 */
+export function clarityEvent(name: string): void {
+  window.clarity?.('event', name);
+}
+
+/** 세션 우선 레코딩: 에러/전환 등 중요한 세션을 일일 샘플링에서 보호 */
+export function upgradeClaritySession(reason: string): void {
+  window.clarity?.('upgrade', reason);
+}
+
+/** 유저 식별: 내부 식별자로 세션을 유저와 연결 (이메일/이름 등 원시 PII 전달 금지) */
+export function identifyClarityUser(customId: string): void {
+  window.clarity?.('identify', customId);
+}

--- a/src/shared/hooks/useClaritySync.ts
+++ b/src/shared/hooks/useClaritySync.ts
@@ -1,0 +1,50 @@
+import { useEffect } from 'react';
+
+import { useLocation } from 'react-router-dom';
+
+import { useUserStore } from '@store/useUserStore';
+
+import { getLoginStatus } from '@shared/analytics/utils/loginStatus';
+import { resolveScreenName } from '@shared/analytics/utils/screenName';
+import { identifyClarityUser, setClarityTag } from '@shared/config/clarity';
+
+import { useABTest } from '@hooks/useABTest';
+
+/**
+ * GA4 세그먼트 소스를 Clarity 커스텀 태그/식별로 미러링하는 훅
+ * RootLayout에서 1회 마운트 — 세션 레코딩·히트맵을 GA4와 같은 축으로 필터링 가능하게 함
+ */
+export const useClaritySync = (): void => {
+  const location = useLocation();
+  const accessToken = useUserStore((state) => state.accessToken);
+  const userId = useUserStore((state) => state.userId);
+  const { variant, isLoading: isABTestLoading } = useABTest();
+
+  // 화면 단위 세그먼트 — SPA 탭 화면(예: home ?tab=product)처럼 pathname이 안 바뀌는 화면을
+  // 히트맵/레코딩에서 구분하는 핵심 태그
+  useEffect(() => {
+    setClarityTag(
+      'screen_name',
+      resolveScreenName(`${location.pathname}${location.search}`)
+    );
+  }, [location.pathname, location.search]);
+
+  // 로그인 상태
+  useEffect(() => {
+    setClarityTag('login_status', getLoginStatus());
+  }, [accessToken]);
+
+  // A/B variant (배정 확정 후)
+  useEffect(() => {
+    if (!isABTestLoading) {
+      setClarityTag('ab_variant', variant);
+    }
+  }, [variant, isABTestLoading]);
+
+  // 유저 식별 — userId 확정 시 (boot 시 localStorage 하이드레이션 또는 로그인 후 useUserSync)
+  useEffect(() => {
+    if (userId != null) {
+      identifyClarityUser(String(userId));
+    }
+  }, [userId]);
+};

--- a/src/shared/hooks/useClaritySync.ts
+++ b/src/shared/hooks/useClaritySync.ts
@@ -7,8 +7,7 @@ import { useUserStore } from '@store/useUserStore';
 import { getLoginStatus } from '@shared/analytics/utils/loginStatus';
 import { resolveScreenName } from '@shared/analytics/utils/screenName';
 import { identifyClarityUser, setClarityTag } from '@shared/config/clarity';
-
-import { useABTest } from '@hooks/useABTest';
+import { AB_TEST_STORAGE_KEY, isABTestGroup } from '@shared/types/abTest';
 
 /**
  * GA4 세그먼트 소스를 Clarity 커스텀 태그/식별로 미러링하는 훅
@@ -18,7 +17,6 @@ export const useClaritySync = (): void => {
   const location = useLocation();
   const accessToken = useUserStore((state) => state.accessToken);
   const userId = useUserStore((state) => state.userId);
-  const { variant, isLoading: isABTestLoading } = useABTest();
 
   // 화면 단위 세그먼트 — SPA 탭 화면(예: home ?tab=product)처럼 pathname이 안 바뀌는 화면을
   // 히트맵/레코딩에서 구분하는 핵심 태그
@@ -34,12 +32,19 @@ export const useClaritySync = (): void => {
     setClarityTag('login_status', getLoginStatus());
   }, [accessToken]);
 
-  // A/B variant (배정 확정 후)
+  // A/B variant — 이미 배정된 값을 storage에서 수동 read만 (여기서 배정을 트리거하지 않음)
+  // useABTest()를 호출하면 userId 로딩 전(로그인 직후 등) 조기 랜덤 배정이 캐시되어
+  // 이후 userId 기반 결정적 배정을 영구히 덮어쓰므로, 관측용 훅에서는 직접 읽어 태깅만 수행
   useEffect(() => {
-    if (!isABTestLoading) {
-      setClarityTag('ab_variant', variant);
+    try {
+      const cached = localStorage.getItem(AB_TEST_STORAGE_KEY);
+      if (cached && isABTestGroup(cached)) {
+        setClarityTag('ab_variant', cached);
+      }
+    } catch {
+      // localStorage 접근 실패 시 무시
     }
-  }, [variant, isABTestLoading]);
+  }, [location.pathname, location.search]);
 
   // 유저 식별 — userId 확정 시 (boot 시 localStorage 하이드레이션 또는 로그인 후 useUserSync)
   useEffect(() => {


### PR DESCRIPTION
## 📌 Summary

- close #608

## 📄 Tasks

- 기존에 적용되어있던 Microsoft Clarity(세션 레코딩·히트맵 분석 도구)의 기본 스크립트 + [GA4 신규 작업](https://github.com/TEAM-HOUME/HOUME-CLIENT/pull/606)을 바탕으로 작업 진행
- GA4 계측이 쓰는 정보(현재 화면·로그인 여부·A/B 그룹·유저 식별자)를 Clarity에도 그대로 흘려보내, Clarity의 세션 레코딩과 히트맵을 GA4와 같은 기준으로 필터링
- 이미지 생성 완료·앱 에러 같은 서비스 핵심 동작을 Clarity에 표시하도록 구현

## 변경 사항
- **Clarity 고급 API 래퍼 추가** (`clarity.ts`): 커스텀 태그·커스텀 이벤트·세션 우선 레코딩·유저 식별을 함수로 wrapping. Clarity가 설정되지 않은 환경에서는 자동으로 아무 동작도 하지 않도록 안전장치 적용 완
- **`useClaritySync` 훅 추가 + RootLayout 마운트**: 라우트 이동, 로그인 상태, A/B variant, userId 변화를 감지해 Clarity 태그(`screen_name`·`login_status`·`ab_variant`)와 유저 식별을 실시간으로 동기화
- **전환 이벤트 추가** (`ResultPage`): 이미지 생성이 완료되어 결과 화면에 진입할 때 `image_generated` 이벤트 생성 (마이페이지·연관 이미지 재진입에서는 생성하지 않음)
- **에러 세션 우선 레코딩** (`main.tsx`): 앱 크래시(ErrorBoundary) 발생 세션을 Clarity가 우선적으로 레코딩하도록 지정

## To Reviewer

- Identify 기능은 우선 제외했습니다