### PR TITLE
[feat] 배포 버전 감지 및 자동 업데이트 로직 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,60 +1,11 @@
-import { useEffect, useRef } from 'react';
-
 import { RouterProvider } from 'react-router-dom';
 
 import { router } from '@routes/router';
 
-import { TOAST_TYPE, TOASTER_ID } from '@shared/types/toast';
-
-import { useToast } from '@components/v2/toast/useToast';
-
-import { TOAST_ACTION_LABEL, TOAST_MESSAGE } from '@constants/toastMessage';
-
-import { useAppUpdate } from '@hooks/useAppUpdate';
-
-/** setTimeout 최대 지연(약 24.8일). Infinity는 브라우저에서 즉시 만료됨 */
-const PERSISTENT_TOAST_DURATION_MS = 2_147_483_647;
+import { useAppUpdateToast } from '@hooks/useAppUpdateToast';
 
 function App() {
-  const { updateAvailable, latestVersion, reload, dismiss } = useAppUpdate();
-  const { notify } = useToast();
-  const shownVersionRef = useRef<string | null>(null);
-  const isReloadingRef = useRef(false);
-
-  useEffect(() => {
-    if (!updateAvailable || !latestVersion) {
-      return;
-    }
-
-    if (shownVersionRef.current === latestVersion) {
-      return;
-    }
-
-    shownVersionRef.current = latestVersion;
-    isReloadingRef.current = false;
-
-    notify({
-      text: TOAST_MESSAGE.APP_UPDATE_AVAILABLE,
-      type: TOAST_TYPE.ACTION,
-      actionLabel: TOAST_ACTION_LABEL.RELOAD,
-      ariaLabel: '지금 새로고침하여 업데이트',
-      onClick: () => {
-        isReloadingRef.current = true;
-        reload();
-      },
-      options: {
-        duration: PERSISTENT_TOAST_DURATION_MS,
-        toasterId: TOASTER_ID.BOTTOM_4,
-        onDismiss: () => {
-          // 스와이프 등으로 닫은 경우에만 세션 dismiss (같은 버전 재알림 방지)
-          if (!isReloadingRef.current) {
-            dismiss();
-          }
-          shownVersionRef.current = null;
-        },
-      },
-    });
-  }, [updateAvailable, latestVersion, notify, reload, dismiss]);
+  useAppUpdateToast();
 
   return <RouterProvider router={router} />;
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,61 @@
+import { useEffect, useRef } from 'react';
+
 import { RouterProvider } from 'react-router-dom';
 
 import { router } from '@routes/router';
 
+import { TOAST_TYPE, TOASTER_ID } from '@shared/types/toast';
+
+import { useToast } from '@components/v2/toast/useToast';
+
+import { TOAST_ACTION_LABEL, TOAST_MESSAGE } from '@constants/toastMessage';
+
+import { useAppUpdate } from '@hooks/useAppUpdate';
+
+/** setTimeout 최대 지연(약 24.8일). Infinity는 브라우저에서 즉시 만료됨 */
+const PERSISTENT_TOAST_DURATION_MS = 2_147_483_647;
+
 function App() {
+  const { updateAvailable, latestVersion, reload, dismiss } = useAppUpdate();
+  const { notify } = useToast();
+  const shownVersionRef = useRef<string | null>(null);
+  const isReloadingRef = useRef(false);
+
+  useEffect(() => {
+    if (!updateAvailable || !latestVersion) {
+      return;
+    }
+
+    if (shownVersionRef.current === latestVersion) {
+      return;
+    }
+
+    shownVersionRef.current = latestVersion;
+    isReloadingRef.current = false;
+
+    notify({
+      text: TOAST_MESSAGE.APP_UPDATE_AVAILABLE,
+      type: TOAST_TYPE.ACTION,
+      actionLabel: TOAST_ACTION_LABEL.RELOAD,
+      ariaLabel: '지금 새로고침하여 업데이트',
+      onClick: () => {
+        isReloadingRef.current = true;
+        reload();
+      },
+      options: {
+        duration: PERSISTENT_TOAST_DURATION_MS,
+        toasterId: TOASTER_ID.BOTTOM_4,
+        onDismiss: () => {
+          // 스와이프 등으로 닫은 경우에만 세션 dismiss (같은 버전 재알림 방지)
+          if (!isReloadingRef.current) {
+            dismiss();
+          }
+          shownVersionRef.current = null;
+        },
+      },
+    });
+  }, [updateAvailable, latestVersion, notify, reload, dismiss]);
+
   return <RouterProvider router={router} />;
 }
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -20,12 +20,15 @@ import { queryClient } from '@apis/config/queryClient';
 
 import AppErrorFallback from '@components/errorFallback/AppErrorFallback';
 import MainToaster from '@components/v2/toast/Sonner';
+
 import '@styles/global.css';
+import { setupVitePreloadErrorReload } from '@utils/setupVitePreloadErrorReload';
 
 import App from './App';
 
 initSentry();
 initClarity();
+setupVitePreloadErrorReload();
 
 // 개발 모드: ?ab=A|B (useABTest와 동일 — 앱 부트 시 storage 선반영)
 if (import.meta.env.DEV) {

--- a/src/shared/constants/appUpdate.ts
+++ b/src/shared/constants/appUpdate.ts
@@ -7,11 +7,11 @@ export const APP_UPDATE_CHECK_INTERVAL_MS = 5 * 60 * 1000;
 
 export const APP_UPDATE_STORAGE_KEYS = {
   /** 닫은(스와이프 등) 최신 version.json 값 (세션 단위) */
-  dismissedVersion: 'houme:dismissed-app-version',
+  DISMISSED_VERSION: 'houme:dismissed-app-version',
   /** vite:preloadError 로 reload 한 빌드 표시 (빌드당 1회) */
-  preloadReloadedPrefix: 'houme:preload-reloaded:',
+  PRELOAD_RELOADED_PREFIX: 'houme:preload-reloaded:',
 } as const;
 
 export const getPreloadReloadedStorageKey = (
   buildId: string = CLIENT_BUILD_ID
-) => `${APP_UPDATE_STORAGE_KEYS.preloadReloadedPrefix}${buildId}`;
+) => `${APP_UPDATE_STORAGE_KEYS.PRELOAD_RELOADED_PREFIX}${buildId}`;

--- a/src/shared/constants/appUpdate.ts
+++ b/src/shared/constants/appUpdate.ts
@@ -1,0 +1,17 @@
+/** 배포 버전 감지·업데이트 알림용 상수 */
+
+/** 현재 번들에 주입된 배포 빌드 ID (`vite.config` define) */
+export const CLIENT_BUILD_ID: string = __BUILD_ID__;
+
+export const APP_UPDATE_CHECK_INTERVAL_MS = 5 * 60 * 1000;
+
+export const APP_UPDATE_STORAGE_KEYS = {
+  /** 닫은(스와이프 등) 최신 version.json 값 (세션 단위) */
+  dismissedVersion: 'houme:dismissed-app-version',
+  /** vite:preloadError 로 reload 한 빌드 표시 (빌드당 1회) */
+  preloadReloadedPrefix: 'houme:preload-reloaded:',
+} as const;
+
+export const getPreloadReloadedStorageKey = (
+  buildId: string = CLIENT_BUILD_ID
+) => `${APP_UPDATE_STORAGE_KEYS.preloadReloadedPrefix}${buildId}`;

--- a/src/shared/constants/toastMessage.ts
+++ b/src/shared/constants/toastMessage.ts
@@ -15,9 +15,11 @@ export const TOAST_MESSAGE = {
   NETWORK_UNSTABLE: '네트워크가 불안정해요. 확인 후 다시 시도해 주세요.',
   IMAGE_GENERATION_SERVER_ERROR:
     '이미지 생성에 문제가 발생했어요. 잠시 후에 다시 시도해 주세요.',
+  APP_UPDATE_AVAILABLE: '새로운 버전이 배포되었습니다.',
 } as const;
 
 export const TOAST_ACTION_LABEL = {
   VIEW: '보러가기',
   UNDO: '되돌리기',
+  RELOAD: '새로고침',
 } as const;

--- a/src/shared/hooks/useAppUpdate.ts
+++ b/src/shared/hooks/useAppUpdate.ts
@@ -1,0 +1,136 @@
+import { useCallback, useEffect, useState } from 'react';
+
+import {
+  APP_UPDATE_CHECK_INTERVAL_MS,
+  APP_UPDATE_STORAGE_KEYS,
+  CLIENT_BUILD_ID,
+} from '@constants/appUpdate';
+
+interface VersionResponse {
+  version: string;
+  builtAt?: string;
+}
+
+interface UseAppUpdateOptions {
+  /** 기본 5분 */
+  intervalMs?: number;
+  /**
+   * 버전 검사 활성화 여부.
+   * 기본값은 프로덕션(`import.meta.env.PROD`)입니다.
+   */
+  enabled?: boolean;
+}
+
+/**
+ * 프로덕션에서 /version.json 을 확인해 새 배포 여부를 알립니다.
+ * 자동 새로고침은 하지 않고, 호출측에서 토스트 등으로 안내합니다.
+ */
+export function useAppUpdate({
+  intervalMs = APP_UPDATE_CHECK_INTERVAL_MS,
+  enabled = import.meta.env.PROD,
+}: UseAppUpdateOptions = {}) {
+  const [updateAvailable, setUpdateAvailable] = useState(false);
+  const [latestVersion, setLatestVersion] = useState<string>();
+
+  const reload = useCallback(() => {
+    window.location.reload();
+  }, []);
+
+  const dismiss = useCallback(() => {
+    if (latestVersion) {
+      try {
+        sessionStorage.setItem(
+          APP_UPDATE_STORAGE_KEYS.dismissedVersion,
+          latestVersion
+        );
+      } catch {
+        // sessionStorage 실패 시에도 UI만 닫음
+      }
+    }
+    setUpdateAvailable(false);
+  }, [latestVersion]);
+
+  const checkForUpdate = useCallback(async () => {
+    if (!enabled) {
+      return;
+    }
+
+    try {
+      const versionUrl = `${import.meta.env.BASE_URL}version.json?t=${Date.now()}`;
+      const response = await fetch(versionUrl, {
+        cache: 'no-store',
+      });
+
+      if (!response.ok) {
+        return;
+      }
+
+      const data = (await response.json()) as VersionResponse;
+
+      if (!data.version || data.version === CLIENT_BUILD_ID) {
+        return;
+      }
+
+      let dismissedVersion: string | null = null;
+      try {
+        dismissedVersion = sessionStorage.getItem(
+          APP_UPDATE_STORAGE_KEYS.dismissedVersion
+        );
+      } catch {
+        dismissedVersion = null;
+      }
+
+      if (data.version === dismissedVersion) {
+        return;
+      }
+
+      setLatestVersion(data.version);
+      setUpdateAvailable(true);
+    } catch {
+      // 일시적 네트워크 오류는 업데이트 없음으로 처리
+    }
+  }, [enabled]);
+
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+
+    void checkForUpdate();
+
+    const intervalId = window.setInterval(checkForUpdate, intervalMs);
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'visible') {
+        void checkForUpdate();
+      }
+    };
+
+    const handleOnline = () => {
+      void checkForUpdate();
+    };
+
+    const handleFocus = () => {
+      void checkForUpdate();
+    };
+
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    window.addEventListener('online', handleOnline);
+    window.addEventListener('focus', handleFocus);
+
+    return () => {
+      window.clearInterval(intervalId);
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+      window.removeEventListener('online', handleOnline);
+      window.removeEventListener('focus', handleFocus);
+    };
+  }, [checkForUpdate, enabled, intervalMs]);
+
+  return {
+    currentVersion: CLIENT_BUILD_ID,
+    latestVersion,
+    updateAvailable,
+    reload,
+    dismiss,
+  };
+}

