### PR TITLE
[feat] Meta Pixel 및 회원가입 완료 전환 이벤트 연동

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,31 +40,35 @@
 
     <!-- Meta Pixel Code -->
     <script>
-      !(function (f, b, e, v, n, t, s) {
-        if (f.fbq) return;
-        n = f.fbq = function () {
-          n.callMethod
-            ? n.callMethod.apply(n, arguments)
-            : n.queue.push(arguments);
-        };
-        if (!f._fbq) f._fbq = n;
-        n.push = n;
-        n.loaded = !0;
-        n.version = '2.0';
-        n.queue = [];
-        t = b.createElement(e);
-        t.async = !0;
-        t.src = v;
-        s = b.getElementsByTagName(e)[0];
-        s.parentNode.insertBefore(t, s);
-      })(
-        window,
-        document,
-        'script',
-        'https://connect.facebook.net/en_US/fbevents.js'
-      );
-      fbq('init', '3647457258725425');
-      fbq('track', 'PageView');
+      const metaPixelId = '%VITE_META_PIXEL_ID%';
+
+      if ('%VITE_ENABLE_META_PIXEL%' === 'true' && metaPixelId) {
+        !(function (f, b, e, v, n, t, s) {
+          if (f.fbq) return;
+          n = f.fbq = function () {
+            n.callMethod
+              ? n.callMethod.apply(n, arguments)
+              : n.queue.push(arguments);
+          };
+          if (!f._fbq) f._fbq = n;
+          n.push = n;
+          n.loaded = !0;
+          n.version = '2.0';
+          n.queue = [];
+          t = b.createElement(e);
+          t.async = !0;
+          t.src = v;
+          s = b.getElementsByTagName(e)[0];
+          s.parentNode.insertBefore(t, s);
+        })(
+          window,
+          document,
+          'script',
+          'https://connect.facebook.net/en_US/fbevents.js'
+        );
+        fbq('init', metaPixelId);
+        fbq('track', 'PageView');
+      }
     </script>
     <!-- End Meta Pixel Code -->
   </head>
@@ -74,7 +78,7 @@
         height="1"
         width="1"
         style="display: none"
-        src="https://www.facebook.com/tr?id=3647457258725425&ev=PageView&noscript=1"
+        src="https://www.facebook.com/tr?id=%VITE_META_PIXEL_ID%&ev=PageView&noscript=1"
         alt=""
       />
     </noscript>

--- a/index.html
+++ b/index.html
@@ -37,8 +37,48 @@
       content="https://www.houme.kr/images/thumbnail.png"
     />
     <meta property="og:url" content="https://www.houme.kr/" />
+
+    <!-- Meta Pixel Code -->
+    <script>
+      !(function (f, b, e, v, n, t, s) {
+        if (f.fbq) return;
+        n = f.fbq = function () {
+          n.callMethod
+            ? n.callMethod.apply(n, arguments)
+            : n.queue.push(arguments);
+        };
+        if (!f._fbq) f._fbq = n;
+        n.push = n;
+        n.loaded = !0;
+        n.version = '2.0';
+        n.queue = [];
+        t = b.createElement(e);
+        t.async = !0;
+        t.src = v;
+        s = b.getElementsByTagName(e)[0];
+        s.parentNode.insertBefore(t, s);
+      })(
+        window,
+        document,
+        'script',
+        'https://connect.facebook.net/en_US/fbevents.js'
+      );
+      fbq('init', '3647457258725425');
+      fbq('track', 'PageView');
+    </script>
+    <!-- End Meta Pixel Code -->
   </head>
   <body>
