### PR TITLE
[feat] 시트 최소화 기능 구현

### DIFF
--- a/src/pages/home/components/product/ProductTab.tsx
+++ b/src/pages/home/components/product/ProductTab.tsx
@@ -8,6 +8,7 @@ import {
   MAX_SELECTED_PRODUCTS,
   useProductTabController,
 } from '@pages/home/hooks/useProductTabController';
+import { useSheetMinimizeOnScroll } from '@pages/home/hooks/useSheetMinimizeOnScroll';
 import { consumeReopenProduct } from '@pages/home/utils/productDetailOverlayReopen';
 
 import { useImageFlowStore } from '@store/useImageFlowStore';
@@ -20,7 +21,10 @@ import ProductDetailOverlay from './ProductPopup/ProductDetailOverlay';
 import * as styles from './ProductTab.css';
 import SearchSection from './SearchSection/SearchSection';
 import SelectedProductSheet from './SelectedProductSheet/SelectedProductSheet';
-import { PRODUCT_BOTTOM_SHEET_COLLAPSED_HEIGHT } from '../../constants/productTab';
+import {
+  PRODUCT_BOTTOM_SHEET_COLLAPSED_HEIGHT,
+  PRODUCT_BOTTOM_SHEET_MINIMIZED_HEIGHT,
+} from '../../constants/productTab';
 
 const ProductTab = () => {
   const productsToBeRestored = useMemo(() => {
@@ -87,6 +91,11 @@ const ProductTab = () => {
     handleFilterSheetClose,
   } = controller;
 
+  // 스크롤 다운 시 시트 최소화(핸들+썸네일만) / 스크롤 업 시 복원
+  // collapsed & 스크롤 가능한 구간에서만 활성화
+  const { minimized: sheetMinimized, restore: restoreSheet } =
+    useSheetMinimizeOnScroll({ active: !filterSheetOpen && !sheetExpanded });
+
   useEffect(() => {
     const reopen = consumeReopenProduct();
     if (!reopen) return;
@@ -152,11 +161,15 @@ const ProductTab = () => {
       <DragHandleBottomSheet
         open={!filterSheetOpen}
         collapsedHeight={PRODUCT_BOTTOM_SHEET_COLLAPSED_HEIGHT}
+        minimizedHeight={PRODUCT_BOTTOM_SHEET_MINIMIZED_HEIGHT}
+        minimized={sheetMinimized}
+        onRestoreFromMinimized={restoreSheet}
         expanded={sheetExpanded}
         onExpandedChange={setSheetExpanded}
         contentSlot={
           <SelectedProductSheet
             expanded={sheetExpanded}
+            minimized={sheetMinimized}
             selectedProducts={selectedProducts}
             onRemoveProduct={handleRemoveSelectedProduct}
             onAddProductClick={handleAddProductClick}

--- a/src/pages/home/components/product/SelectedProductSheet/SelectedProductSheet.css.ts
+++ b/src/pages/home/components/product/SelectedProductSheet/SelectedProductSheet.css.ts
@@ -1,21 +1,57 @@
 import { style } from '@vanilla-extract/css';
+import { recipe } from '@vanilla-extract/recipes';
 
 import { colorVars } from '@styles/tokensV2/color.css';
 import { fontVars } from '@styles/tokensV2/font.css';
+import { transition } from '@styles/tokensV2/interaction/utils';
 import { unitVars } from '@styles/tokensV2/unit.css';
 
-export const container = style({
-  display: 'flex',
-  flexDirection: 'column',
-  gap: unitVars.unit.gapPadding['200'],
-  width: '100%',
+// 최소화 시 헤더가 접히는 트랜지션 (패널 height 슬라이드와 동일 duration/easing)
+const collapseTransition = [
+  transition('max-height'),
+  transition('opacity'),
+].join(', ');
+
+export const container = recipe({
+  base: {
+    display: 'flex',
+    flexDirection: 'column',
+    // Figma contentSlot gap = gap/100 (4px)
+    gap: unitVars.unit.gapPadding['100'],
+    width: '100%',
+  },
+  variants: {
+    minimized: {
+      true: { gap: unitVars.unit.gapPadding['000'] },
+      false: {},
+    },
+  },
+  defaultVariants: {
+    minimized: false,
+  },
 });
 
-export const headerRow = style({
-  display: 'flex',
-  alignItems: 'center',
-  gap: unitVars.unit.gapPadding['100'],
-  padding: `${unitVars.unit.gapPadding['000']} ${unitVars.unit.gapPadding['200']}`,
+// 최소화 시 헤더("선택한 상품 n/6")를 접어서 숨김 (양방향 트랜지션 위해 base에 유한 maxHeight)
+export const headerRow = recipe({
+  base: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: unitVars.unit.gapPadding['100'],
+    transition: collapseTransition,
+    padding: `${unitVars.unit.gapPadding['000']} ${unitVars.unit.gapPadding['100']}`,
+    // 헤더 실제 높이(~2.7rem) 바로 위 — reveal 타이밍을 버튼/패널과 맞춤
+    maxHeight: '3rem',
+    overflow: 'hidden',
+  },
+  variants: {
+    minimized: {
+      true: { opacity: 0, maxHeight: 0 },
+      false: {},
+    },
+  },
+  defaultVariants: {
+    minimized: false,
+  },
 });
 
 export const title = style({
@@ -37,7 +73,7 @@ export const compactRow = style({
   display: 'grid',
   gridTemplateColumns: 'repeat(6, 1fr)',
   gap: unitVars.unit.gapPadding['050'],
-  padding: `0 ${unitVars.unit.gapPadding['050']}`,
+  padding: `${unitVars.unit.gapPadding['050']} ${unitVars.unit.gapPadding['100']}`,
   width: '100%',
 });
 

--- a/src/pages/home/components/product/SelectedProductSheet/SelectedProductSheet.tsx
+++ b/src/pages/home/components/product/SelectedProductSheet/SelectedProductSheet.tsx
@@ -12,6 +12,8 @@ import * as styles from './SelectedProductSheet.css';
 
 interface SelectedProductSheetProps {
   expanded: boolean;
+  /** 스크롤 다운 최소화 상태. 헤더를 접어서 숨김 (기본: false) */
+  minimized?: boolean;
   selectedProducts: SelectedProduct[];
   onRemoveProduct: (id: number) => void;
   onAddProductClick?: () => void;
@@ -21,6 +23,7 @@ interface SelectedProductSheetProps {
 
 const SelectedProductSheet = ({
   expanded,
+  minimized = false,
   selectedProducts,
   onRemoveProduct,
   onAddProductClick,
@@ -77,8 +80,8 @@ const SelectedProductSheet = ({
   );
 
   return (
-    <div className={styles.container}>
-      <div className={styles.headerRow}>
+    <div className={styles.container({ minimized })}>
+      <div className={styles.headerRow({ minimized })}>
         <Icon name={expanded ? 'ChevronUp' : 'ChevronDown'} size="16" />
         <p className={styles.title}>선택한 상품</p>
         <span className={styles.count}>

--- a/src/pages/home/constants/productTab.ts
+++ b/src/pages/home/constants/productTab.ts
@@ -1,1 +1,7 @@
 export const PRODUCT_BOTTOM_SHEET_COLLAPSED_HEIGHT = '20rem';
+
+/**
+ * 스크롤 다운 시 최소화된 시트 높이 (핸들 + 썸네일 한 줄).
+ * collapsed(20rem)에서 헤더·CTA 버튼을 접었을 때 남는 높이에 맞춘 값.
+ */
+export const PRODUCT_BOTTOM_SHEET_MINIMIZED_HEIGHT = '10rem';

--- a/src/pages/home/hooks/useSheetMinimizeOnScroll.ts
+++ b/src/pages/home/hooks/useSheetMinimizeOnScroll.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 /**
  * 상품 탭 선택 시트 최소화 전용 훅
@@ -68,8 +68,8 @@ const useSheetMinimizeOnScroll = ({
     };
   }, [active]);
 
-  /** 드래그 시작 등 외부에서 즉시 복원할 때 사용 */
-  const restore = () => setMinimized(false);
+  /** 드래그 시작 등 외부에서 즉시 복원할 때 사용 (참조 안정 — 소비처 useCallback 의존성) */
+  const restore = useCallback(() => setMinimized(false), []);
 
   return { minimized, restore };
 };

--- a/src/pages/home/hooks/useSheetMinimizeOnScroll.ts
+++ b/src/pages/home/hooks/useSheetMinimizeOnScroll.ts
@@ -1,0 +1,77 @@
+import { useEffect, useRef, useState } from 'react';
+
+/**
+ * 상품 탭 선택 시트 최소화 전용 훅
+ * - 스크롤 다운 시 시트를 최소화(핸들 + 썸네일 한 줄)하고, 스크롤 업 시 복원한다.
+ * - `active`가 false면(시트 expanded / 필터 시트 열림 등) 리스너를 비활성화하고 즉시 복원한다.
+ */
+interface UseSheetMinimizeOnScrollParams {
+  /** collapsed 상태이면서 페이지 스크롤이 가능한 구간에서만 true */
+  active: boolean;
+}
+
+/**
+ * 방향 판단 임계 이동량
+ * 임계 미만 이동은 기준점을 갱신하지 않아 누적되므로, 느린 스크롤도 임계를 넘으면 트리거된다.
+ */
+const SCROLL_DELTA_THRESHOLD_PX = 6;
+
+/** 이 지점 이하로 올라오면 최소화를 강제 해제 (리스트 최상단) */
+const RESTORE_AT_TOP_PX = 8;
+
+const useSheetMinimizeOnScroll = ({
+  active,
+}: UseSheetMinimizeOnScrollParams) => {
+  const lastScrollYRef = useRef(0);
+  const [minimized, setMinimized] = useState(false);
+
+  /** active가 꺼지면(expanded/필터 열림) 최소화 상태를 즉시 해제 */
+  useEffect(() => {
+    if (!active) setMinimized(false);
+  }, [active]);
+
+  /**
+   * window 스크롤 방향으로 최소화 상태를 계산한다.
+   * - 아래로 임계 이상 → 최소화 / 위로 임계 이상 → 복원 (누적 delta 기준)
+   * - 임계 미만 이동은 기준점을 갱신하지 않아 누적됨 (느린 스크롤 대응 + 지터 무시)
+   * - 최상단 근처 → 강제 복원
+   */
+  useEffect(() => {
+    if (!active) return undefined;
+
+    lastScrollYRef.current = window.scrollY || window.pageYOffset;
+
+    const handleScroll = () => {
+      const currentY = window.scrollY || window.pageYOffset;
+
+      if (currentY <= RESTORE_AT_TOP_PX) {
+        lastScrollYRef.current = currentY;
+        setMinimized(false);
+        return;
+      }
+
+      const delta = currentY - lastScrollYRef.current;
+
+      if (delta > SCROLL_DELTA_THRESHOLD_PX) {
+        lastScrollYRef.current = currentY;
+        setMinimized(true);
+      } else if (delta < -SCROLL_DELTA_THRESHOLD_PX) {
+        lastScrollYRef.current = currentY;
+        setMinimized(false);
+      }
+    };
+
+    window.addEventListener('scroll', handleScroll, { passive: true });
+
+    return () => {
+      window.removeEventListener('scroll', handleScroll);
+    };
+  }, [active]);
+
+  /** 드래그 시작 등 외부에서 즉시 복원할 때 사용 */
+  const restore = () => setMinimized(false);
+
+  return { minimized, restore };
+};
+
+export { useSheetMinimizeOnScroll };

--- a/src/shared/components/v2/bottomSheet/BottomSheetBase.css.ts
+++ b/src/shared/components/v2/bottomSheet/BottomSheetBase.css.ts
@@ -7,7 +7,15 @@ import {
   pressInteraction,
   sheetSlideInteraction,
 } from '@styles/tokensV2/interaction/presets';
+import { transition } from '@styles/tokensV2/interaction/utils';
 import { unitVars } from '@styles/tokensV2/unit.css';
+
+// 최소화 시 actionRow가 접히는 트랜지션 (패널 height 슬라이드와 동일 duration/easing)
+// transform은 쓰지 않음 — translateY(%)가 애니메이션 중인 높이에 종속돼 버튼이 출렁이므로 maxHeight+opacity만 사용
+const collapseTransition = [
+  transition('max-height'),
+  transition('opacity'),
+].join(', ');
 // dim과 바텀시트를 동일한 모바일 프레임 폭으로 맞추기 위한 공통 폭 제한
 const mobileFrame = style({
   width: '100%',
@@ -185,7 +193,6 @@ export const body = recipe({
   base: {
     display: 'flex',
     flexDirection: 'column',
-    justifyContent: 'space-between',
     padding: `${unitVars.unit.gapPadding['000']} ${unitVars.unit.gapPadding['600']}`,
     width: '100%',
     height: '100%',
@@ -200,6 +207,10 @@ export const body = recipe({
       true: {},
       false: {},
     },
+    minimized: {
+      true: {},
+      false: {},
+    },
   },
   compoundVariants: [
     {
@@ -210,10 +221,16 @@ export const body = recipe({
       variants: { headerType: 'dragHandle', expanded: true },
       style: { gap: unitVars.unit.gapPadding['500'] },
     },
+    // 최소화 시 접힌 버튼 자리에 남는 gap 제거 (썸네일이 핸들 바로 아래 붙도록)
+    {
+      variants: { headerType: 'dragHandle', minimized: true },
+      style: { gap: unitVars.unit.gapPadding['000'] },
+    },
   ],
   defaultVariants: {
     headerType: 'close',
     expanded: false,
+    minimized: false,
   },
 });
 
@@ -236,11 +253,32 @@ export const contentSlot = style({
 });
 
 // 버튼 래퍼 row
-export const actionRow = style({
-  display: 'flex',
-  alignItems: 'stretch',
-  gap: unitVars.unit.gapPadding['200'],
-  width: '100%',
+// minimized(스크롤 다운)일 때 maxHeight+opacity로 접혀서 사라짐
+// base maxHeight는 버튼 높이(2XL=5.6rem) 바로 위로 두어 collapse/reveal 타이밍을 패널 전환과 맞춤
+// overflow:hidden은 minimized일 때만 적용 (close 타입 버튼 포커스 링 클립 방지)
+export const actionRow = recipe({
+  base: {
+    display: 'flex',
+    alignItems: 'stretch',
+    gap: unitVars.unit.gapPadding['200'],
+    transition: collapseTransition,
+    width: '100%',
+    maxHeight: '6rem',
+  },
+  variants: {
+    minimized: {
+      true: {
+        opacity: 0,
+        pointerEvents: 'none',
+        maxHeight: 0,
+        overflow: 'hidden',
+      },
+      false: {},
+    },
+  },
+  defaultVariants: {
+    minimized: false,
+  },
 });
 
 // secondary 버튼이 자기 너비를 유지하도록 감싸는 슬롯

--- a/src/shared/components/v2/bottomSheet/BottomSheetBase.tsx
+++ b/src/shared/components/v2/bottomSheet/BottomSheetBase.tsx
@@ -51,6 +51,8 @@ interface BottomSheetBaseProps {
   preventScroll?: boolean;
   /** dragHandle 시트의 펼침 상태. 본문↔버튼 gap을 collapsed 8px / expanded 20px로 분기 (기본: false) */
   expanded?: boolean;
+  /** 최소화 상태(스크롤 다운). actionRow(버튼)를 접어 슬라이드 아웃 (기본: false) */
+  minimized?: boolean;
   /** 콘텐츠 스크롤 컨테이너(contentSlot) ref. body 드래그 시 scrollTop 측정용 */
   contentScrollRef?: React.Ref<HTMLDivElement>;
   /** contentSlot에 부착할 body 터치 드래그 핸들러 (DragHandleBottomSheet에서 시트 expand/collapse 제어) */
@@ -80,6 +82,7 @@ const BottomSheetBase = ({
   backgroundInteractable = false,
   preventScroll = true,
   expanded = false,
+  minimized = false,
   contentScrollRef,
   contentTouchHandlers,
 }: BottomSheetBaseProps) => {
@@ -283,7 +286,7 @@ const BottomSheetBase = ({
               />
             </div>
           )}
-          <div className={styles.body({ headerType, expanded })}>
+          <div className={styles.body({ headerType, expanded, minimized })}>
             <div
               ref={contentScrollRef}
               className={styles.contentSlot}
@@ -295,7 +298,7 @@ const BottomSheetBase = ({
             >
               {contentSlot}
             </div>
-            <div className={styles.actionRow}>
+            <div className={styles.actionRow({ minimized })}>
               {secondaryButton && (
                 <div className={styles.secondaryActionSlot}>
                   {secondaryButton}

--- a/src/shared/components/v2/bottomSheet/DragHandleBottomSheet.tsx
+++ b/src/shared/components/v2/bottomSheet/DragHandleBottomSheet.tsx
@@ -27,6 +27,12 @@ interface DragHandleBottomSheetProps {
   collapsedHeight?: string;
   /** Dismissible 모드에서 바텀시트가 닫혀야 할 때 부모에게 알리는 콜백 */
   onDismiss?: () => void;
+  /** 스크롤 다운 시 최소화 상태(핸들 + 썸네일만). Persistent 모드에서만 유효 (기본: false) */
+  minimized?: boolean;
+  /** 최소화 시 패널 높이 (rem 문자열). minimized일 때만 사용 */
+  minimizedHeight?: string;
+  /** 최소화 상태에서 드래그가 시작될 때 부모에게 복원을 알리는 콜백 */
+  onRestoreFromMinimized?: () => void;
 }
 
 // 'snapping' = collapsed → expanded snap 중 콘텐츠 자연 높이로 부드럽게 보간하는 단계
@@ -53,6 +59,9 @@ const DragHandleBottomSheet = ({
   expanded: expandedFromParent,
   collapsedHeight,
   onDismiss,
+  minimized = false,
+  minimizedHeight,
+  onRestoreFromMinimized,
 }: DragHandleBottomSheetProps) => {
   const isPersistent = collapsedHeight !== undefined;
 
@@ -142,7 +151,9 @@ const DragHandleBottomSheet = ({
         ? parsePxFromRem(collapsedHeight as string)
         : 0;
       const expandedPx = resolveExpandedPx();
-      const startHeight = panel.offsetHeight;
+      // 최소화 상태에서 드래그 시작 시엔 패널 실측(minimizedHeight)이 아니라 collapsed 높이를 기준으로 삼아, clamp 데드존/점프 없이 collapsed에서 확장 드래그가 이어지도록 함
+      const startHeight =
+        isPersistent && minimized ? collapsedPx : panel.offsetHeight;
 
       startYRef.current = clientY;
       startHeightRef.current = startHeight;
@@ -152,7 +163,7 @@ const DragHandleBottomSheet = ({
       draggedRef.current = false;
       finishedRef.current = false;
     },
-    [isPersistent, collapsedHeight]
+    [isPersistent, collapsedHeight, minimized]
   );
 
   // 드래그 이동: delta → height clamp → setDragHeight
@@ -245,11 +256,12 @@ const DragHandleBottomSheet = ({
       if (!panel) return;
 
       e.stopPropagation();
+      if (isPersistent && minimized) onRestoreFromMinimized?.();
       beginDrag(e.clientY, panel);
       pointerIdRef.current = e.pointerId;
       e.currentTarget.setPointerCapture(e.pointerId);
     },
-    [beginDrag]
+    [beginDrag, isPersistent, minimized, onRestoreFromMinimized]
   );
 
   const handlePointerMove = useCallback(
@@ -305,12 +317,20 @@ const DragHandleBottomSheet = ({
 
       // takeover: 현재 y 기준으로 드래그 시작 (점프 없이 이 지점부터 시트 이동)
       bodyTakenOverRef.current = true;
+      if (isPersistent && minimized) onRestoreFromMinimized?.();
       beginDrag(y, panel);
       draggedRef.current = true;
       setDragPhase('dragging');
       applyDragMove(y);
     },
-    [expanded, beginDrag, applyDragMove]
+    [
+      expanded,
+      beginDrag,
+      applyDragMove,
+      isPersistent,
+      minimized,
+      onRestoreFromMinimized,
+    ]
   );
 
   const handleBodyTouchEnd = useCallback(
@@ -339,12 +359,21 @@ const DragHandleBottomSheet = ({
     return Math.max(0, Math.min(1, dragHeight / expandedPx));
   };
 
-  // panel height 결정
+  // expanded일 땐 minimized 무시 (안전 가드). minimized는 항상 collapsed의 서브상태
+  const isMinimized = isPersistent && minimized && !expanded;
+
+  // panel height 결정 (dragging > expanded > minimized > collapsed 우선순위)
   const panelStyle: React.CSSProperties =
     dragPhase === 'dragging' && dragHeight !== null
       ? { height: `${dragHeight}px` }
       : isPersistent
-        ? { height: expanded ? 'auto' : collapsedHeight }
+        ? {
+            height: expanded
+              ? 'auto'
+              : isMinimized && minimizedHeight
+                ? minimizedHeight
+                : collapsedHeight,
+          }
         : {};
 
   const handleOverlayClick = () => {
@@ -360,6 +389,7 @@ const DragHandleBottomSheet = ({
       open={open}
       headerType="dragHandle"
       expanded={expanded}
+      minimized={isMinimized}
       contentSlot={contentSlot}
       primaryButton={primaryButton}
       secondaryButton={secondaryButton}


### PR DESCRIPTION
## 📌 Summary

- close #630 

_해당 PR에 대한 작업 내용을 요약하여 작성해주세요._

## 📄 Tasks

- 상품 탭 시트 최소화 기능 추가 (시트에 minimize 상태 추가)
- 상품 탭에서 scroll down 동작 시 시트 최소화(minimize 상태로 전환), scroll up 시 expanded=false 상태로 복구
  - scroll up/down 판별은 기존에 상품 탭에서 사용되던 로직 재사용

## 📸 Screenshot

https://github.com/user-attachments/assets/947ec674-3613-4a91-bba6-b3763d8aee47