--- a/src/shared/hooks/useAppUpdate.ts
+++ b/src/shared/hooks/useAppUpdate.ts
@@ -40,7 +40,7 @@ export function useAppUpdate({
     if (latestVersion) {
       try {
         sessionStorage.setItem(
-          APP_UPDATE_STORAGE_KEYS.dismissedVersion,
+          APP_UPDATE_STORAGE_KEYS.DISMISSED_VERSION,
           latestVersion
         );
       } catch {
@@ -74,7 +74,7 @@ export function useAppUpdate({
       let dismissedVersion: string | null = null;
       try {
         dismissedVersion = sessionStorage.getItem(
-          APP_UPDATE_STORAGE_KEYS.dismissedVersion
+          APP_UPDATE_STORAGE_KEYS.DISMISSED_VERSION
         );
       } catch {
         dismissedVersion = null;

--- a/src/shared/hooks/useAppUpdateToast.ts
+++ b/src/shared/hooks/useAppUpdateToast.ts
@@ -33,6 +33,8 @@ export function useAppUpdateToast() {
     shownVersionRef.current = latestVersion;
     isReloadingRef.current = false;
 
+    const toastVersion = latestVersion;
+
     notify({
       text: TOAST_MESSAGE.APP_UPDATE_AVAILABLE,
       type: TOAST_TYPE.ACTION,
@@ -46,6 +48,9 @@ export function useAppUpdateToast() {
         duration: PERSISTENT_TOAST_DURATION_MS,
         toasterId: TOASTER_ID.BOTTOM_4,
         onDismiss: () => {
+          if (shownVersionRef.current !== toastVersion) {
+            return;
+          }
           // 스와이프 등으로 닫은 경우에만 세션 dismiss (같은 버전 재알림 방지)
           if (!isReloadingRef.current) {
             dismiss();

--- a/src/shared/hooks/useAppUpdateToast.ts
+++ b/src/shared/hooks/useAppUpdateToast.ts
@@ -1,0 +1,58 @@
+import { useEffect, useRef } from 'react';
+
+import { TOAST_TYPE, TOASTER_ID } from '@shared/types/toast';
+
+import { useToast } from '@components/v2/toast/useToast';
+
+import { TOAST_ACTION_LABEL, TOAST_MESSAGE } from '@constants/toastMessage';
+
+import { useAppUpdate } from '@hooks/useAppUpdate';
+
+/** setTimeout 최대 지연(약 24.8일). Infinity는 브라우저에서 즉시 만료됨 */
+const PERSISTENT_TOAST_DURATION_MS = 2_147_483_647;
+
+/**
+ * 새 배포 감지 시 새로고침 ActionToast를 표시합니다.
+ * App 진입점에서 한 번 호출하면 됩니다.
+ */
+export function useAppUpdateToast() {
+  const { updateAvailable, latestVersion, reload, dismiss } = useAppUpdate();
+  const { notify } = useToast();
+  const shownVersionRef = useRef<string | null>(null);
+  const isReloadingRef = useRef(false);
+
+  useEffect(() => {
+    if (!updateAvailable || !latestVersion) {
+      return;
+    }
+
+    if (shownVersionRef.current === latestVersion) {
+      return;
+    }
+
+    shownVersionRef.current = latestVersion;
+    isReloadingRef.current = false;
+
+    notify({
+      text: TOAST_MESSAGE.APP_UPDATE_AVAILABLE,
+      type: TOAST_TYPE.ACTION,
+      actionLabel: TOAST_ACTION_LABEL.RELOAD,
+      ariaLabel: '지금 새로고침하여 업데이트',
+      onClick: () => {
+        isReloadingRef.current = true;
+        reload();
+      },
+      options: {
+        duration: PERSISTENT_TOAST_DURATION_MS,
+        toasterId: TOASTER_ID.BOTTOM_4,
+        onDismiss: () => {
+          // 스와이프 등으로 닫은 경우에만 세션 dismiss (같은 버전 재알림 방지)
+          if (!isReloadingRef.current) {
+            dismiss();
+          }
+          shownVersionRef.current = null;
+        },
+      },
+    });
+  }, [updateAvailable, latestVersion, notify, reload, dismiss]);
+}

--- a/src/shared/utils/setupVitePreloadErrorReload.ts
+++ b/src/shared/utils/setupVitePreloadErrorReload.ts
@@ -13,12 +13,11 @@ export function setupVitePreloadErrorReload(
   }
 
   window.addEventListener('vite:preloadError', (event) => {
-    event.preventDefault();
-
     const reloadKey = getPreloadReloadedStorageKey();
 
     try {
       if (sessionStorage.getItem(reloadKey)) {
+        // 이미 1회 reload 한 빌드 → preventDefault 하지 않아 원본 에러가 라우터/에러 UI로 전달됨
         return;
       }
       sessionStorage.setItem(reloadKey, 'true');
@@ -26,6 +25,7 @@ export function setupVitePreloadErrorReload(
       // sessionStorage 사용 불가 시에도 1회 reload는 시도
     }
 
+    event.preventDefault();
     window.location.reload();
   });
 }

--- a/src/shared/utils/setupVitePreloadErrorReload.ts
+++ b/src/shared/utils/setupVitePreloadErrorReload.ts
@@ -22,7 +22,8 @@ export function setupVitePreloadErrorReload(
       }
       sessionStorage.setItem(reloadKey, 'true');
     } catch {
-      // sessionStorage 사용 불가 시에도 1회 reload는 시도
+      // 가드를 남길 수 없으면 자동 reload하지 않음 (무한 새로고침 방지)
+      return;
     }
 
     event.preventDefault();

--- a/src/shared/utils/setupVitePreloadErrorReload.ts
+++ b/src/shared/utils/setupVitePreloadErrorReload.ts
@@ -1,0 +1,31 @@
+import { getPreloadReloadedStorageKey } from '@constants/appUpdate';
+
+/**
+ * 새 배포로 이전 chunk가 사라져 동적 import가 실패할 때,
+ * 현재 빌드당 한 번만 전체 새로고침합니다.
+ * @see https://vitejs.dev/guide/build.html#load-error-handling
+ */
+export function setupVitePreloadErrorReload(
+  enabled: boolean = import.meta.env.PROD
+) {
+  if (!enabled) {
+    return;
+  }
+
+  window.addEventListener('vite:preloadError', (event) => {
+    event.preventDefault();
+
+    const reloadKey = getPreloadReloadedStorageKey();
+
+    try {
+      if (sessionStorage.getItem(reloadKey)) {
+        return;
+      }
+      sessionStorage.setItem(reloadKey, 'true');
+    } catch {
+      // sessionStorage 사용 불가 시에도 1회 reload는 시도
+    }
+
+    window.location.reload();
+  });
+}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -12,6 +12,7 @@ interface ImportMetaEnv {
 }
 
 declare const __APP_VERSION__: string;
+declare const __BUILD_ID__: string;
 
 declare module '*.svg?react' {
   import * as React from 'react';

--- a/vercel.json
+++ b/vercel.json
@@ -23,6 +23,15 @@
           "value": "public, max-age=31536000, immutable"
         }
       ]
+    },
+    {
+      "source": "/version.json",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "no-store, max-age=0"
+        }
+      ]
     }
   ]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,8 +14,14 @@ const dirname =
     ? __dirname
     : path.dirname(fileURLToPath(import.meta.url));
 
-/** 배포 감지용 빌드 ID (Sentry용 __APP_VERSION__과 분리) */
+/** 배포 감지용 빌드 ID (Sentry용 __APP_VERSION__과 분리)
+ * 배포(빌드) 인스턴스마다 고유해야 같은 커밋 재배포도 감지 가능
+ */
 const buildId =
+  process.env.VERCEL_DEPLOYMENT_ID ??
+  (process.env.GITHUB_RUN_ID
+    ? `${process.env.GITHUB_SHA ?? 'gha'}-${process.env.GITHUB_RUN_ID}-${process.env.GITHUB_RUN_ATTEMPT ?? '1'}`
+    : undefined) ??
   process.env.VERCEL_GIT_COMMIT_SHA ??
   process.env.GITHUB_SHA ??
   Date.now().toString();

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,13 +6,35 @@ import { sentryVitePlugin } from '@sentry/vite-plugin';
 import { storybookTest } from '@storybook/addon-vitest/vitest-plugin';
 import { vanillaExtractPlugin } from '@vanilla-extract/vite-plugin';
 import react from '@vitejs/plugin-react';
-import { defineConfig } from 'vite';
+import { defineConfig, type Plugin } from 'vite';
 import svgr from 'vite-plugin-svgr';
 // https://vite.dev/config/
 const dirname =
   typeof __dirname !== 'undefined'
     ? __dirname
     : path.dirname(fileURLToPath(import.meta.url));
+
+/** 배포 감지용 빌드 ID (Sentry용 __APP_VERSION__과 분리) */
+const buildId =
+  process.env.VERCEL_GIT_COMMIT_SHA ??
+  process.env.GITHUB_SHA ??
+  Date.now().toString();
+
+function versionFilePlugin(version: string): Plugin {
+  return {
+    name: 'generate-version-file',
+    generateBundle() {
+      this.emitFile({
+        type: 'asset',
+        fileName: 'version.json',
+        source: JSON.stringify({
+          version,
+          builtAt: new Date().toISOString(),
+        }),
+      });
+    },
+  };
+}
 
 // More info at: https://storybook.js.org/docs/next/writing-tests/integrations/vitest-addon
 export default defineConfig({
@@ -28,6 +50,7 @@ export default defineConfig({
         },
       },
     }),
+    versionFilePlugin(buildId),
     // 프로덕션 빌드 시 source map을 Sentry에 업로드 (auth token이 있을 때만 동작)
     sentryVitePlugin({
       org: process.env.SENTRY_ORG,
@@ -42,6 +65,7 @@ export default defineConfig({
   ],
   define: {
     __APP_VERSION__: JSON.stringify(process.env.npm_package_version ?? '0.0.0'),
+    __BUILD_ID__: JSON.stringify(buildId),
   },
   build: {
     // source map은 Sentry auth token이 있을 때만 생성 → 업로드 후 플러그인이 삭제(원본 노출 방지)


### PR DESCRIPTION
## 📌 Summary

- close #632

프로덕션에서 새 버전이 배포되었을 때, 이미 열려 있는 탭이 `/version.json` 폴링으로 변경을 감지하고 새로고침 액션 토스트를 통해 최신 코드를 반영할 수 있도록 했습니다.

## 📄 Tasks

- [x] `__APP_VERSION__`(Sentry)와 분리된 `__BUILD_ID__` / `CLIENT_BUILD_ID` 추가
- [x] 빌드 시 `dist/version.json` emit 
- [x] `vercel.json`에 `/version.json` `Cache-Control: no-store` 헤더 추가
- [x] 프로덕션에서만 version 폴링 (최초 / visibility / focus / online / 5분)
- [x] 새 버전 감지 시 ActionToast(새로고침) 표시
- [x] `vite:preloadError` 시 sessionStorage로 빌드당 1회 reload

## 🔍 To Reviewer

### 1. 배포 버전 식별자 분리

기존 `__APP_VERSION__`은 `package.json`의 버전을 기반으로 Sentry release 식별에 사용되고 있습니다.

하지만 현재 `package.json` 버전은 배포마다 변경되는 값이 아니기 때문에, 새 배포 여부를 판단하는 용도로는 사용할 수 없어요. 따라서 기존 Sentry 로직은 유지하고, 배포 감지 전용 식별자인 `__BUILD_ID__`와 `CLIENT_BUILD_ID`를 별도로 추가했습니다.

빌드 ID는 다음 우선순위로 결정됩니다.

1. `VERCEL_GIT_COMMIT_SHA`
2. `GITHUB_SHA`
3. 빌드 시점의 timestamp

| 환경                | BUILD_ID                  |
| ----------------- | ------------------------- |
| Vercel Git 배포     | `VERCEL_GIT_COMMIT_SHA`   |
| GitHub Actions 등  | `GITHUB_SHA`              |
| 로컬 build / SHA 없음 | `Date.now()` 기반 timestamp |

동일한 BUILD_ID가 클라이언트 번들과 `dist/version.json`에 함께 들어가기 때문에, 현재 탭에서 실행 중인 코드와 서버에 배포된 최신 코드의 버전을 비교할 수 있어요.

기존 `__APP_VERSION__`과 Sentry 관련 설정은 수정하지 않았습니다.

---

### 2. `version.json` 생성 및 캐시 설정

Vite 빌드 시 플러그인의 `emitFile`을 통해 아래 형태의 `dist/version.json`을 생성합니다.

```json
{
  "version": "현재 BUILD_ID",
  "builtAt": "빌드 시각"
}
```

클라이언트 번들에 삽입되는 `__BUILD_ID__`와 `version.json`의 `version`에는 동일한 값이 사용됩니다.

`public/version.json`을 정적으로 두는 방식은 배포마다 값을 직접 갱신해야 하고, 갱신을 누락할 가능성이 있어 사용하지 않았어요. 대신 빌드 과정에서 파일을 생성하도록 하여 항상 현재 배포 버전과 일치하도록 했습니다.

또 브라우저나 CDN에 이전 `version.json`이 캐시되면 새 배포를 감지하지 못할 수도 있어서, 기존 `vercel.json`의 `headers` 배열에 아래 설정을 추가했습니다.

```json
{
  "source": "/version.json",
  "headers": [
    {
      "key": "Cache-Control",
      "value": "no-store, max-age=0"
    }
  ]
}
```

기존 `/models`, `/onnxruntime` 관련 헤더와 SPA catch-all rewrite 설정은 그대로 유지했습니다.

클라이언트 요청에서도 다음과 같이 `cache: 'no-store'`를 사용합니다.

```ts
fetch(versionUrl, {
  cache: 'no-store',
});
```

---

### 3. 새 배포 감지 방식

버전 확인 로직은 프로덕션 환경에서만 실행됩니다.

로컬 `pnpm dev`에서는 `import.meta.env.PROD === false`이므로 폴링과 이벤트 리스너가 등록되지 않습니다.

프로덕션에서는 다음 시점에 `/version.json`을 요청합니다.

* 앱 최초 실행
* 탭이 다시 visible 상태가 됐을 때
* 브라우저 창이 다시 focus됐을 때
* 네트워크가 online 상태로 돌아왔을 때
* 5분 간격

각 요청에서 다음 두 값을 비교해요.

| 값                          | 의미                           |
| -------------------------- | ---------------------------- |
| `__BUILD_ID__`             | 현재 탭에서 실행 중인 클라이언트 코드의 빌드 ID |
| `/version.json`의 `version` | 현재 서버에 배포된 최신 빌드 ID          |

두 값이 같으면 아무 동작도 하지 않고, 두 값이 다르면 현재 탭이 이전 배포의 코드를 실행 중인 것으로 판단하고, 업데이트 ActionToast를 표시합니다.

네트워크 오류, 일시적인 배포 전환, JSON 파싱 오류가 발생하더라도 애플리케이션 동작에 영향을 주지 않도록 버전 확인 실패는 조용히 무시하고 다음 확인 시점에 다시 요청합니다.

---

### 4. 업데이트 UX

새 버전을 감지해도 페이지를 즉시 새로고침하지 않습니다.

현재 서비스에는 이미지 설정, 업로드, 이미지 생성 등 사용자의 진행 상태가 존재하기 때문에 자동 reload 시 작업 내용이 유실될 수 있다고 판단해서, 일반적인 버전 감지 상황에서는 사용자가 직접 갱신 시점을 선택하도록 했어요.

새 버전이 감지되면 기존 토스트 공컴을 사용한 ActionToast가 노출됩니다.

* **새로고침** 클릭 → `window.location.reload()` 실행
* 사용자가 클릭하지 않으면 현재 탭의 기존 상태 유지

즉, 일반적인 새 배포 감지는 아래 흐름으로 동작합니다.

```text
새 버전 배포
→ 기존 탭에서 version.json 확인
→ BUILD_ID 불일치 감지
→ ActionToast 노출
→ 사용자가 새로고침 클릭
→ 최신 index.html 및 chunk 로드
```

자동 reload는 아래의 `vite:preloadError` 상황에서만 동작합니다.

---

### 5. 동적 import chunk 유실 대응

현재 프로젝트에는 React Router lazy 페이지가 다수 존재합니다.

사용자가 이전 버전의 탭을 계속 열어둔 상태에서 새 버전이 배포되면, 기존 번들이 이전 배포의 해시 chunk를 참조할 수 있다고 해요.

예를 들어 다음과 같은 상황입니다.

```text
기존 탭 실행 중
→ 새 버전 배포
→ 기존 hash chunk가 배포 대상에서 제거됨
→ 사용자가 아직 방문하지 않은 lazy route로 이동
→ 기존 탭이 이전 chunk URL 요청
→ 동적 import 실패
```

이 경우 Vite에서 발생시키는 `vite:preloadError` 이벤트를 감지하여 한 번 자동 reload하도록 처리했습니다.

정규식 기반의 전역 `unhandledrejection` 감지는 브라우저마다 오류 문구가 다를 수 있고 다른 Promise 오류까지 포함할 수 있어, 따로 추가하지 않았고, Vite가 제공하는 전용 이벤트만 사용했어요.

---

### 6. preload 오류 무한 reload 방지

동적 import 오류가 발생했다고 해서 계속 reload하면, 배포 상태나 CDN 문제에 따라 무한 새로고침이 발생할 수 있습니다.

이를 방지하기 위해 현재 빌드 ID가 포함된 아래 키를 `sessionStorage`에 저장합니다.

```text
houme:preload-reloaded:${__BUILD_ID__}
```

동작은 다음과 같습니다.

```text
vite:preloadError 발생
→ 현재 BUILD_ID의 reload 기록 확인
→ 기록이 없으면 sessionStorage에 저장 후 reload
→ 같은 BUILD_ID에서 다시 오류가 발생하면 추가 reload하지 않음
```

빌드 ID가 키에 포함되어 있기 때문에, 이후 정상적으로 새 버전이 로드되어 `__BUILD_ID__`가 변경되면 이전 빌드의 reload 기록과 충돌하지 않습니다.

| 상황                    | 동작                       |
| --------------------- | ------------------------ |
| 현재 빌드에서 첫 preload 오류  | 1회 자동 reload             |
| 동일 빌드에서 오류 재발         | reload하지 않음              |
| 새 빌드로 전환 후 preload 오류 | 새 BUILD_ID 기준으로 다시 1회 가능 |

---

### 7. 로컬 검증 방법

`pnpm dev`에서는 프로덕션 전용 폴링이 실행되지 않기 때문에, 버전 감지 UI는 아래 방식으로 확인해 주세요.

```bash
pnpm run build
pnpm preview
```

빌드 후 생성된 `dist/version.json`의 `version` 값을 현재 번들에 삽입된 BUILD_ID와 다른 값으로 수정합니다.

예:

```json
{
  "version": "test-new-version",
  "builtAt": "2026-07-23T00:00:00.000Z"
}
```

이후 preview 페이지에서 다음 방법 중 하나로 버전 확인을 다시 실행하면 ActionToast가 노출됩니다.

* 브라우저 탭을 다른 탭으로 전환했다가 복귀
* 브라우저 창의 focus를 해제했다가 복귀
* 페이지를 처음 열기
* 폴링 주기인 5분 대기

검증 시 아래 항목을 확인해 주세요.

* `dist/version.json`이 실제 생성되는지
* 번들 BUILD_ID와 `version.json`의 초기 version이 동일한지
* version 값을 다르게 수정했을 때 ActionToast가 노출되는지
* **새로고침** 클릭 시 `window.location.reload()`가 실행되는지
* `/version.json` 요청에 `cache: 'no-store'`가 적용되는지
* 개발 환경에서는 버전 요청이 발생하지 않는지

Vercel 환경의 캐시 헤더와 실제 배포 전환까지 포함한 최종 검증은 동일한 도메인에 새 버전을 재배포한 뒤, 기존 탭에서 ActionToast가 노출되는 방식으로 확인해야 합니다!

## 📸 Screenshot

<img width="280" alt="image" src="https://github.com/user-attachments/assets/dfa419ad-bccf-466b-abb9-fe41e3201f62" />

> `pnpm run preview`로 테스트한 화면이기 때문에 API 응답이 없는 UI이니 참고 토스트만 확인해주시면 됩니다. 일단 임의로 구현해놓았고, 회의 중으로 기/디 컨펌 받을 예정입니다!