+    <noscript
+      ><img
+        height="1"
+        width="1"
+        style="display: none"
+        src="https://www.facebook.com/tr?id=3647457258725425&ev=PageView&noscript=1"
+        alt=""
+      />
+    </noscript>
+
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/src/pages/generate/analytics/signupCompAnalytics.test.ts
+++ b/src/pages/generate/analytics/signupCompAnalytics.test.ts
@@ -1,8 +1,14 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { META_COMPLETE_REGISTRATION_PENDING_KEY } from '@shared/analytics/metaPixel';
 
 import { trackSignupCompCompleteRegistration } from './signupCompAnalytics';
 
 describe('trackSignupCompCompleteRegistration', () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
   afterEach(() => {
     vi.unstubAllEnvs();
     delete window.fbq;
@@ -10,6 +16,20 @@ describe('trackSignupCompCompleteRegistration', () => {
 
   it('Meta Pixel이 비활성화된 환경에서는 이벤트를 전송하지 않는다', () => {
     vi.stubEnv('VITE_ENABLE_META_PIXEL', 'false');
+    sessionStorage.setItem(META_COMPLETE_REGISTRATION_PENDING_KEY, 'true');
+    const fbq = vi.fn();
+    window.fbq = fbq;
+
+    trackSignupCompCompleteRegistration();
+
+    expect(fbq).not.toHaveBeenCalled();
+    expect(
+      sessionStorage.getItem(META_COMPLETE_REGISTRATION_PENDING_KEY)
+    ).toBeNull();
+  });
+
+  it('회원가입 성공 marker가 없으면 이벤트를 전송하지 않는다', () => {
+    vi.stubEnv('VITE_ENABLE_META_PIXEL', 'true');
     const fbq = vi.fn();
     window.fbq = fbq;
 
@@ -18,14 +38,19 @@ describe('trackSignupCompCompleteRegistration', () => {
     expect(fbq).not.toHaveBeenCalled();
   });
 
-  it('Meta Pixel이 활성화된 환경에서는 CompleteRegistration 이벤트를 전송한다', () => {
+  it('회원가입 성공 marker를 소비해 CompleteRegistration 이벤트를 한 번만 전송한다', () => {
     vi.stubEnv('VITE_ENABLE_META_PIXEL', 'true');
+    sessionStorage.setItem(META_COMPLETE_REGISTRATION_PENDING_KEY, 'true');
     const fbq = vi.fn();
     window.fbq = fbq;
 
     trackSignupCompCompleteRegistration();
+    trackSignupCompCompleteRegistration();
 
     expect(fbq).toHaveBeenCalledOnce();
     expect(fbq).toHaveBeenCalledWith('track', 'CompleteRegistration');
+    expect(
+      sessionStorage.getItem(META_COMPLETE_REGISTRATION_PENDING_KEY)
+    ).toBeNull();
   });
 });

--- a/src/pages/generate/analytics/signupCompAnalytics.test.ts
+++ b/src/pages/generate/analytics/signupCompAnalytics.test.ts
@@ -1,0 +1,31 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { trackSignupCompCompleteRegistration } from './signupCompAnalytics';
+
+describe('trackSignupCompCompleteRegistration', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    delete window.fbq;
+  });
+
+  it('Meta Pixel이 비활성화된 환경에서는 이벤트를 전송하지 않는다', () => {
+    vi.stubEnv('VITE_ENABLE_META_PIXEL', 'false');
+    const fbq = vi.fn();
+    window.fbq = fbq;
+
+    trackSignupCompCompleteRegistration();
+
+    expect(fbq).not.toHaveBeenCalled();
+  });
+
+  it('Meta Pixel이 활성화된 환경에서는 CompleteRegistration 이벤트를 전송한다', () => {
+    vi.stubEnv('VITE_ENABLE_META_PIXEL', 'true');
+    const fbq = vi.fn();
+    window.fbq = fbq;
+
+    trackSignupCompCompleteRegistration();
+
+    expect(fbq).toHaveBeenCalledOnce();
+    expect(fbq).toHaveBeenCalledWith('track', 'CompleteRegistration');
+  });
+});

--- a/src/pages/generate/analytics/signupCompAnalytics.ts
+++ b/src/pages/generate/analytics/signupCompAnalytics.ts
@@ -1,4 +1,5 @@
 import { GA_EVENTS } from '@shared/analytics/events';
+import { META_COMPLETE_REGISTRATION_PENDING_KEY } from '@shared/analytics/metaPixel';
 import { VALID_LOGIN_STATUS } from '@shared/analytics/params/auth';
 import { SCREEN_NAME } from '@shared/analytics/screenNames';
 import { trackEvent } from '@shared/analytics/track';
@@ -24,6 +25,15 @@ export const trackSignupCompCtaClick = () => {
 
 // Meta Pixel CompleteRegistration 이벤트 호출
 export const trackSignupCompCompleteRegistration = () => {
+  const isCompleteRegistrationPending =
+    sessionStorage.getItem(META_COMPLETE_REGISTRATION_PENDING_KEY) === 'true';
+
+  sessionStorage.removeItem(META_COMPLETE_REGISTRATION_PENDING_KEY);
+
+  if (!isCompleteRegistrationPending) {
+    return;
+  }
+
   const isMetaPixelEnabled = import.meta.env.VITE_ENABLE_META_PIXEL === 'true';
 
   if (!isMetaPixelEnabled) {

--- a/src/pages/generate/analytics/signupCompAnalytics.ts
+++ b/src/pages/generate/analytics/signupCompAnalytics.ts
@@ -21,3 +21,20 @@ export const trackSignupCompCtaClick = () => {
     return_screen_name,
   });
 };
+
+// Meta Pixel CompleteRegistration 이벤트 호출
+export const trackSignupCompCompleteRegistration = () => {
+  if (typeof window.fbq !== 'function') {
+    if (import.meta.env.DEV) {
+      console.warn('[Meta Pixel] fbq가 로드되지 않았습니다.');
+    }
+
+    return;
+  }
+
+  window.fbq('track', 'CompleteRegistration');
+
+  if (import.meta.env.DEV) {
+    console.info('[Meta Pixel] CompleteRegistration 호출');
+  }
+};

--- a/src/pages/generate/analytics/signupCompAnalytics.ts
+++ b/src/pages/generate/analytics/signupCompAnalytics.ts
@@ -24,6 +24,18 @@ export const trackSignupCompCtaClick = () => {
 
 // Meta Pixel CompleteRegistration 이벤트 호출
 export const trackSignupCompCompleteRegistration = () => {
+  const isMetaPixelEnabled = import.meta.env.VITE_ENABLE_META_PIXEL === 'true';
+
+  if (!isMetaPixelEnabled) {
+    if (import.meta.env.DEV) {
+      console.info(
+        '[Meta Pixel] CompleteRegistration 전송 안 함: 비활성화된 환경'
+      );
+    }
+
+    return;
+  }
+
   if (typeof window.fbq !== 'function') {
     if (import.meta.env.DEV) {
       console.warn('[Meta Pixel] fbq가 로드되지 않았습니다.');

--- a/src/pages/generate/pages/welcome/WelcomePage.tsx
+++ b/src/pages/generate/pages/welcome/WelcomePage.tsx
@@ -1,7 +1,10 @@
+import { useEffect } from 'react';
+
 import { useNavigate } from 'react-router-dom';
 
 import {
   getSignupCompPageViewParams,
+  trackSignupCompCompleteRegistration,
   trackSignupCompCtaClick,
 } from '@pages/generate/analytics/signupCompAnalytics';
 import { useWelcomePageModelPreload } from '@pages/generate/hooks/useWelcomePageModelPreload';
@@ -37,6 +40,11 @@ const WelcomePage = () => {
     SCREEN_NAME.SIGNUP_COMP,
     getSignupCompPageViewParams()
   );
+
+  // Meta Pixel CompleteRegistration 이벤트 호출
+  useEffect(() => {
+    trackSignupCompCompleteRegistration();
+  }, []);
 
   const redirectPath = getLoginRedirect();
   const isFromMypage = redirectPath?.startsWith(ROUTES.MYPAGE);

--- a/src/pages/signup/apis/mutations/usePostSignupMutation.ts
+++ b/src/pages/signup/apis/mutations/usePostSignupMutation.ts
@@ -6,6 +6,7 @@ import { ROUTES } from '@routes/paths';
 
 import { useUserStore } from '@store/useUserStore';
 
+import { META_COMPLETE_REGISTRATION_PENDING_KEY } from '@shared/analytics/metaPixel';
 import { TOAST_TYPE, TOASTER_ID } from '@shared/types/toast';
 
 import type { SocialSignUpV2Request } from '@apis/__generated__/data-contracts';
@@ -57,6 +58,7 @@ export const usePostSignupMutation = () => {
       setUserName(response.userName);
       setAccessToken(response.accessToken);
       sessionStorage.removeItem('signupToken');
+      sessionStorage.setItem(META_COMPLETE_REGISTRATION_PENDING_KEY, 'true');
       navigate(ROUTES.WELCOME);
       notify({
         text: TOAST_MESSAGE.SIGNUP_SUCCESS,

--- a/src/shared/analytics/metaPixel.ts
+++ b/src/shared/analytics/metaPixel.ts
@@ -1,0 +1,2 @@
+export const META_COMPLETE_REGISTRATION_PENDING_KEY =
+  'meta_complete_registration_pending' as const;

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -2,6 +2,8 @@
 
 interface ImportMetaEnv {
   readonly VITE_ENABLE_FIREBASE_ANALYTICS?: string;
+  readonly VITE_ENABLE_META_PIXEL?: string;
+  readonly VITE_META_PIXEL_ID?: string;
   readonly VITE_ANALYTICS_ENV?: 'local' | 'staging' | 'production';
   readonly VITE_SENTRY_DSN?: string;
   readonly VITE_SENTRY_ENVIRONMENT?: string;

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -25,3 +25,7 @@ declare module '*.lottie' {
   const src: string;
   export default src;
 }
+
+interface Window {
+  fbq?: (command: 'track', eventName: 'CompleteRegistration') => void;
+}


### PR DESCRIPTION
## 📌 Summary

- close #641

> Meta 광고의 회원가입 전환 측정을 위해 Meta Pixel을 연동했습니다.

## 📄 Tasks

- `index.html`에 Meta Pixel 기본 코드 및 `PageView` 이벤트를 추가했습니다.
  - JavaScript 비활성화 환경을 위한 `<noscript><img /></noscript>` fallback은 HTML 유효성을 고려해 `<body>`에 배치했습니다.
- 회원가입 완료 화면 진입 시 `CompleteRegistration` 이벤트가 전송되도록 구현했습니다.
- 기존 GA `signupComp_page_view`와 동일하게 `WelcomePage` 마운트 시 이벤트가 호출됩니다.
- `signupCompAnalytics.ts`에 Meta 이벤트 전송 함수를 추가했습니다.
- 환경변수 플래그를 통해 Meta Pixel 활성화 여부를 제어하도록 구현했습니다. (GA와 동일한 방식)
- Local 및 Preview 환경에서는 Meta Pixel이 비활성화되고 Production 환경에서만 활성화됩니다.
- 회원가입 API 성공 시 일회성 marker를 저장하고, `WelcomePage`에서 이를 소비해 `CompleteRegistration` 이벤트가 가입당 한 번만 전송되도록 처리했습니다.
  - `/welcome` 직접 접근, 새로고침 및 재진입으로 인한 가입 전환 중복 집계를 방지했습니다.

## 🔍 To Reviewer

- 로컬 env, Vercel Production 환경변수 설정값은 디스코드에 별도로 공유하겠습니다.
- 환경변수는 Vite 빌드 시점에 반영되므로 설정 후 Production 재배포가 필요합니다.
- Production 배포 후 Meta Events Manager와 Network 탭에서 `PageView`, `CompleteRegistration` 이벤트 최종확인이 필요합니다!!

## 📸 Screenshot
- Local 환경에서 Meta Pixel을 활성화한 후 Network 탭에서 다음 이벤트 전송을 확인했습니다. (디코에 스크린샷 추가할게요!)
  - `PageView`
  - `CompleteRegistration`
- 이후 production에서만 이벤트를 전송할 수 있도록 변경해서 다음과 같이 비활성화된 환경에선 전송하지 않는다는 것을 확인했습니다. 
<img width="664" height="180" alt="image" src="https://github.com/user-attachments/assets/ca48e392-9a99-4d77-9309-bc3b057d0229" />
