### PR TITLE
[feat] 상품 탭 시트 GA 파라미터 값 추가

### DIFF
--- a/src/pages/home/analytics/shopAnalytics.ts
+++ b/src/pages/home/analytics/shopAnalytics.ts
@@ -143,6 +143,7 @@ export const trackShopSelectSheetItemClick = (
 
 export interface ShopSelectSheetCtaContext extends ShopListContext {
   sheetExpanded: boolean;
+  sheetCollapsed?: boolean;
   selectedProducts: SelectedProduct[];
   imageEntryRoute?: ImageEntryRoute;
   returnScreenName: ScreenName;
@@ -152,6 +153,7 @@ export interface ShopSelectSheetCtaContext extends ShopListContext {
 
 export const trackShopSelectSheetCtaClick = ({
   sheetExpanded,
+  sheetCollapsed = false,
   selectedProducts,
   imageEntryRoute,
   returnScreenName,
@@ -162,7 +164,7 @@ export const trackShopSelectSheetCtaClick = ({
 
   trackEvent(GA_EVENTS.shop.SELECT_SHEET_CTA_CLICK, {
     ...getShopSelectSheetBaseParams(
-      { sheetExpanded, selectedProducts },
+      { sheetExpanded, sheetCollapsed, selectedProducts },
       { includeLoginStatus: true }
     ),
     ...getShopSelectedProductFields(lastProduct),

--- a/src/pages/home/analytics/shopAnalyticsParams.ts
+++ b/src/pages/home/analytics/shopAnalyticsParams.ts
@@ -28,6 +28,7 @@ export interface ShopListContext {
 
 export interface ShopSelectSheetContext extends ShopListContext {
   sheetExpanded: boolean;
+  sheetCollapsed?: boolean;
   selectedProducts: SelectedProduct[];
   countTriggerEvent?: CountTriggerEvent;
 }
@@ -122,18 +123,25 @@ export const getShopListContextParams = (
 export const getShopSelectSheetBaseParams = (
   {
     sheetExpanded,
+    sheetCollapsed = false,
     selectedProducts,
     countTriggerEvent,
   }: Pick<
     ShopSelectSheetContext,
-    'sheetExpanded' | 'selectedProducts' | 'countTriggerEvent'
+    | 'sheetExpanded'
+    | 'sheetCollapsed'
+    | 'selectedProducts'
+    | 'countTriggerEvent'
   >,
   options?: Pick<ShopListParamsOptions, 'includeLoginStatus'>
 ) => {
   return {
     ...(options?.includeLoginStatus ? loginStatusParams() : {}),
     ...shopScreenParams(),
-    sheet_expansion_status: toSheetExpansionStatus(sheetExpanded),
+    sheet_expansion_status: toSheetExpansionStatus(
+      sheetExpanded,
+      sheetCollapsed
+    ),
     selected_count: selectedProducts.length,
     selected_product_ids: formatSelectedProductIds(selectedProducts),
     ...(countTriggerEvent ? { count_trigger_event: countTriggerEvent } : {}),

--- a/src/pages/home/analytics/useProductShopAnalytics.ts
+++ b/src/pages/home/analytics/useProductShopAnalytics.ts
@@ -34,6 +34,7 @@ import { resolveShopImageEntryRoute } from '@shared/analytics/utils/shop/resolve
 interface UseProductShopAnalyticsOptions {
   productCountViewed: number;
   onProductViewedCountChange: (count: number) => void;
+  sheetCollapsed?: boolean;
 }
 
 /**
@@ -44,6 +45,7 @@ const useProductShopAnalytics = (
   {
     productCountViewed,
     onProductViewedCountChange,
+    sheetCollapsed = false,
   }: UseProductShopAnalyticsOptions
 ) => {
   const { data: recentFloorPlanData } = useRecentFloorPlanQuery();
@@ -75,7 +77,11 @@ const useProductShopAnalytics = (
     getSelectSheetContext,
     getSelectSheetContextRef,
     shopListContext,
-  } = useShopAnalyticsContext({ controller, productCountViewed });
+  } = useShopAnalyticsContext({
+    controller,
+    productCountViewed,
+    sheetCollapsed,
+  });
 
   const shopPageParams = useMemo(
     () =>
@@ -284,6 +290,7 @@ const useProductShopAnalytics = (
     trackShopSelectSheetCtaClick({
       ...getShopListContext(),
       sheetExpanded,
+      sheetCollapsed,
       selectedProducts,
       imageEntryRoute: resolveShopImageEntryRoute(),
       // 상품 탭 CTA의 return screen은 항상 shop 고정 (진입 경로는 image_entry_route로 별도 계산)
@@ -299,6 +306,7 @@ const useProductShopAnalytics = (
     recentFloorPlanData,
     selectedProducts,
     sheetExpanded,
+    sheetCollapsed,
   ]);
 
   const handleSelectSheetItemClick = useCallback(

--- a/src/pages/home/analytics/useShopAnalyticsContext.ts
+++ b/src/pages/home/analytics/useShopAnalyticsContext.ts
@@ -11,6 +11,7 @@ import { withProductSubCategory } from '@pages/home/utils/productFilterUtils';
 interface UseShopAnalyticsContextParams {
   controller: ProductTabController;
   productCountViewed: number;
+  sheetCollapsed?: boolean;
 }
 
 /**
@@ -20,6 +21,7 @@ interface UseShopAnalyticsContextParams {
 export const useShopAnalyticsContext = ({
   controller,
   productCountViewed,
+  sheetCollapsed = false,
 }: UseShopAnalyticsContextParams) => {
   const {
     sheetExpanded,
@@ -90,11 +92,12 @@ export const useShopAnalyticsContext = ({
     (overrides?: Partial<ShopSelectSheetContext>): ShopSelectSheetContext => ({
       ...getShopListContext(),
       sheetExpanded: overrides?.sheetExpanded ?? sheetExpanded,
+      sheetCollapsed: overrides?.sheetCollapsed ?? sheetCollapsed,
       selectedProducts:
         overrides?.selectedProducts ?? selectedProductsRef.current,
       countTriggerEvent: overrides?.countTriggerEvent,
     }),
-    [getShopListContext, sheetExpanded]
+    [getShopListContext, sheetExpanded, sheetCollapsed]
   );
 
   const getSelectSheetContextRef = useRef(getSelectSheetContext);

--- a/src/pages/home/components/product/ProductTab.tsx
+++ b/src/pages/home/components/product/ProductTab.tsx
@@ -50,26 +50,6 @@ const ProductTab = () => {
   });
 
   const {
-    shopListContext,
-    setSheetExpanded,
-    handleProductListRender,
-    handleFilterChipClick,
-    handleFilterApply,
-    handleFilterResetClick,
-    handleSelectProduct,
-    handleSelectProductFromDetailModal,
-    handleRemoveSelectedProduct,
-    handleAddProductClick,
-    handleDecorateWithProductsClick,
-    handleSearchBarClick,
-    handleSearchClear,
-    handleSelectSheetItemClick,
-  } = useProductShopAnalytics(controller, {
-    productCountViewed,
-    onProductViewedCountChange: setProductCountViewed,
-  });
-
-  const {
     sheetExpanded,
     filterSheetOpen,
     chipSelected,
@@ -91,10 +71,31 @@ const ProductTab = () => {
     handleFilterSheetClose,
   } = controller;
 
-  // 스크롤 다운 시 시트 최소화(핸들+썸네일만) / 스크롤 업 시 복원
-  // collapsed & 스크롤 가능한 구간에서만 활성화
-  const { minimized: sheetMinimized, restore: restoreSheet } =
+  // 스크롤 다운 시 시트 축소(핸들+썸네일만) / 스크롤 업 시 복원
+  // default 높이 & 스크롤 가능한 구간에서만 활성화
+  const { minimized: sheetCollapsed, restore: restoreSheet } =
     useSheetMinimizeOnScroll({ active: !filterSheetOpen && !sheetExpanded });
+
+  const {
+    shopListContext,
+    setSheetExpanded,
+    handleProductListRender,
+    handleFilterChipClick,
+    handleFilterApply,
+    handleFilterResetClick,
+    handleSelectProduct,
+    handleSelectProductFromDetailModal,
+    handleRemoveSelectedProduct,
+    handleAddProductClick,
+    handleDecorateWithProductsClick,
+    handleSearchBarClick,
+    handleSearchClear,
+    handleSelectSheetItemClick,
+  } = useProductShopAnalytics(controller, {
+    productCountViewed,
+    onProductViewedCountChange: setProductCountViewed,
+    sheetCollapsed,
+  });
 
   useEffect(() => {
     const reopen = consumeReopenProduct();
@@ -162,14 +163,14 @@ const ProductTab = () => {
         open={!filterSheetOpen}
         collapsedHeight={PRODUCT_BOTTOM_SHEET_COLLAPSED_HEIGHT}
         minimizedHeight={PRODUCT_BOTTOM_SHEET_MINIMIZED_HEIGHT}
-        minimized={sheetMinimized}
+        minimized={sheetCollapsed}
         onRestoreFromMinimized={restoreSheet}
         expanded={sheetExpanded}
         onExpandedChange={setSheetExpanded}
         contentSlot={
           <SelectedProductSheet
             expanded={sheetExpanded}
-            minimized={sheetMinimized}
+            minimized={sheetCollapsed}
             selectedProducts={selectedProducts}
             onRemoveProduct={handleRemoveSelectedProduct}
             onAddProductClick={handleAddProductClick}

--- a/src/pages/home/components/product/SelectedProductSheet/SelectedProductSheet.css.ts
+++ b/src/pages/home/components/product/SelectedProductSheet/SelectedProductSheet.css.ts
@@ -82,6 +82,7 @@ export const compactSlot = style({
   border: `1px solid ${colorVars.color.border.tertiary}`,
   borderRadius: unitVars.unit.radius['300'],
   backgroundColor: colorVars.color.bg.primary,
+  cursor: 'pointer',
 });
 
 export const expandedGrid = style({

--- a/src/pages/home/components/product/SelectedProductSheet/SelectedProductSheet.tsx
+++ b/src/pages/home/components/product/SelectedProductSheet/SelectedProductSheet.tsx
@@ -124,7 +124,11 @@ const SelectedProductSheet = ({
             />
           ))}
           {Array.from({ length: emptyCount }).map((_, index) => (
-            <div key={`empty-${index}`} className={styles.compactSlot} />
+            <div
+              key={`empty-${index}`}
+              className={styles.compactSlot}
+              onClick={onAddProductClick}
+            />
           ))}
         </div>
       )}

--- a/src/shared/analytics/params/shop.ts
+++ b/src/shared/analytics/params/shop.ts
@@ -2,6 +2,7 @@
 export const SHEET_EXPANSION_STATUS = {
   DEFAULT: 'default',
   EXPANDED: 'expanded',
+  COLLAPSED: 'collapsed',
 } as const;
 
 export type SheetExpansionStatus =

--- a/src/shared/analytics/utils/imageFlow/formatFunnelGaParams.ts
+++ b/src/shared/analytics/utils/imageFlow/formatFunnelGaParams.ts
@@ -71,5 +71,11 @@ export const toResultPreferenceType = (
 
 // ── sheet_expansion_status (shop) ─────────────────────────────
 
-export const toSheetExpansionStatus = (expanded: boolean) =>
-  expanded ? SHEET_EXPANSION_STATUS.EXPANDED : SHEET_EXPANSION_STATUS.DEFAULT;
+export const toSheetExpansionStatus = (
+  expanded: boolean,
+  collapsed = false
+) => {
+  if (expanded) return SHEET_EXPANSION_STATUS.EXPANDED;
+  if (collapsed) return SHEET_EXPANSION_STATUS.COLLAPSED;
+  return SHEET_EXPANSION_STATUS.DEFAULT;
+};


### PR DESCRIPTION
## 📌 Summary

- close #633

상품 탭 선택 시트 GA에 `sheet_expansion_status: collapsed`를 추가하고, compact 빈 슬롯 클릭 트래킹을 보완했어요.

## 📄 Tasks

- `sheet_expansion_status`에 `collapsed` 값 추가
- select sheet 관련 이벤트에 축소(`sheetCollapsed`) 상태 전달
- compact 빈 슬롯 클릭 시 `shop_selectSheetAddItem_click` 발화 (선택 상품 0개일 때)

## 🔍 To Reviewer

### 1. `sheet_expansion_status`에 `collapsed` 추가

스크롤 다운으로 선택 시트가 축소된 상태(핸들 + 썸네일)를 GA에서 `collapsed`로 구분하기 위해 스펙 값을 추가했어요.

| UI 상태 | `sheet_expansion_status` |
|---|---|
| expanded | `expanded` |
| default (기본 높이) | `default` |
| 스크롤 다운 축소 | `collapsed` |

변환은 `toSheetExpansionStatus(expanded, collapsed)`에서 `expanded > collapsed > default` 우선순위로 매핑합니다.

적용 대상은 select sheet 이벤트 7개입니다.

- `shop_selectSheet_swipeUp`
- `shop_selectSheet_swipeDown`
- `shop_selectSheetItem_click`
- `shop_selectSheetAddItem_click`
- `shop_selectSheetRemove_click`
- `shop_selectSheetCTA_click`
- `shop_selectSheetItemCount_change`

필터 시트 이벤트(`shop_filterSht_view` / `submit` / `reset`)에는 `collapsed`를 넣지 않았고, 기존처럼 `default` / `expanded`만 전송합니다.

### 2. compact 빈 슬롯 클릭 트래킹

expanded의 ‘상품 추가하기’는 이미 `onAddProductClick`이 연결되어 있었는데, compact 빈 슬롯(`compactSlot`)에는 클릭 핸들러가 없어서 축소 상태에서 이벤트가 안 찍히고 있었어요.

compact 빈 슬롯에도 같은 `onAddProductClick`을 연결했고, 선택 상품이 **0개일 때만** 기존 로직대로 `shop_selectSheetAddItem_click`이 전송됩니다!

## 📸 Screenshot
.