### PR TITLE
[fix] Sentry 로깅 노이즈 제거 + Sentry가 잡지 못하던 FE 고유 실패를 수집하도록 로깅 구조 개선

### DIFF
--- a/src/pages/generate/apis/mutations/useGenerateBannerImageMutation.ts
+++ b/src/pages/generate/apis/mutations/useGenerateBannerImageMutation.ts
@@ -3,6 +3,8 @@ import { useMutation } from '@tanstack/react-query';
 import type { GeneratedImagePayload } from '@pages/generate/types/generate';
 import { useGenerateStore } from '@pages/generate/v2/stores/useGenerateStore';
 
+import { MONITORING_SCOPE } from '@shared/monitoring/scope';
+
 import type {
   BannerGenerateImageRequest,
   BannerGenerateImageResponse,
@@ -33,6 +35,8 @@ export const useGenerateBannerImageMutation = () => {
 
   return useMutation<GeneratedImagePayload, Error, BannerGenerateImageRequest>({
     mutationFn: postGenerateBannerImage,
+    // 실패 시 전역 에러 핸들러가 이 scope를 태그로 붙여 Sentry로 보낸다
+    meta: { sentry: { scope: MONITORING_SCOPE.IMAGE_GENERATE } },
     onSuccess: (data) => {
       resetGenerate();
       setNavigationData(data);

--- a/src/pages/generate/apis/mutations/useGenerateFullFunnelImageMutation.ts
+++ b/src/pages/generate/apis/mutations/useGenerateFullFunnelImageMutation.ts
@@ -3,6 +3,8 @@ import { useMutation } from '@tanstack/react-query';
 import type { GeneratedImagePayload } from '@pages/generate/types/generate';
 import { useGenerateStore } from '@pages/generate/v2/stores/useGenerateStore';
 
+import { MONITORING_SCOPE } from '@shared/monitoring/scope';
+
 import type {
   GenerateImageV4Response,
   GenerateImageV4Request,
@@ -33,6 +35,8 @@ export const useGenerateFullFunnelImageMutation = () => {
 
   return useMutation<GeneratedImagePayload, Error, GenerateImageV4Request>({
     mutationFn: postGenerateFullFunnelImage,
+    // 실패 시 전역 에러 핸들러가 이 scope를 태그로 붙여 Sentry로 보낸다
+    meta: { sentry: { scope: MONITORING_SCOPE.IMAGE_GENERATE } },
     onSuccess: (data) => {
       resetGenerate();
       setNavigationData(data);

--- a/src/pages/generate/apis/mutations/useGenerateOtherStyleImageMutation.ts
+++ b/src/pages/generate/apis/mutations/useGenerateOtherStyleImageMutation.ts
@@ -3,6 +3,8 @@ import { useMutation } from '@tanstack/react-query';
 import type { GeneratedImagePayload } from '@pages/generate/types/generate';
 import { useGenerateStore } from '@pages/generate/v2/stores/useGenerateStore';
 
+import { MONITORING_SCOPE } from '@shared/monitoring/scope';
+
 import type {
   OtherStyleGenerateImageRequest,
   OtherStyleGenerateImageResponse,
@@ -37,6 +39,8 @@ export const useGenerateOtherStyleImageMutation = () => {
     OtherStyleGenerateImageRequest
   >({
     mutationFn: postGenerateOtherStyleImage,
+    // 실패 시 전역 에러 핸들러가 이 scope를 태그로 붙여 Sentry로 보낸다
+    meta: { sentry: { scope: MONITORING_SCOPE.IMAGE_GENERATE } },
     onSuccess: (data) => {
       resetGenerate();
       setNavigationData(data);

--- a/src/pages/generate/apis/mutations/useGenerateProductImageMutation.ts
+++ b/src/pages/generate/apis/mutations/useGenerateProductImageMutation.ts
@@ -3,6 +3,8 @@ import { useMutation } from '@tanstack/react-query';
 import type { GeneratedImagePayload } from '@pages/generate/types/generate';
 import { useGenerateStore } from '@pages/generate/v2/stores/useGenerateStore';
 
+import { MONITORING_SCOPE } from '@shared/monitoring/scope';
+
 import type {
   GenerateImageV4Response,
   ProductGenerateImageRequest,
@@ -34,6 +36,8 @@ export const useGenerateProductImageMutation = () => {
   return useMutation<GeneratedImagePayload, Error, ProductGenerateImageRequest>(
     {
       mutationFn: postGenerateProductImage,
+      // 실패 시 전역 에러 핸들러가 이 scope를 태그로 붙여 Sentry로 보낸다
+      meta: { sentry: { scope: MONITORING_SCOPE.IMAGE_GENERATE } },
       onSuccess: (data) => {
         resetGenerate();
         setNavigationData(data);

--- a/src/pages/generate/v2/pages/loading/LoadingPage.tsx
+++ b/src/pages/generate/v2/pages/loading/LoadingPage.tsx
@@ -53,6 +53,7 @@ import { useExitBlocker } from '@hooks/useExitBlocker';
 
 import { useExitImageFlow } from './hooks/useExitImageFlow';
 import { useGenerateImageRequest } from './hooks/useGenerateImageRequest';
+import { useGenerateStallWatchdog } from './hooks/useGenerateStallWatchdog';
 import * as styles from './LoadingPage.css';
 import ProgressBar from './ProgressBar';
 import { usePostCarouselLikeMutation } from '../../apis/mutations/useCarouselLikeMutation';
@@ -248,6 +249,7 @@ const LoadingPage = () => {
   // 진입경로별 mutation 호출 (풀퍼널 / banner / otherStyle / product 분기)
   useEffect(() => {
     const onMutationError = (error: unknown) => {
+      // Sentry 전송은 전역 에러 핸들러가 담당한다 (mutation의 meta.sentry.scope로 도메인 식별)
       if (isImageGenerationServerError(error)) {
         notifyImageGenerationError();
       } else {
@@ -268,10 +270,8 @@ const LoadingPage = () => {
       onSettled: onMutationSettled,
     };
 
-    if (requestState.kind === 'invalid') {
-      console.error('invalid requestState kind');
-      return;
-    }
+    // invalid 리포트는 원인(reason)을 아는 useGenerateImageRequest가 담당한다
+    if (requestState.kind === 'invalid') return;
 
     ensureShortFunnelFlowSnapshot();
 
@@ -303,6 +303,18 @@ const LoadingPage = () => {
       }
     };
   }, []);
+
+  // 생성이 끝나지 않아 이 화면에 갇히면 Sentry로 남기고 홈으로 빼낸다
+  // (알림은 기존 생성 실패 토스트 재사용 — 크레딧 소모 안내 문구는 기획 확인 후 결정)
+  useGenerateStallWatchdog({
+    enabled: isRequestValid,
+    isApiCompleted,
+    hasNavigationData: Boolean(navigationData),
+    onStall: () => {
+      notifyImageGenerationError();
+      recoverFromImageGenerationError();
+    },
+  });
 
   // currentImages는 `currentStack?.carousels ?? []`로 항상 배열 → 빈 배열 여부만 확인
   const hasError = isError || currentImages.length === 0;
@@ -347,7 +359,10 @@ const LoadingPage = () => {
   }, [displayCurrentImage, hasError, isPending]);
 
   const handleProgressComplete = () => {
+    // 여기서 빠져나가면 ProgressBar가 완료를 한 번만 처리하므로 다시 호출되지 않음.
+    // 즉 사용자는 ProgressBar가 100%인 상태에서 갇힘 → useGenerateStallWatchdog가 감지해서 빼낸다.
     if (!navigationData || !isApiCompleted) return;
+
     const { imageId, imageUrl, isMirror } = navigationData;
     // 결과 화면 종류(STYLE/PRODUCT/BANNER/FULL_FUNNEL)를 flow에서 계산.
     // flow가 없으면 null → ResultPage가 기본(추천형) 화면으로 보여준다.

--- a/src/pages/generate/v2/pages/loading/hooks/useGenerateImageRequest.ts
+++ b/src/pages/generate/v2/pages/loading/hooks/useGenerateImageRequest.ts
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 
 import { useGenerateBannerImageMutation } from '@pages/generate/apis/mutations/useGenerateBannerImageMutation';
 import { useGenerateFullFunnelImageMutation } from '@pages/generate/apis/mutations/useGenerateFullFunnelImageMutation';
@@ -6,8 +6,13 @@ import { useGenerateOtherStyleImageMutation } from '@pages/generate/apis/mutatio
 import { useGenerateProductImageMutation } from '@pages/generate/apis/mutations/useGenerateProductImageMutation';
 
 import { buildGenerateRequest } from '@store/imageFlow/buildGenerateRequest';
+import type { GenerateInvalidReason } from '@store/imageFlow/buildGenerateRequest';
+import type { ImageFlow } from '@store/imageFlow/flowConfig';
 import { useFunnelStore } from '@store/useFunnelStore';
 import { useImageFlowStore } from '@store/useImageFlowStore';
+
+import { reportMessage } from '@shared/monitoring/report';
+import { MONITORING_SCOPE } from '@shared/monitoring/scope';
 
 import type {
   BannerGenerateImageRequest,
@@ -51,8 +56,20 @@ export type GenerateImageRequestResult =
       mutate: ProductMutate;
       payload: ProductGenerateImageRequest;
     }
-  | { kind: 'invalid' };
+  // reason·route는 LoadingPage가 Sentry로 보낼 때 원인을 구분하는 데 쓴다
+  | {
+      kind: 'invalid';
+      reason: GenerateInvalidReason;
+      route: ImageFlow['route'] | null;
+    };
 
+/**
+ * 진입경로별 payload를 조립하고 알맞은 mutate를 골라 돌려준다
+ *
+ * `invalid`는 여기서 Sentry로 남긴다 — 원인(reason)을 아는 유일한 지점이기 때문.
+ * 사용자는 퍼널을 다 밟고 CTA를 눌렀는데 에러 화면도 없이 홈으로 튕기고,
+ * 서버 입장에서는 요청이 온 적이 없어 서버 로그에도 흔적이 없다.
+ */
 export const useGenerateImageRequest = (): GenerateImageRequestResult => {
   // 이미지 생성 API의 mutate 메서드 가져오기
   const { mutate: mutateFullFunnel } = useGenerateFullFunnelImageMutation();
@@ -62,7 +79,7 @@ export const useGenerateImageRequest = (): GenerateImageRequestResult => {
 
   // useMemo로 감싸 마운트 시 1회만 경로 분기 평가 → requestState 객체 ref 고정
   // (store는 getState() 스냅샷만 읽고, mutate 4개는 React Query가 컴포넌트 동안 같은 주소 유지 → deps 불변)
-  return useMemo(() => {
+  const result = useMemo<GenerateImageRequestResult>(() => {
     // 검증·조립은 순수 함수 buildGenerateRequest가 담당, 훅은 kind에 맞는 mutate만 바인딩
     const plan = buildGenerateRequest(
       useImageFlowStore.getState().flow,
@@ -91,7 +108,25 @@ export const useGenerateImageRequest = (): GenerateImageRequestResult => {
           payload: plan.payload,
         };
       case 'invalid':
-        return { kind: 'invalid' };
+        return {
+          kind: 'invalid',
+          reason: plan.reason,
+          route: plan.route,
+        };
     }
   }, [mutateFullFunnel, mutateBanner, mutateOtherStyle, mutateProduct]);
+
+  // fingerprint에 reason을 넣어 9가지 원인이 한 이슈로 뭉치지 않게 한다
+  useEffect(() => {
+    if (result.kind !== 'invalid') return;
+
+    reportMessage('image generate request invalid', {
+      scope: MONITORING_SCOPE.IMAGE_GENERATE,
+      level: 'error',
+      fingerprint: ['generate-invalid', result.reason],
+      context: { reason: result.reason, route: result.route },
+    });
+  }, [result]);
+
+  return result;
 };

--- a/src/pages/generate/v2/pages/loading/hooks/useGenerateStallWatchdog.ts
+++ b/src/pages/generate/v2/pages/loading/hooks/useGenerateStallWatchdog.ts
@@ -1,0 +1,78 @@
+import { useEffect, useRef } from 'react';
+
+import { reportMessage } from '@shared/monitoring/report';
+import { MONITORING_SCOPE } from '@shared/monitoring/scope';
+
+import { PROGRESS_CONFIG } from '../../../constants/progressConfig';
+
+/**
+ * 이미지 생성이 정지했다고 판정하는 시간 (ms)
+ *
+ * 진행바 예상 소요(PROGRESS_CONFIG.TOTAL_TIME = 27초)의 3배.
+ * 정상 생성이 이보다 오래 걸리면 오탐이 되므로, 배포 후 실제 소요 시간 분포를 보고 조정한다.
+ */
+const STALL_TIMEOUT_MS = PROGRESS_CONFIG.TOTAL_TIME * 3;
+
+interface UseGenerateStallWatchdogParams {
+  /** 생성 요청이 실제로 나간 경우에만 감시한다 */
+  enabled: boolean;
+  isApiCompleted: boolean;
+  hasNavigationData: boolean;
+  /** 정지로 판정됐을 때 사용자를 빼내는 처리 (토스트 + 홈 이동) */
+  onStall: () => void;
+}
+
+/**
+ * 이미지 생성이 끝나지 않아 화면에 갇히는 것을 감지하고 빠져나오게 한다
+ *
+ * 두 가지 정지가 실제로 발생, 문제 재현 X
+ * - `isApiCompleted`가 오지 않아 진행바가 90%에서 멈춤 (mutation이 응답하지 않음)
+ * - 진행바는 100%인데 `navigationData`가 없어 이동하지 못함
+ *
+ * 후자는 `ProgressBar`가 완료를 한 번만 처리하기 때문에 회복 수단이 없다.
+ * 둘 다 아무 이벤트도 발생시키지 않아 관측되지 않았고, 사용자는 나가려면 이탈 팝업을
+ * 통과해야 하는데 그러면 퍼널 입력이 전부 삭제된다(크레딧은 이미 소모된 상태).
+ *
+ * 그래서 시간을 기준으로 판정한다. 어느 쪽 정지였는지는 전송하는
+ * `is_api_completed`·`has_navigation_data`로 구분한다.
+ */
+export const useGenerateStallWatchdog = ({
+  enabled,
+  isApiCompleted,
+  hasNavigationData,
+  onStall,
+}: UseGenerateStallWatchdogParams): void => {
+  // 타이머는 마운트 시 한 번만 걸어야 한다. 값이 바뀔 때마다 다시 걸면 정지를 영원히 감지하지 못한다.
+  // 그래서 최신 값은 ref로만 읽는다.
+  const isApiCompletedRef = useRef(isApiCompleted);
+  const hasNavigationDataRef = useRef(hasNavigationData);
+  const onStallRef = useRef(onStall);
+
+  useEffect(() => {
+    isApiCompletedRef.current = isApiCompleted;
+    hasNavigationDataRef.current = hasNavigationData;
+    onStallRef.current = onStall;
+  }, [isApiCompleted, hasNavigationData, onStall]);
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    const timer = window.setTimeout(() => {
+      reportMessage('image generation stalled', {
+        scope: MONITORING_SCOPE.IMAGE_GENERATE,
+        level: 'error',
+        fingerprint: ['generate-stalled'],
+        context: {
+          elapsed_ms: STALL_TIMEOUT_MS,
+          is_api_completed: isApiCompletedRef.current,
+          has_navigation_data: hasNavigationDataRef.current,
+        },
+      });
+
+      onStallRef.current();
+    }, STALL_TIMEOUT_MS);
+
+    // 정상 완료 시 결과 화면으로 이동하며 언마운트돼 여기서 타이머가 정리된다
+    return () => window.clearTimeout(timer);
+  }, [enabled]);
+};

--- a/src/pages/imageSetup/ImageSetupPage.tsx
+++ b/src/pages/imageSetup/ImageSetupPage.tsx
@@ -10,6 +10,8 @@ import { useFunnelStore } from '@store/useFunnelStore';
 import { useImageFlowStore } from '@store/useImageFlowStore';
 
 import { mapEntryRouteToLoginEntry } from '@shared/analytics/utils/loginEntryRoute';
+import { reportMessage } from '@shared/monitoring/report';
+import { MONITORING_SCOPE } from '@shared/monitoring/scope';
 
 import FeatureErrorFallback from '@components/errorFallback/FeatureErrorFallback';
 
@@ -78,7 +80,28 @@ const ImageSetupPage = () => {
   // 그 외(URL로 바로 들어옴, 이미 퍼널을 나감)는 홈으로 보냄.
   // 새로고침·로그인 복귀 때는 flow가 sessionStorage에 남아 phase='funnel'이라 그대로 통과된다.
   const flow = useImageFlowStore.getState().flow;
-  if (flow?.phase !== 'funnel') {
+  const isBlockedByGuard = flow?.phase !== 'funnel';
+
+  // 가드에 걸려 홈으로 돌아간 경우를 남긴다.
+  // sessionStorage 복원 실패로 flow가 사라진 경우가 여기 섞여 있는데,
+  // 사용자는 아무 안내 없이 홈으로 이동하고 서버는 이 일을 전혀 모른다.
+  // (렌더 중이 아니라 effect에서 호출해 중복 전송을 막는다)
+  useEffect(() => {
+    if (!isBlockedByGuard) return;
+
+    reportMessage('imageSetup entry blocked by guard', {
+      scope: MONITORING_SCOPE.IMAGE_GENERATE,
+      level: 'warning',
+      fingerprint: ['imagesetup-guard-redirect'],
+      context: {
+        has_flow: Boolean(flow),
+        phase: flow?.phase ?? null,
+        route: flow?.route ?? null,
+      },
+    });
+  }, [isBlockedByGuard, flow]);
+
+  if (isBlockedByGuard) {
     return <Navigate to={ROUTES.HOME} replace />;
   }
 

--- a/src/pages/imageSetup/utils/staticDataPrefetch.ts
+++ b/src/pages/imageSetup/utils/staticDataPrefetch.ts
@@ -1,3 +1,6 @@
+import type { SentryQueryMeta } from '@shared/monitoring/queryMeta';
+import { MONITORING_SCOPE } from '@shared/monitoring/scope';
+
 import { queryKeys } from '@constants/queryKey';
 
 import { getActivities } from '../apis/queries/useActivitiesQuery';
@@ -11,6 +14,14 @@ import { DEFAULT_FILTERS } from '../v2/types/floorPlan';
 import type { QueryClient } from '@tanstack/react-query';
 
 /**
+ * 앱 부팅과 동시에 나가는 백그라운드 요청이라 실패해도 사용자 영향이 없다.
+ * (필요해지는 시점에 해당 화면의 쿼리가 다시 요청한다) → Sentry로는 보내지 않는다.
+ */
+const PREFETCH_QUERY_META: SentryQueryMeta = {
+  sentry: { scope: MONITORING_SCOPE.API, capture: 'never' },
+};
+
+/**
  * 앱 시작 시점에 미리 로딩할 데이터들을 prefetch하는 함수
  */
 export const prefetchStaticData = (queryClient: QueryClient) => {
@@ -20,6 +31,7 @@ export const prefetchStaticData = (queryClient: QueryClient) => {
     queryKey: queryKeys.imageSetup.houseTemplates(DEFAULT_FILTERS),
     queryFn: () => getHouseTemplates(DEFAULT_FILTERS),
     ...STATIC_DATA_QUERY_OPTIONS,
+    meta: PREFETCH_QUERY_META,
   });
 
   // 주요활동 데이터 (활동 목록 + 활동별 필수 가구)
@@ -27,6 +39,7 @@ export const prefetchStaticData = (queryClient: QueryClient) => {
     queryKey: queryKeys.imageSetup.activities(),
     queryFn: getActivities,
     ...STATIC_DATA_QUERY_OPTIONS,
+    meta: PREFETCH_QUERY_META,
   });
 
   // 가구 카테고리 데이터 (카테고리 + 카테고리별 가구)
@@ -34,6 +47,7 @@ export const prefetchStaticData = (queryClient: QueryClient) => {
     queryKey: queryKeys.imageSetup.furnitureCategories(),
     queryFn: getFurnitureCategories,
     ...STATIC_DATA_QUERY_OPTIONS,
+    meta: PREFETCH_QUERY_META,
   });
 
   // 무드보드 이미지 데이터
@@ -43,5 +57,6 @@ export const prefetchStaticData = (queryClient: QueryClient) => {
     ),
     queryFn: () => getMoodBoardImage(),
     ...STATIC_DATA_QUERY_OPTIONS,
+    meta: PREFETCH_QUERY_META,
   });
 };

--- a/src/routes/RootLayout.tsx
+++ b/src/routes/RootLayout.tsx
@@ -6,6 +6,7 @@ import { useGenerateWarmup } from '@pages/generate/hooks/useGenerateWarmup';
 import { useScreenNavigation } from '@shared/analytics/hooks';
 import { useClaritySync } from '@shared/hooks/useClaritySync';
 import { useScrollToTop } from '@shared/hooks/useScrollToTop';
+import { useSentrySync } from '@shared/hooks/useSentrySync';
 
 import * as styles from './RootLayout.css';
 
@@ -15,6 +16,7 @@ function RootLayout() {
   useGenerateWarmup();
   useScreenNavigation();
   useClaritySync();
+  useSentrySync();
 
   return (
     <OverlayProvider>

--- a/src/shared/analytics/params/types.ts
+++ b/src/shared/analytics/params/types.ts
@@ -33,6 +33,11 @@ export type AnalyticsParamValue = string | number | boolean | null;
  *
  * - DB 전송 값은 이벤트 발생 시점 데이터를 그대로 전달
  * - `undefined` 값은 Firebase 전송 시 제외 (콘솔 로그에는 포함)
+ *
+ * **주의** — 여기 담기는 값은 GA4뿐 아니라 **Sentry breadcrumb으로도 전송된다**
+ * (`track.ts`의 `addReportBreadcrumb`). 새 필드를 추가할 때 개인정보가 들어가지 않는지
+ * 확인해야 한다. 예외 처리가 필요하면 `track.ts`의 `toBreadcrumbData`에서 거른다.
+ * (현재 예외: `page_path`는 주소에 인가코드가 실릴 수 있어 URL 스크럽을 통과시킨다)
  */
 export type TrackEventParams = {
   // --- 1. 전역 / 경로 ---

--- a/src/shared/analytics/track.ts
+++ b/src/shared/analytics/track.ts
@@ -13,6 +13,8 @@ import type {
   TrackEventParams,
 } from '@shared/analytics/params/types';
 import { analytics } from '@shared/config/firebase';
+import { addReportBreadcrumb } from '@shared/monitoring/report';
+import { redactUrl } from '@shared/monitoring/scrub';
 
 export type { LoginStatus, TrackEventParams } from '@shared/analytics/params';
 
@@ -29,6 +31,22 @@ const buildEventParams = (
 };
 
 /**
+ * breadcrumb에 실을 파라미터를 만든다.
+ *
+ * `page_path`만 URL 스크럽을 통과시킨다 — 주소에 카카오 인가코드(`?code=`)나 토큰이
+ * 실릴 수 있다. 나머지는 화면 이름·id·개수 계열이라 그대로 보낸다.
+ * (상품 검색어는 개인정보가 아니고 어떤 검색어에서 실패했는지가 진단에 쓰이므로 유지)
+ */
+const toBreadcrumbData = (
+  eventParams: Record<string, AnalyticsParamValue>
+): Record<string, AnalyticsParamValue> => {
+  const pagePath = eventParams.page_path;
+  if (typeof pagePath !== 'string') return eventParams;
+
+  return { ...eventParams, page_path: redactUrl(pagePath) };
+};
+
+/**
  * GA4 이벤트 전송
  *
  * - `VITE_ENABLE_FIREBASE_ANALYTICS=true` → Firebase Analytics 전송
@@ -41,6 +59,18 @@ export const trackEvent = (
   params?: TrackEventParams
 ): void => {
   const eventParams = buildEventParams(params);
+
+  // GA 이벤트를 Sentry breadcrumb으로도 남긴다.
+  // 에러 직전에 사용자가 어느 화면에서 무엇을 선택했는지 재구성하는 유일한 수단이다.
+  // (Sentry 기본 breadcrumb은 vanilla-extract 클래스명·원시 경로만 담아 화면을 특정할 수 없다)
+  //
+  // 아래 early return보다 위에 두는 이유 — GA가 꺼져 있거나 Firebase 초기화가 실패한 환경에서도 breadcrumb은 쌓여야 하므로(정작 그때가 관측이 가장 필요한 순간)
+  addReportBreadcrumb({
+    category: 'ga',
+    message: eventName,
+    level: 'info',
+    data: toBreadcrumbData(eventParams),
+  });
 
   if (!isAnalyticsEnabled) {
     console.info('[Analytics]', eventName, params);

--- a/src/shared/apis/config/globalErrorHandler.test.ts
+++ b/src/shared/apis/config/globalErrorHandler.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // 외부 의존성 모킹 (실제 모듈 동작과 독립적으로 로직만 검증)
 vi.mock('sonner', () => ({ toast: { custom: vi.fn() } }));
@@ -79,6 +79,14 @@ describe('handleGlobalError', () => {
 describe('handleQueryError — Sentry 전송', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // 5xx는 20% 샘플링이라 확률에 따라 결과가 흔들린다.
+    // 이 파일은 "정책 결과가 전송으로 연결되는가"를 보는 것이므로 샘플은 항상 통과시킨다.
+    // (샘플링 비율 자체는 apiReportPolicy.test.ts에서 검증)
+    vi.spyOn(Math, 'random').mockReturnValue(0);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   it('5xx는 Sentry로 전송한다', async () => {
@@ -124,20 +132,28 @@ describe('handleQueryError — Sentry 전송', () => {
     expect(addReportBreadcrumb).toHaveBeenCalledTimes(1);
   });
 
-  it('queryKey에 담긴 검색어가 컨텍스트로 새어나가지 않는다', async () => {
+  // queryKey 세 번째 자리에는 필터·cursor를 담은 객체가 통째로 들어가고,
+  // 앞으로 무엇이 추가될지 모른다. 그래서 앞 2개 세그먼트만 쓴다.
+  // (검색어 자체는 개인정보가 아니라 GA breadcrumb으로는 원문이 실린다)
+  it('queryKey는 앞 2개 세그먼트만 컨텍스트에 담는다', async () => {
     const { reportError } = await import('@shared/monitoring/report');
 
     handleQueryError(axiosError(500), fakeQuery());
 
     const serialized = JSON.stringify(vi.mocked(reportError).mock.calls[0][1]);
-    expect(serialized).not.toContain('검색어');
     expect(serialized).toContain('product.productList');
+    expect(serialized).not.toContain('검색어');
   });
 });
 
 describe('handleMutationError — Sentry 전송', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.spyOn(Math, 'random').mockReturnValue(0);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   it('meta.sentry.capture가 always면 4xx도 전송한다', async () => {

--- a/src/shared/apis/config/globalErrorHandler.test.ts
+++ b/src/shared/apis/config/globalErrorHandler.test.ts
@@ -10,26 +10,40 @@ vi.mock('@shared/types/toast', () => ({
 vi.mock('@components/v2/toast/Toast', () => ({ default: vi.fn() }));
 vi.mock('@components/v2/toast/Toast.css', () => ({ toastStyle: {} }));
 vi.mock('@/routes/router', () => ({ router: { navigate: vi.fn() } }));
+// Sentry 전송 자체는 report 모듈이 담당하므로 여기서는 호출 여부만 검증
+vi.mock('@shared/monitoring/report', () => ({
+  reportError: vi.fn(),
+  reportMessage: vi.fn(),
+  addReportBreadcrumb: vi.fn(),
+}));
 
-import { handleGlobalError, isSessionExpiredError } from './globalErrorHandler';
+import {
+  handleGlobalError,
+  handleMutationError,
+  handleQueryError,
+} from './globalErrorHandler';
 
-describe('isSessionExpiredError', () => {
-  // 정확히 'SESSION_EXPIRED' 메시지인 Error 인스턴스만 true여야 함
-  it('SESSION_EXPIRED 메시지인 Error를 true로 판별한다', () => {
-    expect(isSessionExpiredError(new Error('SESSION_EXPIRED'))).toBe(true);
-  });
+import type { Mutation, Query } from '@tanstack/react-query';
 
-  it('다른 메시지의 Error는 false를 반환한다', () => {
-    expect(isSessionExpiredError(new Error('Network Error'))).toBe(false);
-  });
-
-  // Error 인스턴스가 아닌 값(문자열, null 등)은 false여야 함
-  it('Error 인스턴스가 아니면 false를 반환한다', () => {
-    expect(isSessionExpiredError('SESSION_EXPIRED')).toBe(false);
-    expect(isSessionExpiredError(null)).toBe(false);
-    expect(isSessionExpiredError(undefined)).toBe(false);
-  });
+/** 테스트용 AxiosError 형태 (axios는 isAxiosError 플래그로 판별한다) */
+const axiosError = (status: number, code?: number) => ({
+  isAxiosError: true,
+  config: { method: 'get', url: '/api/v1/x' },
+  response: { status, data: code === undefined ? undefined : { code } },
 });
+
+const fakeQuery = (meta?: unknown) =>
+  ({
+    meta,
+    queryKey: ['product', 'productList', { keyword: '검색어' }],
+  }) as unknown as Query<unknown, unknown, unknown>;
+
+const fakeMutation = (meta?: unknown) =>
+  ({
+    options: { meta, mutationKey: ['generate', 'fullFunnel'] },
+  }) as unknown as Mutation<unknown, unknown, unknown>;
+
+// isSessionExpiredError 자체의 판별 테스트는 정의가 있는 classifyApiError.test.ts에 둔다
 
 describe('handleGlobalError', () => {
   beforeEach(() => {
@@ -48,16 +62,7 @@ describe('handleGlobalError', () => {
   it('이미지 생성 예외 코드는 LoadingPage에서만 처리하도록 전역 toast를 호출하지 않는다', async () => {
     const { toast } = await import('sonner');
 
-    handleGlobalError({
-      isAxiosError: true,
-      response: {
-        status: 500,
-        data: {
-          code: 50013,
-          message: 'GENERATED_IMAGE_EXCEPTION',
-        },
-      },
-    });
+    handleGlobalError(axiosError(500, 50013));
 
     expect(toast.custom).not.toHaveBeenCalled();
   });
@@ -68,5 +73,98 @@ describe('handleGlobalError', () => {
     handleGlobalError(new Error('SESSION_EXPIRED'));
 
     expect(toast.custom).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('handleQueryError — Sentry 전송', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('5xx는 Sentry로 전송한다', async () => {
+    const { reportError } = await import('@shared/monitoring/report');
+
+    handleQueryError(axiosError(500), fakeQuery());
+
+    expect(reportError).toHaveBeenCalledTimes(1);
+  });
+
+  it('404는 전송하지 않는다 (4xx는 allowlist만)', async () => {
+    const { reportError } = await import('@shared/monitoring/report');
+
+    handleQueryError(axiosError(404), fakeQuery());
+
+    expect(reportError).not.toHaveBeenCalled();
+  });
+
+  it('SESSION_EXPIRED는 전송하지 않는다', async () => {
+    const { reportError } = await import('@shared/monitoring/report');
+
+    handleQueryError(new Error('SESSION_EXPIRED'), fakeQuery());
+
+    expect(reportError).not.toHaveBeenCalled();
+  });
+
+  it('meta.sentry.capture가 never면 5xx도 전송하지 않는다', async () => {
+    const { reportError } = await import('@shared/monitoring/report');
+
+    handleQueryError(
+      axiosError(500),
+      fakeQuery({ sentry: { scope: 'api', capture: 'never' } })
+    );
+
+    expect(reportError).not.toHaveBeenCalled();
+  });
+
+  it('전송하지 않는 실패도 breadcrumb는 남긴다', async () => {
+    const { addReportBreadcrumb } = await import('@shared/monitoring/report');
+
+    handleQueryError(axiosError(404), fakeQuery());
+
+    expect(addReportBreadcrumb).toHaveBeenCalledTimes(1);
+  });
+
+  it('queryKey에 담긴 검색어가 컨텍스트로 새어나가지 않는다', async () => {
+    const { reportError } = await import('@shared/monitoring/report');
+
+    handleQueryError(axiosError(500), fakeQuery());
+
+    const serialized = JSON.stringify(vi.mocked(reportError).mock.calls[0][1]);
+    expect(serialized).not.toContain('검색어');
+    expect(serialized).toContain('product.productList');
+  });
+});
+
+describe('handleMutationError — Sentry 전송', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('meta.sentry.capture가 always면 4xx도 전송한다', async () => {
+    const { reportError } = await import('@shared/monitoring/report');
+
+    handleMutationError(
+      axiosError(400),
+      undefined,
+      undefined,
+      fakeMutation({ sentry: { scope: 'imageGenerate', capture: 'always' } })
+    );
+
+    expect(reportError).toHaveBeenCalledTimes(1);
+  });
+
+  it('meta의 scope를 전송 옵션에 반영한다', async () => {
+    const { reportError } = await import('@shared/monitoring/report');
+
+    handleMutationError(
+      axiosError(500),
+      undefined,
+      undefined,
+      fakeMutation({ sentry: { scope: 'imageGenerate' } })
+    );
+
+    expect(vi.mocked(reportError).mock.calls[0][1]).toMatchObject({
+      scope: 'imageGenerate',
+    });
   });
 });

--- a/src/shared/apis/config/globalErrorHandler.ts
+++ b/src/shared/apis/config/globalErrorHandler.ts
@@ -4,10 +4,23 @@ import { toast } from 'sonner';
 
 import { ROUTES } from '@routes/paths';
 
+import {
+  decideApiReport,
+  type ApiCaptureMode,
+} from '@shared/monitoring/apiReportPolicy';
+import {
+  classifyApiError,
+  isSessionExpiredError,
+} from '@shared/monitoring/classifyApiError';
+import type { SentryQueryMeta } from '@shared/monitoring/queryMeta';
+import { addReportBreadcrumb, reportError } from '@shared/monitoring/report';
+import { MONITORING_SCOPE } from '@shared/monitoring/scope';
 import { TOASTER_ID, TOAST_TYPE } from '@shared/types/toast';
 
 import Toast from '@components/v2/toast/Toast';
 import { toastStyle } from '@components/v2/toast/Toast.css';
+
+import type { Mutation, Query } from '@tanstack/react-query';
 
 // React 외부 toast 유틸 (훅을 쓸 수 없는 모듈 스코프에서 사용)
 const showGlobalToast = (text: string, hasIcon = true) => {
@@ -26,10 +39,6 @@ const redirectTo = async (path: string): Promise<void> => {
   router.navigate(path);
 };
 
-// SESSION_EXPIRED 판별
-export const isSessionExpiredError = (error: unknown): boolean =>
-  error instanceof Error && error.message === 'SESSION_EXPIRED';
-
 // 중복 방지 (여러 쿼리가 동시에 실패할 때)
 let lastSessionExpiredAt = 0;
 const SESSION_EXPIRED_COOLDOWN = 5000;
@@ -43,11 +52,118 @@ const handleSessionExpired = () => {
   setTimeout(() => redirectTo(ROUTES.LOGIN), 1000);
 };
 
-/** QueryCache/MutationCache의 onError에서 호출 */
+/**
+ * 사용자에게 보여줄 처리 (toast/redirect)
+ * QueryCache/MutationCache의 onError 어댑터가 호출한다.
+ */
 export const handleGlobalError = (error: unknown) => {
   if (import.meta.env.DEV) console.error('[QueryClient Error]', error);
 
   if (isSessionExpiredError(error)) {
     handleSessionExpired();
   }
+};
+
+/**
+ * queryKey/mutationKey에서 앞 2개 세그먼트만 문자열로 뽑는다.
+ *
+ * 키 전체를 붙이지 않는 이유: `queryKeys.product.productList`처럼
+ * 세 번째 세그먼트에 검색어 등 사용자 입력이 들어가는 키가 있다.
+ */
+const toKeyLabel = (key: unknown): string | undefined => {
+  if (!Array.isArray(key)) return undefined;
+
+  const label = key
+    .slice(0, 2)
+    .filter(
+      (segment) => typeof segment === 'string' || typeof segment === 'number'
+    )
+    .join('.');
+
+  return label || undefined;
+};
+
+interface ReportApiErrorOptions {
+  isMutation: boolean;
+  meta?: SentryQueryMeta;
+  keyLabel?: string;
+}
+
+/**
+ * API 실패를 Sentry로 보낸다.
+ *
+ * 캡처 지점을 여기 한 곳으로 모아 호출부의 중복 전송을 구조적으로 막는다.
+ * 전송하지 않기로 한 실패도 breadcrumb는 남겨 이후 이벤트에 맥락으로 붙게 한다.
+ */
+const reportApiError = (error: unknown, options: ReportApiErrorOptions) => {
+  const info = classifyApiError(error);
+  const captureMode: ApiCaptureMode = options.meta?.sentry?.capture ?? 'auto';
+  const scope = options.meta?.sentry?.scope ?? MONITORING_SCOPE.API;
+
+  const context = {
+    kind: info.kind,
+    method: info.method,
+    path: info.routePattern,
+    status: info.status,
+    serverCode: info.code,
+    key: options.keyLabel,
+    requestType: options.isMutation ? 'mutation' : 'query',
+  };
+
+  addReportBreadcrumb({
+    category: 'api',
+    message: `${info.method ?? '-'} ${info.routePattern ?? '-'} ${info.status ?? info.kind}`,
+    level: 'warning',
+    data: context,
+  });
+
+  const decision = decideApiReport(info, {
+    isMutation: options.isMutation,
+    captureMode,
+  });
+  if (!decision) return;
+
+  reportError(error, {
+    scope,
+    level: decision.level,
+    fingerprint: decision.fingerprint,
+    context,
+    tags: {
+      'api.kind': info.kind,
+      ...(info.status !== undefined
+        ? { 'api.status': String(info.status) }
+        : {}),
+      ...(info.code !== undefined ? { 'api.code': String(info.code) } : {}),
+    },
+  });
+};
+
+/** QueryCache의 onError — 모든 useQuery 실패가 여기를 통과 */
+export const handleQueryError = (
+  error: unknown,
+  query: Query<unknown, unknown, unknown>
+) => {
+  handleGlobalError(error);
+
+  reportApiError(error, {
+    isMutation: false,
+    meta: query.meta,
+    keyLabel: toKeyLabel(query.queryKey),
+  });
+};
+
+/** MutationCache의 onError — 모든 useMutation 실패가 여기를 지난다 */
+export const handleMutationError = (
+  error: unknown,
+  _variables: unknown,
+  _context: unknown,
+  mutation: Mutation<unknown, unknown, unknown>
+) => {
+  handleGlobalError(error);
+
+  reportApiError(error, {
+    isMutation: true,
+    meta: mutation.options.meta,
+    keyLabel: toKeyLabel(mutation.options.mutationKey),
+  });
 };

--- a/src/shared/apis/config/queryClient.ts
+++ b/src/shared/apis/config/queryClient.ts
@@ -3,11 +3,14 @@ import { isAxiosError } from 'axios';
 
 import { prefetchStaticData } from '@pages/imageSetup/utils/staticDataPrefetch';
 
-import { handleGlobalError, isSessionExpiredError } from './globalErrorHandler';
+import { isSessionExpiredError } from '@shared/monitoring/classifyApiError';
+
+import { handleMutationError, handleQueryError } from './globalErrorHandler';
 
 export const queryClient = new QueryClient({
-  queryCache: new QueryCache({ onError: handleGlobalError }),
-  mutationCache: new MutationCache({ onError: handleGlobalError }),
+  // 사용자 처리(toast/redirect) + Sentry 전송을 함께 담당하는 어댑터
+  queryCache: new QueryCache({ onError: handleQueryError }),
+  mutationCache: new MutationCache({ onError: handleMutationError }),
   defaultOptions: {
     queries: {
       refetchOnWindowFocus: false, // 브라우저 포커싱 시 자동 재요청 방지

--- a/src/shared/config/sentry.ts
+++ b/src/shared/config/sentry.ts
@@ -1,5 +1,13 @@
 import * as Sentry from '@sentry/react';
 
+import {
+  isInjectedScriptEvent,
+  NOISE_DENY_URLS,
+  NOISE_ERROR_PATTERNS,
+} from '@shared/monitoring/noiseFilter';
+import { consumeSessionEventBudget } from '@shared/monitoring/sampling';
+import { redactBreadcrumb, scrubErrorEvent } from '@shared/monitoring/scrub';
+
 const SENTRY_DSN = import.meta.env.VITE_SENTRY_DSN;
 const SENTRY_ENVIRONMENT =
   import.meta.env.VITE_SENTRY_ENVIRONMENT ?? import.meta.env.MODE;
@@ -7,18 +15,50 @@ const SENTRY_RELEASE =
   import.meta.env.VITE_SENTRY_RELEASE ?? `houme-client@${__APP_VERSION__}`;
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
 
-// 에러 리포트에서 토큰·민감 헤더를 제거
-function scrubSensitiveData(event: Sentry.ErrorEvent): Sentry.ErrorEvent {
-  const headers = event.request?.headers;
-  if (headers) {
-    delete headers['Authorization'];
-    delete headers['authorization'];
+/**
+ * DEV dry-run 모드
+ *
+ * 로컬에서도 필터·스크럽 파이프라인을 그대로 실행하되, 실제 Sentry 전송만 차단
+ * 무엇이 어떤 태그·fingerprint로 전송될 뻔했는지 콘솔에서 확인할 수 있어
+ * `enabled: false`라 아무것도 확인할 수 없던 기존 문제를 해결한다.
+ *
+ * - 실제 전송까지 확인하려면 `.env.local`에 아래 두 값을 넣는다.
+ *   VITE_SENTRY_FORCE_ENABLE=true
+ *   VITE_SENTRY_ENVIRONMENT=local-verify
+ * - dry-run도 SDK 초기화가 필요하므로 `VITE_SENTRY_DSN`은 설정돼 있어야 한다.
+ */
+const IS_DRY_RUN =
+  import.meta.env.DEV && import.meta.env.VITE_SENTRY_FORCE_ENABLE !== 'true';
+
+/** 전송 직전 최종 파이프라인: 스크럽 → 노이즈 표시 → dry-run/예산 확인 */
+function handleBeforeSend(event: Sentry.ErrorEvent): Sentry.ErrorEvent | null {
+  const scrubbed = scrubErrorEvent(event);
+
+  // Sentry 스택 트레이스 전체가 .js 파일이 아닌 곳에서 왔으면 인앱브라우저가 끼워 넣은 스크립트일 가능성이 높음
+  // 그래도 오탐 여지가 있으므로 에러를 완전히 버리지 않고 표시만 한다(분포 직접 확인 후 에러 로깅 여부 결정)
+  if (isInjectedScriptEvent(scrubbed)) {
+    scrubbed.tags = { ...scrubbed.tags, noise_candidate: 'true' };
   }
-  // withCredentials: true라 쿠키에 refresh token이 있을 수 있어 통째로 제거
-  if (event.request?.cookies) {
-    delete event.request.cookies;
+
+  if (IS_DRY_RUN) {
+    console.info('[sentry:dry-run] 전송되지 않음', scrubbed);
+    return null;
   }
-  return event;
+
+  // 로깅 폭주 방어 — 세션 상한(SESSION_EVENT_BUDGET)을 넘으면 Sentry에 로그를 더 보내지 않는다
+  if (!consumeSessionEventBudget()) return null;
+
+  return scrubbed;
+}
+
+/** breadcrumb 수집 직전 필터: console 제거 + URL 스크럽 */
+function handleBeforeBreadcrumb(
+  breadcrumb: Sentry.Breadcrumb
+): Sentry.Breadcrumb | null {
+  // console breadcrumb에는 에러 객체·응답 바디가 통째로 실릴 수 있어 수집하지 않는다
+  if (breadcrumb.category === 'console') return null;
+
+  return redactBreadcrumb(breadcrumb);
 }
 
 export function initSentry() {
@@ -28,21 +68,34 @@ export function initSentry() {
     dsn: SENTRY_DSN,
     environment: SENTRY_ENVIRONMENT,
     release: SENTRY_RELEASE,
-    // 로컬 개발(pnpm dev)에서는 이벤트를 전송하지 않음
-    enabled: !import.meta.env.DEV,
+    // dry-run에서도 파이프라인 검증이 되도록 SDK는 켜고, 실제 전송은 beforeSend에서 막는다
+    enabled: true,
 
     // ── 성능 추적 (tracing) ──
-    integrations: [Sentry.browserTracingIntegration()],
-    // 프로덕션은 10%만 샘플링(무료 플랜 quota라 한도 고려), 그 외 환경은 전량 수집
-    tracesSampleRate: import.meta.env.PROD ? 0.1 : 1.0,
+    integrations: (defaultIntegrations) => {
+      // 세션 추적은 beforeSend를 거치지 않고 전송되므로 dry-run에서는 제외한다
+      const base = IS_DRY_RUN
+        ? defaultIntegrations.filter(
+            (integration) => !/session/i.test(integration.name)
+          )
+        : defaultIntegrations;
+
+      return [...base, Sentry.browserTracingIntegration()];
+    },
+    // 프로덕션은 10%만 샘플링(무료 플랜 quota라 한도 고려), dry-run은 전송 자체를 하지 않음
+    tracesSampleRate: IS_DRY_RUN ? 0 : import.meta.env.PROD ? 0.1 : 1.0,
     // trace 헤더(sentry-trace/baggage)를 전파할 대상 — API 도메인
     tracePropagationTargets: API_BASE_URL ? [API_BASE_URL] : [],
 
+    // ── 노이즈 차단 ──
+    // SESSION_EXPIRED는 정상 로그아웃 플로우, 나머지는 인앱브라우저·브라우저 내부 노이즈
+    ignoreErrors: [/SESSION_EXPIRED/, ...NOISE_ERROR_PATTERNS],
+    denyUrls: NOISE_DENY_URLS,
+
     // ── 개인정보·토큰 보호 ──
     sendDefaultPii: false,
-    // SESSION_EXPIRED는 정상 로그아웃 플로우라 리포트에서 제외
-    ignoreErrors: [/SESSION_EXPIRED/],
-    beforeSend: scrubSensitiveData,
+    beforeSend: handleBeforeSend,
+    beforeBreadcrumb: handleBeforeBreadcrumb,
 
     initialScope: {
       tags: {

--- a/src/shared/hooks/useCreditGuard.ts
+++ b/src/shared/hooks/useCreditGuard.ts
@@ -4,6 +4,8 @@ import { overlay } from 'overlay-kit';
 
 import { useMyPageUserQuery } from '@pages/mypage/apis/queries/useMyPageUserQuery';
 
+import { reportError, reportMessage } from '@shared/monitoring/report';
+import { MONITORING_SCOPE } from '@shared/monitoring/scope';
 import { TOAST_TYPE } from '@shared/types/toastLegacy';
 
 import { useToast } from '@components/toast/useToast';
@@ -72,6 +74,14 @@ export const useCreditGuard = (
       const { data: latestUserData } = await refetch();
 
       if (!latestUserData) {
+        // 조회는 성공했는데 응답이 비어 생성이 차단된 상태.
+        // 사용자는 퍼널을 다 밟고 CTA를 눌렀는데 아무 일도 일어나지 않는다.
+        reportMessage('credit check returned no data', {
+          scope: MONITORING_SCOPE.IMAGE_GENERATE,
+          level: 'warning',
+          fingerprint: ['credit-guard', 'no-data'],
+          context: { required_credits: requiredCredits },
+        });
         notify({
           text: '정보를 불러올 수 없습니다.',
           type: TOAST_TYPE.WARNING,
@@ -88,7 +98,13 @@ export const useCreditGuard = (
         return false;
       }
     } catch (error) {
-      console.error('[useCreditGuard] 크레딧 확인 실패:', error);
+      // 크레딧이 실제로 있는데도 생성이 막히는 경우다.
+      // 호출부(useActivityInfo)가 false를 받으면 CTA 버튼을 비활성화해 재시도도 불가능해진다.
+      reportError(error, {
+        scope: MONITORING_SCOPE.IMAGE_GENERATE,
+        tags: { step: 'credit_check' },
+        context: { required_credits: requiredCredits },
+      });
       notify({
         text: '크레딧 확인에 실패했습니다.',
         type: TOAST_TYPE.WARNING,

--- a/src/shared/hooks/useSentrySync.ts
+++ b/src/shared/hooks/useSentrySync.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useLayoutEffect } from 'react';
 
 import { useLocation } from 'react-router-dom';
 
@@ -16,6 +16,13 @@ import { AB_TEST_STORAGE_KEY, isABTestGroup } from '@shared/types/abTest';
  * RootLayout에서 1회 마운트 — 이슈를 화면·진입경로 단위로 필터링할 수 있게 한다.
  * 세 도구가 같은 축을 쓰므로 "Clarity에서 본 세션"과 "Sentry에서 본 에러"를 같은 기준으로 맞춰볼 수 있다.
  *
+ * **`useEffect`가 아니라 `useLayoutEffect`인 이유**
+ * React는 자식의 `useEffect`를 부모보다 먼저 실행한다. 태그를 `useEffect`로 붙이면
+ * 첫 렌더에서 바로 리포트하는 이벤트(예: `useGenerateImageRequest`의 invalid)가
+ * 태그 없이 전송된다. 하필 맥락이 가장 필요한 이벤트가 맥락 없이 나가는 셈이다.
+ * layout effect는 전부 끝난 뒤에 passive effect가 시작되므로, 부모의 태그 설정이
+ * 자식의 리포트보다 먼저 실행되는 것이 보장된다. (로컬 dry-run으로 확인한 문제)
+ *
  * +) 개인 식별(setUser)은 하지 않는다 — [[useClaritySync]]와 동일한 비식별 원칙 유지
  *    (개인정보처리방침에 내부 식별자 저장이 가능한지 확인되면 별도로 논의)
  */
@@ -26,7 +33,7 @@ export const useSentrySync = (): void => {
   // 화면 단위 — SPA 탭(`?tab=product`)이나 퍼널 스텝(`?image-generation-funnel.step=`)처럼
   // pathname이 안 바뀌는 화면을 Sentry 이슈에서 구분하는 핵심 태그.
   // Sentry 기본 transaction은 pathname만 보므로 이 태그 없이는 구분이 불가능하다.
-  useEffect(() => {
+  useLayoutEffect(() => {
     setReportTag(
       'screen_name',
       resolveScreenName(`${location.pathname}${location.search}`)
@@ -34,14 +41,14 @@ export const useSentrySync = (): void => {
   }, [location.pathname, location.search]);
 
   // 로그인 상태
-  useEffect(() => {
+  useLayoutEffect(() => {
     setReportTag('login_status', getLoginStatus());
   }, [accessToken]);
 
   // A/B variant — 이미 배정된 값을 storage에서 수동 read만 (여기서 배정을 트리거하지 않음)
   // useABTest()를 호출하면 userId 로딩 전(로그인 직후 등) 조기 랜덤 배정이 캐시되어
   // 이후 userId 기반 결정적 배정을 영구히 덮어쓰므로, 관측용 훅에서는 직접 읽어 태깅만 수행
-  useEffect(() => {
+  useLayoutEffect(() => {
     try {
       const cached = localStorage.getItem(AB_TEST_STORAGE_KEY);
       if (cached && isABTestGroup(cached)) {
@@ -54,7 +61,7 @@ export const useSentrySync = (): void => {
 
   // 이미지 생성 진입경로 — 생성 플로우 밖에서는 값이 없으므로 태그를 지운다.
   // 안 지우면 플로우를 떠난 뒤에도 옛 경로가 남아 잘못된 원인으로 읽힌다.
-  useEffect(() => {
+  useLayoutEffect(() => {
     setReportTag('image_entry_route', getEntryRoute() ?? null);
   }, [location.pathname, location.search]);
 };

--- a/src/shared/hooks/useSentrySync.ts
+++ b/src/shared/hooks/useSentrySync.ts
@@ -1,0 +1,60 @@
+import { useEffect } from 'react';
+
+import { useLocation } from 'react-router-dom';
+
+import { useUserStore } from '@store/useUserStore';
+
+import { getEntryRoute } from '@shared/analytics/utils/imageEntryRoute';
+import { getLoginStatus } from '@shared/analytics/utils/loginStatus';
+import { resolveScreenName } from '@shared/analytics/utils/screenName';
+import { setReportTag } from '@shared/monitoring/report';
+import { AB_TEST_STORAGE_KEY, isABTestGroup } from '@shared/types/abTest';
+
+/**
+ * GA4·Clarity가 쓰는 세그먼트 축을 Sentry 태그로 미러링하는 훅
+ *
+ * RootLayout에서 1회 마운트 — 이슈를 화면·진입경로 단위로 필터링할 수 있게 한다.
+ * 세 도구가 같은 축을 쓰므로 "Clarity에서 본 세션"과 "Sentry에서 본 에러"를 같은 기준으로 맞춰볼 수 있다.
+ *
+ * +) 개인 식별(setUser)은 하지 않는다 — [[useClaritySync]]와 동일한 비식별 원칙 유지
+ *    (개인정보처리방침에 내부 식별자 저장이 가능한지 확인되면 별도로 논의)
+ */
+export const useSentrySync = (): void => {
+  const location = useLocation();
+  const accessToken = useUserStore((state) => state.accessToken);
+
+  // 화면 단위 — SPA 탭(`?tab=product`)이나 퍼널 스텝(`?image-generation-funnel.step=`)처럼
+  // pathname이 안 바뀌는 화면을 Sentry 이슈에서 구분하는 핵심 태그.
+  // Sentry 기본 transaction은 pathname만 보므로 이 태그 없이는 구분이 불가능하다.
+  useEffect(() => {
+    setReportTag(
+      'screen_name',
+      resolveScreenName(`${location.pathname}${location.search}`)
+    );
+  }, [location.pathname, location.search]);
+
+  // 로그인 상태
+  useEffect(() => {
+    setReportTag('login_status', getLoginStatus());
+  }, [accessToken]);
+
+  // A/B variant — 이미 배정된 값을 storage에서 수동 read만 (여기서 배정을 트리거하지 않음)
+  // useABTest()를 호출하면 userId 로딩 전(로그인 직후 등) 조기 랜덤 배정이 캐시되어
+  // 이후 userId 기반 결정적 배정을 영구히 덮어쓰므로, 관측용 훅에서는 직접 읽어 태깅만 수행
+  useEffect(() => {
+    try {
+      const cached = localStorage.getItem(AB_TEST_STORAGE_KEY);
+      if (cached && isABTestGroup(cached)) {
+        setReportTag('ab_variant', cached);
+      }
+    } catch {
+      // localStorage 접근 실패 시 무시 (Safari 프라이빗 등)
+    }
+  }, [location.pathname, location.search]);
+
+  // 이미지 생성 진입경로 — 생성 플로우 밖에서는 값이 없으므로 태그를 지운다.
+  // 안 지우면 플로우를 떠난 뒤에도 옛 경로가 남아 잘못된 원인으로 읽힌다.
+  useEffect(() => {
+    setReportTag('image_entry_route', getEntryRoute() ?? null);
+  }, [location.pathname, location.search]);
+};

--- a/src/shared/monitoring/apiReportPolicy.test.ts
+++ b/src/shared/monitoring/apiReportPolicy.test.ts
@@ -1,0 +1,142 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { decideApiReport } from './apiReportPolicy';
+import { API_ERROR_KIND, type ApiErrorInfo } from './classifyApiError';
+
+const info = (overrides: Partial<ApiErrorInfo>): ApiErrorInfo => ({
+  kind: API_ERROR_KIND.SERVER,
+  method: 'GET',
+  routePattern: '/api/v1/x',
+  ...overrides,
+});
+
+const auto = { isMutation: false, captureMode: 'auto' as const };
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('decideApiReport — 전송하는 것', () => {
+  it('5xx는 error로 전송한다', () => {
+    const decision = decideApiReport(
+      info({ kind: API_ERROR_KIND.SERVER, status: 500 }),
+      auto
+    );
+
+    expect(decision?.level).toBe('error');
+  });
+
+  it('타임아웃과 unknown도 전송한다', () => {
+    expect(
+      decideApiReport(info({ kind: API_ERROR_KIND.TIMEOUT }), auto)
+    ).not.toBeNull();
+    expect(
+      decideApiReport(info({ kind: API_ERROR_KIND.UNKNOWN }), auto)
+    ).not.toBeNull();
+  });
+
+  it('allowlist에 있는 4xx 비즈니스 코드는 전송한다', () => {
+    const decision = decideApiReport(
+      info({ kind: API_ERROR_KIND.CLIENT, status: 400, code: 50400 }),
+      auto
+    );
+
+    expect(decision?.level).toBe('error');
+  });
+
+  it('fingerprint에 경로·상태·코드가 들어간다', () => {
+    const decision = decideApiReport(
+      info({ status: 500, code: 50013, routePattern: '/api/v1/gen' }),
+      auto
+    );
+
+    expect(decision?.fingerprint).toEqual([
+      'api',
+      API_ERROR_KIND.SERVER,
+      'GET',
+      '/api/v1/gen',
+      '500',
+      '50013',
+    ]);
+  });
+});
+
+describe('decideApiReport — 전송하지 않는 것', () => {
+  it('SESSION_EXPIRED와 취소는 어떤 모드에서도 보내지 않는다', () => {
+    expect(
+      decideApiReport(info({ kind: API_ERROR_KIND.SESSION_EXPIRED }), auto)
+    ).toBeNull();
+    expect(
+      decideApiReport(info({ kind: API_ERROR_KIND.CANCELED }), {
+        isMutation: false,
+        captureMode: 'always',
+      })
+    ).toBeNull();
+  });
+
+  it('allowlist에 없는 4xx는 보내지 않는다 (404·409·429)', () => {
+    [404, 409, 429].forEach((status) => {
+      expect(
+        decideApiReport(info({ kind: API_ERROR_KIND.CLIENT, status }), auto)
+      ).toBeNull();
+    });
+  });
+
+  it('크레딧 초과(42900)처럼 정상 비즈니스 코드는 보내지 않는다', () => {
+    expect(
+      decideApiReport(
+        info({ kind: API_ERROR_KIND.CLIENT, status: 429, code: 42900 }),
+        auto
+      )
+    ).toBeNull();
+  });
+
+  it('capture: never면 5xx도 보내지 않는다', () => {
+    expect(
+      decideApiReport(info({ kind: API_ERROR_KIND.SERVER, status: 500 }), {
+        isMutation: false,
+        captureMode: 'never',
+      })
+    ).toBeNull();
+  });
+});
+
+describe('decideApiReport — 샘플링', () => {
+  it('네트워크 에러는 조회일 때 샘플링한다', () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0.99);
+
+    expect(
+      decideApiReport(info({ kind: API_ERROR_KIND.NETWORK }), auto)
+    ).toBeNull();
+  });
+
+  it('네트워크 에러라도 변경 요청이면 전량 전송한다', () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0.99);
+
+    expect(
+      decideApiReport(info({ kind: API_ERROR_KIND.NETWORK }), {
+        isMutation: true,
+        captureMode: 'auto',
+      })
+    ).not.toBeNull();
+  });
+
+  it('401/403은 샘플에 걸릴 때만 전송한다', () => {
+    const authError = info({ kind: API_ERROR_KIND.CLIENT, status: 401 });
+
+    vi.spyOn(Math, 'random').mockReturnValue(0.99);
+    expect(decideApiReport(authError, auto)).toBeNull();
+
+    vi.spyOn(Math, 'random').mockReturnValue(0);
+    expect(decideApiReport(authError, auto)?.level).toBe('warning');
+  });
+
+  it('capture: always면 4xx도 전송한다', () => {
+    const decision = decideApiReport(
+      info({ kind: API_ERROR_KIND.CLIENT, status: 404 }),
+      { isMutation: true, captureMode: 'always' }
+    );
+
+    expect(decision?.level).toBe('error');
+  });
+});

--- a/src/shared/monitoring/apiReportPolicy.test.ts
+++ b/src/shared/monitoring/apiReportPolicy.test.ts
@@ -17,7 +17,9 @@ afterEach(() => {
 });
 
 describe('decideApiReport — 전송하는 것', () => {
-  it('5xx는 error로 전송한다', () => {
+  it('5xx는 샘플에 걸릴 때 error로 전송한다', () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0);
+
     const decision = decideApiReport(
       info({ kind: API_ERROR_KIND.SERVER, status: 500 }),
       auto
@@ -45,6 +47,8 @@ describe('decideApiReport — 전송하는 것', () => {
   });
 
   it('fingerprint에 경로·상태·코드가 들어간다', () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0);
+
     const decision = decideApiReport(
       info({ status: 500, code: 50013, routePattern: '/api/v1/gen' }),
       auto
@@ -98,6 +102,24 @@ describe('decideApiReport — 전송하지 않는 것', () => {
         captureMode: 'never',
       })
     ).toBeNull();
+  });
+
+  // 서버 Sentry가 같은 실패를 더 자세히 잡으므로 FE는 표본만 수집한다
+  it('5xx는 샘플에 걸리지 않으면 보내지 않는다', () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0.99);
+
+    expect(
+      decideApiReport(info({ kind: API_ERROR_KIND.SERVER, status: 500 }), auto)
+    ).toBeNull();
+  });
+
+  // 서버에 요청이 닿지 않은 실패는 서버 로그에 없으므로 줄이지 않는다
+  it('타임아웃은 샘플링하지 않고 항상 보낸다', () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0.99);
+
+    expect(
+      decideApiReport(info({ kind: API_ERROR_KIND.TIMEOUT }), auto)
+    ).not.toBeNull();
   });
 });
 

--- a/src/shared/monitoring/apiReportPolicy.ts
+++ b/src/shared/monitoring/apiReportPolicy.ts
@@ -1,0 +1,109 @@
+import { API_ERROR_KIND, type ApiErrorInfo } from './classifyApiError';
+import { shouldSample } from './sampling';
+
+/**
+ * API 에러 전송 정책
+ *
+ * 무엇을 Sentry로 보내고 무엇을 버릴지 정한다.
+ * 버리는 경우에도 호출부는 breadcrumb를 남기므로 맥락은 보존된다.
+ */
+
+/**
+ * 4xx 중에서도 캡처할 서버 비즈니스 에러 코드 (allowlist)
+ *
+ * 4xx는 기본 미전송이고 여기 등록된 것만 보낸다.
+ * (denylist로 하면 서버에 새 에러 코드가 생길 때마다 quota가 새기 때문)
+ */
+export const CAPTURED_CLIENT_ERROR_CODES = new Set<number>([
+  // 이미지 생성 잘못된 요청 — 클라이언트가 조립한 payload 오류이므로 앱 버그
+  50400,
+]);
+
+/** 네트워크 에러 샘플링 비율 (조회는 대량이라 일부만, 변경 요청은 전량) */
+const NETWORK_QUERY_SAMPLE_RATE = 0.1;
+/** 인증 실패(401/403) 샘플링 비율 */
+const AUTH_STATUS_SAMPLE_RATE = 0.1;
+
+/** query/mutation 단위로 정책을 덮어쓰는 모드 */
+export type ApiCaptureMode = 'auto' | 'always' | 'never';
+
+export interface ApiReportDecision {
+  level: 'error' | 'warning';
+  fingerprint: string[];
+}
+
+/** 엔드포인트 + 상태 + 비즈니스 코드 단위로 이슈를 묶는다 */
+const buildFingerprint = (info: ApiErrorInfo): string[] => [
+  'api',
+  info.kind,
+  info.method ?? '-',
+  info.routePattern ?? '-',
+  info.status !== undefined ? String(info.status) : '-',
+  info.code !== undefined ? String(info.code) : '-',
+];
+
+/**
+ * 분류 결과로 전송 여부를 정한다.
+ * null이면 이벤트를 만들지 않는다(호출부가 breadcrumb만 남김).
+ */
+export const decideApiReport = (
+  info: ApiErrorInfo,
+  options: { isMutation: boolean; captureMode: ApiCaptureMode }
+): ApiReportDecision | null => {
+  const { isMutation, captureMode } = options;
+
+  if (captureMode === 'never') return null;
+
+  // 정상 흐름이라 어떤 설정에서도 보내지 않는다
+  if (
+    info.kind === API_ERROR_KIND.SESSION_EXPIRED ||
+    info.kind === API_ERROR_KIND.CANCELED
+  ) {
+    return null;
+  }
+
+  const fingerprint = buildFingerprint(info);
+
+  if (captureMode === 'always') {
+    return { level: 'error', fingerprint };
+  }
+
+  switch (info.kind) {
+    // 서버 장애·타임아웃·예상 못한 throw는 전량 수집
+    case API_ERROR_KIND.SERVER:
+    case API_ERROR_KIND.TIMEOUT:
+    case API_ERROR_KIND.UNKNOWN:
+      return { level: 'error', fingerprint };
+
+    case API_ERROR_KIND.NETWORK: {
+      // 변경 요청 실패는 사용자 액션이 유실된 것이라 전량 수집
+      if (isMutation) return { level: 'warning', fingerprint };
+
+      return shouldSample(NETWORK_QUERY_SAMPLE_RATE)
+        ? { level: 'warning', fingerprint }
+        : null;
+    }
+
+    case API_ERROR_KIND.CLIENT: {
+      if (
+        info.code !== undefined &&
+        CAPTURED_CLIENT_ERROR_CODES.has(info.code)
+      ) {
+        return { level: 'error', fingerprint };
+      }
+
+      // 401/403은 세션 만료 처리 경로 밖에서만 도달 — 드물어야 정상이라 소량만 확인
+      if (info.status === 401 || info.status === 403) {
+        return shouldSample(AUTH_STATUS_SAMPLE_RATE)
+          ? { level: 'warning', fingerprint }
+          : null;
+      }
+
+      // 그 외 4xx(404·409 중복요청·429 크레딧 초과 등)는 정상 비즈니스 흐름
+      return null;
+    }
+
+    default:
+      return null;
+  }
+};

--- a/src/shared/monitoring/apiReportPolicy.ts
+++ b/src/shared/monitoring/apiReportPolicy.ts
@@ -23,6 +23,20 @@ export const CAPTURED_CLIENT_ERROR_CODES = new Set<number>([
 const NETWORK_QUERY_SAMPLE_RATE = 0.1;
 /** 인증 실패(401/403) 샘플링 비율 */
 const AUTH_STATUS_SAMPLE_RATE = 0.1;
+/**
+ * 서버 오류(5xx) 샘플링 비율
+ *
+ * HOUME-SERVER가 이미 같은 실패를 Sentry로 보내고 Discord 알림까지 띄운다
+ * (`GlobalExceptionHandler`의 `ImageFallbackException`·`GeneralException` 처리).
+ * 서버 쪽이 스택·요청 바디까지 남기므로 FE는 "사용자에게 어떻게 보였나"를 확인할 표본만
+ * 있으면 됨, 로그 100% 수집은 중복·불필요
+ *
+ * 반면 타임아웃과 네트워크 에러는 서버에 요청이 닿지 않아 서버 로그에 흔적이 없으므로
+ * 줄이지 않는다.
+ *
+ * 0.2라는 값 자체는 근거가 약하다. 배포 후 실제 유입량을 보고 조정한다.
+ */
+const SERVER_ERROR_SAMPLE_RATE = 0.2;
 
 /** query/mutation 단위로 정책을 덮어쓰는 모드 */
 export type ApiCaptureMode = 'auto' | 'always' | 'never';
@@ -69,8 +83,13 @@ export const decideApiReport = (
   }
 
   switch (info.kind) {
-    // 서버 장애·타임아웃·예상 못한 throw는 전량 수집
+    // 서버가 응답을 준 실패 — 서버 Sentry가 더 자세히 잡으므로 표본만 수집
     case API_ERROR_KIND.SERVER:
+      return shouldSample(SERVER_ERROR_SAMPLE_RATE)
+        ? { level: 'error', fingerprint }
+        : null;
+
+    // 서버에 요청이 닿지 않은 실패 + 예상 못한 throw는 전량 수집 (서버 로그에 흔적이 없다)
     case API_ERROR_KIND.TIMEOUT:
     case API_ERROR_KIND.UNKNOWN:
       return { level: 'error', fingerprint };

--- a/src/shared/monitoring/classifyApiError.test.ts
+++ b/src/shared/monitoring/classifyApiError.test.ts
@@ -1,0 +1,124 @@
+import { CanceledError } from 'axios';
+import { describe, expect, it } from 'vitest';
+
+import {
+  API_ERROR_KIND,
+  classifyApiError,
+  isSessionExpiredError,
+  normalizeApiPath,
+} from './classifyApiError';
+
+/** 테스트용 AxiosError 형태 (axios는 isAxiosError 플래그로 판별한다) */
+const axiosError = (overrides: Record<string, unknown>) => ({
+  isAxiosError: true,
+  config: { method: 'get', url: '/api/v1/banners/12' },
+  ...overrides,
+});
+
+describe('normalizeApiPath', () => {
+  it('숫자 세그먼트를 :id로 바꾼다', () => {
+    expect(normalizeApiPath('/api/v1/banners/123/items')).toBe(
+      '/api/v1/banners/:id/items'
+    );
+  });
+
+  it('쿼리 스트링을 제거한다', () => {
+    expect(normalizeApiPath('/api/products?keyword=x')).toBe('/api/products');
+  });
+
+  it('url이 없으면 undefined를 반환한다', () => {
+    expect(normalizeApiPath(undefined)).toBeUndefined();
+  });
+});
+
+describe('isSessionExpiredError', () => {
+  it('SESSION_EXPIRED 메시지인 Error만 true다', () => {
+    expect(isSessionExpiredError(new Error('SESSION_EXPIRED'))).toBe(true);
+    expect(isSessionExpiredError(new Error('Network Error'))).toBe(false);
+    expect(isSessionExpiredError('SESSION_EXPIRED')).toBe(false);
+  });
+});
+
+describe('classifyApiError — 판별 우선순위', () => {
+  it('SESSION_EXPIRED가 가장 먼저 판별된다', () => {
+    expect(classifyApiError(new Error('SESSION_EXPIRED')).kind).toBe(
+      API_ERROR_KIND.SESSION_EXPIRED
+    );
+  });
+
+  it('axios 취소는 canceled로 판별한다', () => {
+    expect(classifyApiError(new CanceledError('canceled')).kind).toBe(
+      API_ERROR_KIND.CANCELED
+    );
+  });
+
+  it('AbortError는 canceled로 판별한다', () => {
+    const error = new Error('aborted');
+    error.name = 'AbortError';
+
+    expect(classifyApiError(error).kind).toBe(API_ERROR_KIND.CANCELED);
+  });
+
+  it('axios 에러가 아니면 unknown이다', () => {
+    expect(classifyApiError(new Error('boom')).kind).toBe(
+      API_ERROR_KIND.UNKNOWN
+    );
+    expect(classifyApiError(null).kind).toBe(API_ERROR_KIND.UNKNOWN);
+  });
+
+  it('타임아웃 코드는 timeout이다', () => {
+    expect(classifyApiError(axiosError({ code: 'ECONNABORTED' })).kind).toBe(
+      API_ERROR_KIND.TIMEOUT
+    );
+    expect(classifyApiError(axiosError({ code: 'ETIMEDOUT' })).kind).toBe(
+      API_ERROR_KIND.TIMEOUT
+    );
+  });
+
+  it('응답이 없으면 network다', () => {
+    expect(classifyApiError(axiosError({})).kind).toBe(API_ERROR_KIND.NETWORK);
+  });
+
+  it('5xx는 server, 4xx는 client다', () => {
+    expect(
+      classifyApiError(axiosError({ response: { status: 500 } })).kind
+    ).toBe(API_ERROR_KIND.SERVER);
+    expect(
+      classifyApiError(axiosError({ response: { status: 404 } })).kind
+    ).toBe(API_ERROR_KIND.CLIENT);
+  });
+});
+
+describe('classifyApiError — 부가 정보', () => {
+  it('method와 정규화된 경로를 담는다', () => {
+    const info = classifyApiError(
+      axiosError({
+        config: { method: 'post', url: '/api/v1/banners/12' },
+        response: { status: 500 },
+      })
+    );
+
+    expect(info.method).toBe('POST');
+    expect(info.routePattern).toBe('/api/v1/banners/:id');
+  });
+
+  it('서버 비즈니스 에러 코드를 꺼낸다', () => {
+    const info = classifyApiError(
+      axiosError({ response: { status: 500, data: { code: 50013 } } })
+    );
+
+    expect(info.status).toBe(500);
+    expect(info.code).toBe(50013);
+  });
+
+  it('응답 바디가 없거나 code가 숫자가 아니면 code는 undefined다', () => {
+    expect(
+      classifyApiError(axiosError({ response: { status: 500 } })).code
+    ).toBeUndefined();
+    expect(
+      classifyApiError(
+        axiosError({ response: { status: 500, data: { code: 'X' } } })
+      ).code
+    ).toBeUndefined();
+  });
+});

--- a/src/shared/monitoring/classifyApiError.ts
+++ b/src/shared/monitoring/classifyApiError.ts
@@ -1,0 +1,119 @@
+import axios, { isAxiosError } from 'axios';
+
+/**
+ * API 에러 분류
+ *
+ * "무엇이 실패했는가"를 판별만 하는 순수 함수 모음
+ * 전송 여부 판단은 apiReportPolicy가 맡는다(판별과 정책을 분리해 각각 테스트).
+ */
+
+/** 토큰 재발급 실패 시 axios 인터셉터가 던지는 통일 메시지 */
+export const SESSION_EXPIRED_MESSAGE = 'SESSION_EXPIRED';
+
+export const isSessionExpiredError = (error: unknown): boolean =>
+  error instanceof Error && error.message === SESSION_EXPIRED_MESSAGE;
+
+export const API_ERROR_KIND = {
+  /** 토큰 재발급 실패 → 정상 로그아웃 플로우 */
+  SESSION_EXPIRED: 'sessionExpired',
+  /** 언마운트·중복 요청으로 취소됨 → 정상 */
+  CANCELED: 'canceled',
+  /** 요청 타임아웃 */
+  TIMEOUT: 'timeout',
+  /** 응답 자체를 받지 못함 (오프라인·DNS·CORS) */
+  NETWORK: 'network',
+  /** 4xx */
+  CLIENT: 'client',
+  /** 5xx */
+  SERVER: 'server',
+  /** axios 에러가 아닌 예상 못한 throw */
+  UNKNOWN: 'unknown',
+} as const;
+
+export type ApiErrorKind = (typeof API_ERROR_KIND)[keyof typeof API_ERROR_KIND];
+
+export interface ApiErrorInfo {
+  kind: ApiErrorKind;
+  /** HTTP 상태 코드 */
+  status?: number;
+  /** 서버 BaseResponse.code (비즈니스 에러 코드) */
+  code?: number;
+  /** 동적 세그먼트를 :id로 바꾼 경로 — 이슈가 id마다 쪼개지는 것을 막는다 */
+  routePattern?: string;
+  method?: string;
+}
+
+/** `/banners/123/items` → `/banners/:id/items` */
+export const normalizeApiPath = (url?: string): string | undefined => {
+  if (!url) return undefined;
+
+  const [path] = url.split('?');
+
+  return path
+    .split('/')
+    .map((segment) => (/^\d+$/.test(segment) ? ':id' : segment))
+    .join('/');
+};
+
+/** 응답 바디에서 서버의 비즈니스 에러 코드만 안전하게 추출 */
+const extractServerCode = (data: unknown): number | undefined => {
+  if (!data || typeof data !== 'object') return undefined;
+
+  const code = (data as { code?: unknown }).code;
+
+  return typeof code === 'number' ? code : undefined;
+};
+
+/**
+ * 에러를 종류별로 분류한다.
+ * 판별 순서가 중요 — 위에서 먼저 걸리는 조건이 우선시
+ */
+export const classifyApiError = (error: unknown): ApiErrorInfo => {
+  if (isSessionExpiredError(error)) {
+    return { kind: API_ERROR_KIND.SESSION_EXPIRED };
+  }
+
+  if (axios.isCancel(error)) {
+    return { kind: API_ERROR_KIND.CANCELED };
+  }
+
+  if (error instanceof Error && error.name === 'AbortError') {
+    return { kind: API_ERROR_KIND.CANCELED };
+  }
+
+  if (!isAxiosError(error)) {
+    return { kind: API_ERROR_KIND.UNKNOWN };
+  }
+
+  const base = {
+    method: error.config?.method?.toUpperCase(),
+    routePattern: normalizeApiPath(error.config?.url),
+  };
+
+  if (error.code === 'ERR_CANCELED') {
+    return { ...base, kind: API_ERROR_KIND.CANCELED };
+  }
+
+  if (error.code === 'ECONNABORTED' || error.code === 'ETIMEDOUT') {
+    return { ...base, kind: API_ERROR_KIND.TIMEOUT };
+  }
+
+  // 응답이 없으면 서버에 닿지 못한 것 (오프라인·DNS·CORS)
+  if (!error.response) {
+    return { ...base, kind: API_ERROR_KIND.NETWORK };
+  }
+
+  const status = error.response.status;
+  const code = extractServerCode(error.response.data);
+
+  if (status >= 500) {
+    return { ...base, kind: API_ERROR_KIND.SERVER, status, code };
+  }
+
+  if (status >= 400) {
+    return { ...base, kind: API_ERROR_KIND.CLIENT, status, code };
+  }
+
+  // 2xx/3xx인데 에러로 도달한 경우 (인터셉터가 변환했을 수 있음)
+  return { ...base, kind: API_ERROR_KIND.UNKNOWN, status, code };
+};

--- a/src/shared/monitoring/noiseFilter.test.ts
+++ b/src/shared/monitoring/noiseFilter.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  isInjectedScriptEvent,
+  NOISE_DENY_URLS,
+  NOISE_ERROR_PATTERNS,
+} from './noiseFilter';
+
+import type { ErrorEvent } from '@sentry/react';
+
+const matchesNoise = (message: string) =>
+  NOISE_ERROR_PATTERNS.some((pattern) => pattern.test(message));
+
+const matchesDenyUrl = (url: string) =>
+  NOISE_DENY_URLS.some((pattern) => pattern.test(url));
+
+/**
+ * 프레임을 실제 전송 시점 모양으로 만든다.
+ *
+ * `in_app: true`를 모든 프레임에 붙이는 이유는 `@sentry/browser`가 실제로 그렇게 만들기
+ * 때문이다. 이전 테스트는 `in_app: false`인 프레임을 만들어 검증했는데, SDK가 그런 프레임을
+ * 만들지 않으므로 실제로는 발생할 수 없는 입력이었다.
+ */
+const eventWithFilenames = (filenames: (string | undefined)[]): ErrorEvent =>
+  ({
+    exception: {
+      values: [
+        {
+          stacktrace: {
+            frames: filenames.map((filename) => ({ filename, in_app: true })),
+          },
+        },
+      ],
+    },
+  }) as unknown as ErrorEvent;
+
+describe('NOISE_ERROR_PATTERNS', () => {
+  it('인스타 인앱브라우저가 끼워 넣은 스크립트의 에러를 걸러낸다', () => {
+    expect(
+      matchesNoise(
+        "undefined is not an object (evaluating 'window.webkit.messageHandlers')"
+      )
+    ).toBe(true);
+    expect(
+      matchesNoise('Error invoking postMessage: Java object is gone')
+    ).toBe(true);
+  });
+
+  it('브라우저·서드파티 내부 노이즈를 걸러낸다', () => {
+    expect(matchesNoise('AbortError: AbortError')).toBe(true);
+    expect(
+      matchesNoise(
+        'InvalidStateError: Failed to execute transaction: The database connection is closing.'
+      )
+    ).toBe(true);
+    expect(
+      matchesNoise('UnknownError: Database deleted by request of the user')
+    ).toBe(true);
+    expect(matchesNoise('ResizeObserver loop limit exceeded')).toBe(true);
+  });
+
+  it('앱에서 나는 진짜 에러는 걸러내지 않는다', () => {
+    expect(matchesNoise('TypeError: Cannot read properties of undefined')).toBe(
+      false
+    );
+    expect(
+      matchesNoise(
+        'Error: Invalid blocker state transition: unblocked -> proceeding'
+      )
+    ).toBe(false);
+    expect(matchesNoise('Request failed with status code 500')).toBe(false);
+  });
+});
+
+describe('NOISE_DENY_URLS', () => {
+  // HOUME-CLIENT-N의 실제 프레임 주소
+  it('인스타 안드로이드 인앱브라우저의 iabjs:// 주소를 차단한다', () => {
+    expect(
+      matchesDenyUrl('iabjs://navigation_performance_logger_android:1:10155')
+    ).toBe(true);
+  });
+
+  it('브라우저 확장 프로그램 주소를 차단한다', () => {
+    expect(matchesDenyUrl('chrome-extension://abcdef/inject.js')).toBe(true);
+    expect(matchesDenyUrl('moz-extension://abcdef/inject.js')).toBe(true);
+  });
+
+  it('하우미 자산 주소는 차단하지 않는다', () => {
+    expect(
+      matchesDenyUrl('https://www.houme.kr/assets/index-BjN1JfgV.js')
+    ).toBe(false);
+  });
+});
+
+describe('isInjectedScriptEvent', () => {
+  // HOUME-CLIENT-F의 실제 스택 — 세 프레임 모두 HTML 문서 경로
+  it('인스타 iOS가 문서에 직접 넣은 스크립트를 잡아낸다', () => {
+    expect(
+      isInjectedScriptEvent(
+        eventWithFilenames(['/landing', '/landing', '/landing'])
+      )
+    ).toBe(true);
+  });
+
+  it('절대 주소 형태의 문서 경로도 잡아낸다', () => {
+    expect(
+      isInjectedScriptEvent(
+        eventWithFilenames(['https://www.houme.kr/landing'])
+      )
+    ).toBe(true);
+  });
+
+  it('하우미 빌드 결과(.js)는 잡지 않는다', () => {
+    expect(
+      isInjectedScriptEvent(
+        eventWithFilenames([
+          'https://www.houme.kr/assets/index-BjN1JfgV.js',
+          'https://www.houme.kr/assets/MyPage-C9macM4-.js',
+        ])
+      )
+    ).toBe(false);
+  });
+
+  // HOUME-CLIENT-N의 실제 스택 — iabjs 3개 + @sentry/browser 1개
+  it('.js 프레임이 하나라도 섞여 있으면 잡지 않는다 (이 경우는 denyUrls가 담당)', () => {
+    expect(
+      isInjectedScriptEvent(
+        eventWithFilenames([
+          'iabjs://navigation_performance_logger_android',
+          'iabjs://navigation_performance_logger_android',
+          'iabjs://navigation_performance_logger_android',
+          '../../node_modules/.pnpm/@sentry+browser@10.63.0/node_modules/@sentry/browser/build/npm/esm/prod/helpers.js',
+        ])
+      )
+    ).toBe(false);
+  });
+
+  it('모든 프레임이 in_app: true여도 파일명으로 판별한다', () => {
+    // 이전 구현이 in_app으로 판별해 아무것도 잡지 못했던 회귀를 막는다
+    const event = eventWithFilenames(['/landing']);
+    const frames = event.exception?.values?.[0]?.stacktrace?.frames ?? [];
+
+    expect(frames.every((frame) => frame.in_app === true)).toBe(true);
+    expect(isInjectedScriptEvent(event)).toBe(true);
+  });
+
+  it('파일명을 모르거나 스택이 없으면 잡지 않는다', () => {
+    expect(isInjectedScriptEvent(eventWithFilenames([undefined]))).toBe(false);
+    expect(isInjectedScriptEvent(eventWithFilenames([]))).toBe(false);
+    expect(isInjectedScriptEvent({} as ErrorEvent)).toBe(false);
+  });
+});

--- a/src/shared/monitoring/noiseFilter.ts
+++ b/src/shared/monitoring/noiseFilter.ts
@@ -1,0 +1,79 @@
+import type { ErrorEvent } from '@sentry/react';
+
+/**
+ * 앱과 무관한 노이즈 판별
+ *
+ * 인스타그램 광고 유입 사용자가 대부분 -> 프로덕션 에러의 상당수가
+ * 인앱브라우저(iOS WKWebView / 안드로이드 웹뷰)가 페이지에 끼워 넣은 스크립트에서 발생한다.
+ * 이 노이즈가 진짜 에러를 덮지 않도록 유입 단계에서 걸러낸다.
+ */
+
+/** Sentry `ignoreErrors`에 그대로 전달되는 노이즈 메시지 패턴
+ * '에러 메시지'로 로깅 차단 결정
+ */
+export const NOISE_ERROR_PATTERNS: RegExp[] = [
+  // 인스타 인앱브라우저(iOS)가 끼워 넣은 스크립트의 네이티브 브릿지 접근 — 기능 영향 없음
+  /window\.webkit\.messageHandlers/,
+  // 인스타 안드로이드 웹뷰가 페이지를 떠날 때 브릿지 객체가 먼저 해제되며 발생
+  /Java object is gone/,
+  // 페이지 이동으로 요청이 취소된 정상 상황
+  /^AbortError/,
+  /The operation was aborted/,
+  // Firebase installations가 인앱 웹뷰 종료 중 IndexedDB를 닫으며 발생
+  /database connection is closing/i,
+  /Database deleted by request of the user/,
+  // 브라우저 레이아웃 계산 경고 — 렌더 결과에는 영향 없음
+  /ResizeObserver loop/,
+];
+
+/**
+ * '스크립트 주소(ex: iabjs://)'로 로깅 차단 결정
+ *
+ * `iabjs://`는 인스타그램 안드로이드 인앱브라우저가 자체 스크립트를 실행할 때 쓰는 주소
+ * (iab = in-app browser). 하우미 코드에서는 나올 수 없으므로 메시지와 무관하게 차단한다.
+ * 메시지 패턴(`Java object is gone`)만으로 막으면 인스타가 스크립트를 바꿔 다른 메시지가 나올 때 막지 못함.
+ */
+export const NOISE_DENY_URLS: RegExp[] = [
+  /^iabjs:\/\//i,
+  /^chrome-extension:\/\//i,
+  /^moz-extension:\/\//i,
+  /^safari-(web-)?extension:\/\//i,
+  /extensions\//i,
+];
+
+/** 스크립트 파일 경로로 끝나는지 (쿼리스트링·해시는 빼고 판단) */
+const SCRIPT_FILE_PATTERN = /\.(js|mjs|cjs)(\?|#|$)/i;
+
+/**
+ * 프레임이 실제 스크립트 파일이 아닌 곳에서 왔는지 판별한다.
+ * 파일명을 모르면 판단하지 않는다(모르는 것을 노이즈로 몰지 않기 위해).
+ */
+const isNonScriptFrame = (filename?: string): boolean => {
+  if (!filename) return false;
+
+  return !SCRIPT_FILE_PATTERN.test(filename);
+};
+
+/**
+ * Sentry 대시보드의 스택 트레이스 전체가 스크립트 파일이 아닌 곳에서 나온 에러인지 판별
+ * -> 하나도 .js 파일이 아닐 시 noise_candidate
+ *
+ * 왜 필요한가 — 메시지·주소(형식)로 막는 위 두 방법은 그 값을 미리 알아야 동작한다. 반면 인스타가 스크립트를 바꾸면 새 메시지가 나와 둘 다 놓친다(실제로 -F → -K → -P로 유사한 오류에 대한 변형이 계속 생김).
+ * 이 함수는 '파일로 불러오지 않은 코드'라는 '구조'만 보므로 정확한 메시지·주소(형식)를 몰라도 판별한다.
+ *
+ * 분석 시 주의 — 대시보드에서 In App으로 보여도 실제로는 하우미 내부 코드가
+ * 아닐 수 있다. 이 함수는 방어 장치일 뿐이므로 이슈를 분석할 때는 파일 경로를 눈으로
+ * 한 번 더 확인해야 한다.
+ *
+ * 오탐 가능성 — `index.html`에 직접 넣은 Meta Pixel 스크립트가 에러를 던지면 여기 걸린다. 다만 차단하지 않고 `noise_candidate` 태그만 붙이므로 이벤트는 그대로 수집된다.
+ */
+export const isInjectedScriptEvent = (event: ErrorEvent): boolean => {
+  const values = event.exception?.values;
+  if (!values || values.length === 0) return false;
+
+  const frames = values.flatMap((value) => value.stacktrace?.frames ?? []);
+  // 스택 자체가 없으면 판단 근거가 없다
+  if (frames.length === 0) return false;
+
+  return frames.every((frame) => isNonScriptFrame(frame.filename));
+};

--- a/src/shared/monitoring/queryMeta.ts
+++ b/src/shared/monitoring/queryMeta.ts
@@ -1,0 +1,35 @@
+import type { ApiCaptureMode } from './apiReportPolicy';
+import type { MonitoringScope } from './scope';
+
+/**
+ * query/mutation 단위 Sentry 정책 선언
+ *
+ * 훅 옵션에 `meta: { sentry: { ... } }`로 붙이면 전역 에러 핸들러가 읽어 적용한다.
+ * 캡처 지점은 전역 한 곳으로 유지하면서 도메인별 정책만 선언적으로 조정하기 위한 장치다.
+ *
+ * @example
+ * useMutation({
+ *   mutationFn: postGenerateImage,
+ *   meta: { sentry: { scope: MONITORING_SCOPE.IMAGE_GENERATE, capture: 'always' } },
+ * });
+ */
+/**
+ * interface가 아니라 type으로 선언하는 이유:
+ * TanStack의 `Register`는 `Record<string, unknown>`에 할당 가능한 타입만 받아들이는데,
+ * interface에는 암묵적 인덱스 시그니처가 없어 증강이 무시된다.
+ */
+export type SentryQueryMeta = {
+  sentry?: {
+    /** 이벤트에 붙일 기능 도메인 태그 */
+    scope: MonitoringScope;
+    /** auto(기본 정책) | always(4xx도 전송) | never(전송 안 함) */
+    capture?: ApiCaptureMode;
+  };
+};
+
+declare module '@tanstack/react-query' {
+  interface Register {
+    queryMeta: SentryQueryMeta;
+    mutationMeta: SentryQueryMeta;
+  }
+}

--- a/src/shared/monitoring/report.ts
+++ b/src/shared/monitoring/report.ts
@@ -69,6 +69,16 @@ export const reportMessage = (
 };
 
 /**
+ * 이후 전송되는 모든 이벤트에 붙는 태그를 설정한다.
+ *
+ * `null`을 넘기면 태그를 지운다. 값이 사라진 뒤에도 옛 값이 남아
+ * 잘못된 화면·경로로 표시되는 것을 막기 위함이다.
+ */
+export const setReportTag = (key: string, value: string | null): void => {
+  Sentry.setTag(key, value ?? undefined);
+};
+
+/**
  * 이벤트로 보내지 않고 흔적만 남긴다.
  * 별도 quota를 소모하지 않으면서 이후 실제 이벤트에 맥락으로 첨부된다.
  */

--- a/src/shared/monitoring/report.ts
+++ b/src/shared/monitoring/report.ts
@@ -1,0 +1,82 @@
+import * as Sentry from '@sentry/react';
+
+import type { MonitoringScope } from './scope';
+import type { SeverityLevel } from '@sentry/react';
+
+/**
+ * Sentry 전송 래퍼
+ *
+ * 앱 코드는 `@sentry/react`를 직접 부르지 않고 이 모듈만 사용한다.
+ * Sentry 미초기화(DSN 없음) 상태에서도 안전하게 no-op으로 동작한다.
+ */
+
+/**
+ * 이벤트에 붙일 수 있는 부가 정보
+ *
+ * 객체·배열을 허용하지 않는 이유: 응답 바디나 폼 값이 통째로 실려
+ * 개인정보가 새는 것을 타입 단계에서 막기 위함이다.
+ * 값이 필요하면 개수·존재 여부 같은 요약으로 바꿔서 넣는다.
+ */
+export type ReportContext = Record<
+  string,
+  string | number | boolean | null | undefined
+>;
+
+interface ReportOptions {
+  /** 기능 도메인 (Sentry `scope` 태그로 전송) */
+  scope: MonitoringScope;
+  context?: ReportContext;
+  tags?: Record<string, string>;
+  level?: SeverityLevel;
+  /** 이슈 그룹핑 키. 지정하지 않으면 Sentry 기본 그룹핑을 따른다 */
+  fingerprint?: string[];
+}
+
+const applyOptions = (sentryScope: Sentry.Scope, options: ReportOptions) => {
+  sentryScope.setTag('scope', options.scope);
+
+  if (options.level) sentryScope.setLevel(options.level);
+  if (options.fingerprint) sentryScope.setFingerprint(options.fingerprint);
+
+  if (options.tags) {
+    Object.entries(options.tags).forEach(([key, value]) => {
+      sentryScope.setTag(key, value);
+    });
+  }
+
+  if (options.context) {
+    sentryScope.setContext('houme', options.context);
+  }
+};
+
+/** 에러 객체를 Sentry로 전송한다 */
+export const reportError = (error: unknown, options: ReportOptions): void => {
+  Sentry.withScope((sentryScope) => {
+    applyOptions(sentryScope, options);
+    Sentry.captureException(error);
+  });
+};
+
+/** 에러 객체 없이 상황만 알릴 때 사용한다 (조용한 폴백 노출 등) */
+export const reportMessage = (
+  message: string,
+  options: ReportOptions
+): void => {
+  Sentry.withScope((sentryScope) => {
+    applyOptions(sentryScope, options);
+    Sentry.captureMessage(message, options.level ?? 'warning');
+  });
+};
+
+/**
+ * 이벤트로 보내지 않고 흔적만 남긴다.
+ * 별도 quota를 소모하지 않으면서 이후 실제 이벤트에 맥락으로 첨부된다.
+ */
+export const addReportBreadcrumb = (breadcrumb: {
+  category: string;
+  message: string;
+  level?: SeverityLevel;
+  data?: ReportContext;
+}): void => {
+  Sentry.addBreadcrumb(breadcrumb);
+};

--- a/src/shared/monitoring/sampling.test.ts
+++ b/src/shared/monitoring/sampling.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  consumeSessionEventBudget,
+  createSessionCap,
+  resetSessionEventBudget,
+  SESSION_EVENT_BUDGET,
+  shouldSample,
+} from './sampling';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('shouldSample', () => {
+  it('rate가 1 이상이면 항상 true, 0 이하면 항상 false다', () => {
+    expect(shouldSample(1)).toBe(true);
+    expect(shouldSample(0)).toBe(false);
+    expect(shouldSample(-1)).toBe(false);
+  });
+
+  it('rate 미만의 난수일 때만 true다', () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0.05);
+    expect(shouldSample(0.1)).toBe(true);
+
+    vi.spyOn(Math, 'random').mockReturnValue(0.5);
+    expect(shouldSample(0.1)).toBe(false);
+  });
+});
+
+describe('createSessionCap', () => {
+  it('key별로 limit 횟수까지만 통과시킨다', () => {
+    const cap = createSessionCap(2);
+
+    expect(cap('a')).toBe(true);
+    expect(cap('a')).toBe(true);
+    expect(cap('a')).toBe(false);
+  });
+
+  it('key가 다르면 독립적으로 센다', () => {
+    const cap = createSessionCap(1);
+
+    expect(cap('a')).toBe(true);
+    expect(cap('b')).toBe(true);
+    expect(cap('a')).toBe(false);
+  });
+});
+
+describe('consumeSessionEventBudget', () => {
+  beforeEach(() => {
+    resetSessionEventBudget();
+  });
+
+  it('상한까지 통과시키고 이후에는 막는다', () => {
+    for (let i = 0; i < SESSION_EVENT_BUDGET; i += 1) {
+      expect(consumeSessionEventBudget()).toBe(true);
+    }
+
+    expect(consumeSessionEventBudget()).toBe(false);
+  });
+});

--- a/src/shared/monitoring/sampling.ts
+++ b/src/shared/monitoring/sampling.ts
@@ -1,0 +1,52 @@
+/**
+ * 이벤트 볼륨 제어 유틸
+ *
+ * 무료 플랜 quota를 지키기 위한 샘플링·상한 로직을 순수 함수로 모아둔다.
+ * (모듈 스코프 카운터를 쓰는 함수이므로 페이지 새로고침 시 초기화된다)
+ */
+
+/** rate(0~1) 확률로 true. 0 이하는 항상 false, 1 이상은 항상 true */
+export const shouldSample = (rate: number): boolean => {
+  if (rate >= 1) return true;
+  if (rate <= 0) return false;
+
+  return Math.random() < rate;
+};
+
+/**
+ * key별로 세션 내 최대 limit회까지만 통과시키는 게이트를 만든다.
+ * 같은 원인이 반복될 때 같은 이벤트가 수백 건 쌓이는 것을 막는다.
+ */
+export const createSessionCap = (limit: number) => {
+  const counts = new Map<string, number>();
+
+  return (key: string): boolean => {
+    const current = counts.get(key) ?? 0;
+    if (current >= limit) return false;
+
+    counts.set(key, current + 1);
+    return true;
+  };
+};
+
+/**
+ * 세션 전체 이벤트 상한
+ * 리렌더 루프 같은 에러 하나가 하루치 quota를 소진하는 것을 막는 마지막 방어선
+ * (Sentry 대시보드의 Spike Protection과 별개로 동작하는 클라이언트 측 1차 차단)
+ */
+export const SESSION_EVENT_BUDGET = 20;
+
+let sessionEventCount = 0;
+
+/** 세션 예산을 1 소비한다. 남아있으면 true, 소진됐으면 false */
+export const consumeSessionEventBudget = (): boolean => {
+  if (sessionEventCount >= SESSION_EVENT_BUDGET) return false;
+
+  sessionEventCount += 1;
+  return true;
+};
+
+/** 테스트 전용 — 세션 예산 카운터 초기화 */
+export const resetSessionEventBudget = () => {
+  sessionEventCount = 0;
+};

--- a/src/shared/monitoring/scope.ts
+++ b/src/shared/monitoring/scope.ts
@@ -1,0 +1,23 @@
+/**
+ * 모니터링 이벤트의 기능 도메인 스코프
+ *
+ * Sentry 이벤트에 `scope` 태그로 붙어 대시보드에서 영역별 필터링에 쓰인다.
+ * GA의 `GA_EVENTS`처럼 이 파일이 스코프 이름의 SSOT
+ */
+export const MONITORING_SCOPE = {
+  /** API 요청 실패 — 전역 핸들러가 붙이는 기본값 */
+  API: 'api',
+  /** 이미지 생성 플로우 */
+  IMAGE_GENERATE: 'imageGenerate',
+  /** 로그인·토큰 재발급 등 인증 */
+  AUTH: 'auth',
+  /** 이미지 에셋 로드 폴백 */
+  IMAGE_ASSET: 'imageAsset',
+  /** 인라인 에러 등 폴백 UI 노출 */
+  UI_FALLBACK: 'uiFallback',
+  /** GA·Clarity 등 계측 도구 자체의 실패 */
+  ANALYTICS: 'analytics',
+} as const;
+
+export type MonitoringScope =
+  (typeof MONITORING_SCOPE)[keyof typeof MONITORING_SCOPE];

--- a/src/shared/monitoring/scrub.test.ts
+++ b/src/shared/monitoring/scrub.test.ts
@@ -25,11 +25,12 @@ describe('redactUrl', () => {
     expect(redacted).toContain('env=prod');
   });
 
-  it('상품 검색어(keyword)를 가린다', () => {
-    const redacted = redactUrl('/api/products?keyword=내검색어&cursor=3');
+  // 가구 검색어는 개인정보가 아니고, 어떤 검색어에서 실패했는지가 원인 파악에 쓰인다.
+  // GA 이벤트로도 breadcrumb에 원문이 실리므로 URL에서만 가리면 오해를 부른다.
+  it('상품 검색어(keyword)는 가리지 않는다', () => {
+    const url = '/api/products?keyword=내검색어&cursor=3';
 
-    expect(redacted).not.toContain('내검색어');
-    expect(redacted).toContain('cursor=3');
+    expect(redactUrl(url)).toBe(url);
   });
 
   it('토큰 계열 파라미터를 가린다', () => {

--- a/src/shared/monitoring/scrub.test.ts
+++ b/src/shared/monitoring/scrub.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  redactBreadcrumb,
+  redactQueryString,
+  redactUrl,
+  scrubErrorEvent,
+} from './scrub';
+
+import type { Breadcrumb, ErrorEvent } from '@sentry/react';
+
+/**
+ * 보안 회귀 테스트
+ * 카카오 인가코드·검색어가 Sentry로 새어나가지 않는지 확인한다.
+ */
+describe('redactUrl', () => {
+  it('카카오 OAuth 인가코드(code)를 가린다', () => {
+    const redacted = redactUrl(
+      'https://api.houme.kr/oauth/kakao/callback?code=SECRET_AUTH_CODE&env=prod'
+    );
+
+    expect(redacted).not.toContain('SECRET_AUTH_CODE');
+    expect(redacted).toContain('[Filtered]');
+    // 민감하지 않은 파라미터는 유지돼야 디버깅이 가능하다
+    expect(redacted).toContain('env=prod');
+  });
+
+  it('상품 검색어(keyword)를 가린다', () => {
+    const redacted = redactUrl('/api/products?keyword=내검색어&cursor=3');
+
+    expect(redacted).not.toContain('내검색어');
+    expect(redacted).toContain('cursor=3');
+  });
+
+  it('토큰 계열 파라미터를 가린다', () => {
+    const redacted = redactUrl(
+      'https://api.houme.kr/x?accessToken=aaa&signupToken=bbb'
+    );
+
+    expect(redacted).not.toContain('aaa');
+    expect(redacted).not.toContain('bbb');
+  });
+
+  it('상대 경로도 처리하며 절대 URL로 바꾸지 않는다', () => {
+    const redacted = redactUrl('/oauth/kakao/callback?code=SECRET');
+
+    expect(redacted.startsWith('/oauth/kakao/callback')).toBe(true);
+    expect(redacted).not.toContain('SECRET');
+  });
+
+  it('민감 파라미터가 없으면 원본을 그대로 돌려준다', () => {
+    const url = 'https://api.houme.kr/api/v1/banners?size=10';
+
+    expect(redactUrl(url)).toBe(url);
+  });
+
+  it('파싱할 수 없는 값이나 빈 문자열에도 예외를 던지지 않는다', () => {
+    expect(redactUrl('')).toBe('');
+    expect(() => redactUrl('%%%not-a-url%%%')).not.toThrow();
+  });
+});
+
+describe('redactQueryString', () => {
+  it('query string 형태에서도 민감 값을 가린다', () => {
+    const redacted = redactQueryString('code=SECRET&env=prod');
+
+    expect(redacted).not.toContain('SECRET');
+    expect(redacted).toContain('env=prod');
+  });
+});
+
+describe('redactBreadcrumb', () => {
+  it('xhr breadcrumb의 url을 가린다', () => {
+    const breadcrumb: Breadcrumb = {
+      category: 'xhr',
+      data: { url: '/oauth/kakao/callback?code=SECRET' },
+    };
+
+    expect(redactBreadcrumb(breadcrumb).data?.url).not.toContain('SECRET');
+  });
+
+  it('navigation breadcrumb의 from/to를 가린다', () => {
+    const breadcrumb: Breadcrumb = {
+      category: 'navigation',
+      data: { from: '/login?code=AAA', to: '/callback?code=BBB' },
+    };
+
+    const { data } = redactBreadcrumb(breadcrumb);
+
+    expect(data?.from).not.toContain('AAA');
+    expect(data?.to).not.toContain('BBB');
+  });
+
+  it('data가 없는 breadcrumb에도 예외를 던지지 않는다', () => {
+    expect(() => redactBreadcrumb({ category: 'ui.click' })).not.toThrow();
+  });
+});
+
+describe('scrubErrorEvent', () => {
+  it('Authorization 헤더와 쿠키를 제거하고 URL을 가린다', () => {
+    const event = {
+      request: {
+        url: 'https://api.houme.kr/oauth/kakao/callback?code=SECRET',
+        headers: { Authorization: 'Bearer token', 'Content-Type': 'app/json' },
+        cookies: { refreshToken: 'secret' },
+        query_string: 'code=SECRET',
+      },
+    } as unknown as ErrorEvent;
+
+    const scrubbed = scrubErrorEvent(event);
+
+    expect(scrubbed.request?.headers?.Authorization).toBeUndefined();
+    expect(scrubbed.request?.headers?.['Content-Type']).toBe('app/json');
+    expect(scrubbed.request?.cookies).toBeUndefined();
+    expect(scrubbed.request?.url).not.toContain('SECRET');
+    expect(scrubbed.request?.query_string).not.toContain('SECRET');
+  });
+
+  it('request가 없는 이벤트에도 예외를 던지지 않는다', () => {
+    expect(() => scrubErrorEvent({} as ErrorEvent)).not.toThrow();
+  });
+});

--- a/src/shared/monitoring/scrub.ts
+++ b/src/shared/monitoring/scrub.ts
@@ -1,0 +1,127 @@
+import type { Breadcrumb, ErrorEvent } from '@sentry/react';
+
+/**
+ * 개인정보·자격증명 스크럽
+ *
+ * Sentry는 요청 URL과 breadcrumb를 자동으로 수집하는데, 하우미는 카카오 인가코드를
+ * 쿼리 파라미터로 보내고(`/oauth/kakao/callback?code=...`) 상품 검색어도 URL에 실린다.
+ * 헤더·쿠키만 지우는 것(기존 scrub)으로는 부족해서 URL 계열을 전부 이 모듈에서 걸러낸다.
+ */
+
+/** 값이 노출되면 안 되는 쿼리 파라미터 키 (소문자로 비교) */
+const SENSITIVE_QUERY_KEYS = new Set([
+  'code', // 카카오 OAuth 인가코드
+  'token',
+  'accesstoken',
+  'access-token',
+  'refreshtoken',
+  'refresh-token',
+  'signuptoken',
+  'id_token',
+  'keyword', // 상품 검색어 (사용자 입력)
+  'q',
+  'email',
+  'phone',
+]);
+
+const REDACTED = '[Filtered]';
+/** 상대 경로도 URL로 파싱하기 위한 임시 base (외부로 나가지 않는 값) */
+const RELATIVE_URL_BASE = 'https://redacted.invalid';
+/** searchParams.set이 인코딩한 대괄호를 되돌려 가독성을 유지 */
+const ENCODED_REDACTED = /%5BFiltered%5D/g;
+
+const isSensitiveKey = (key: string) =>
+  SENSITIVE_QUERY_KEYS.has(key.toLowerCase());
+
+/**
+ * URL을 받아 민감한 쿼리 파라미터 값을 [Filtered]로 치환한다.
+ * 파싱할 수 없거나 치환 대상이 없으면 원본을 그대로 돌려준다.
+ *
+ * redact: 문서에서 민감한 부분을 가리는 것
+ */
+export const redactUrl = (rawUrl: string): string => {
+  if (!rawUrl) return rawUrl;
+
+  try {
+    const isAbsolute = /^[a-z][a-z0-9+.-]*:/i.test(rawUrl);
+    const url = new URL(rawUrl, RELATIVE_URL_BASE);
+
+    const sensitiveKeys = [...url.searchParams.keys()].filter(isSensitiveKey);
+    if (sensitiveKeys.length === 0) return rawUrl;
+
+    sensitiveKeys.forEach((key) => url.searchParams.set(key, REDACTED));
+
+    const redacted = isAbsolute
+      ? url.toString()
+      : `${url.pathname}${url.search}${url.hash}`;
+
+    return redacted.replace(ENCODED_REDACTED, REDACTED);
+  } catch {
+    return rawUrl;
+  }
+};
+
+/** `?a=1&code=xxx` 형태의 query string을 받아 민감 값을 찾고 치환한다 */
+export const redactQueryString = (queryString: string): string => {
+  if (!queryString) return queryString;
+
+  try {
+    const params = new URLSearchParams(queryString);
+
+    const sensitiveKeys = [...params.keys()].filter(isSensitiveKey);
+    if (sensitiveKeys.length === 0) return queryString;
+
+    sensitiveKeys.forEach((key) => params.set(key, REDACTED));
+
+    return params.toString().replace(ENCODED_REDACTED, REDACTED);
+  } catch {
+    return queryString;
+  }
+};
+
+/** breadcrumb 객체를 받아 URL 계열 데이터의 민감 파라미터를 제거한다 */
+export const redactBreadcrumb = (breadcrumb: Breadcrumb): Breadcrumb => {
+  const data = breadcrumb.data;
+  if (!data) return breadcrumb;
+
+  // xhr/fetch는 url, navigation은 from/to에 URL이 담긴다
+  (['url', 'from', 'to'] as const).forEach((key) => {
+    const value = data[key];
+    if (typeof value === 'string') {
+      data[key] = redactUrl(value);
+    }
+  });
+
+  return breadcrumb;
+};
+
+/** 에러 이벤트 객체를 받아 토큰·민감헤더·쿠키·URL 파라미터를 제거한다 */
+export const scrubErrorEvent = (event: ErrorEvent): ErrorEvent => {
+  const request = event.request;
+
+  if (request) {
+    const headers = request.headers;
+    if (headers) {
+      delete headers['Authorization'];
+      delete headers['authorization'];
+    }
+
+    // withCredentials: true라 쿠키에 refresh token이 있을 수 있어 통째로 제거
+    if (request.cookies) {
+      delete request.cookies;
+    }
+
+    if (typeof request.url === 'string') {
+      request.url = redactUrl(request.url);
+    }
+
+    if (typeof request.query_string === 'string') {
+      request.query_string = redactQueryString(request.query_string);
+    }
+  }
+
+  // beforeBreadcrumb를 거치지 않고 이벤트에 직접 붙은 breadcrumb도 한 번 더 확인
+  event.breadcrumbs?.forEach(redactBreadcrumb);
+
+  return event;
+};

--- a/src/shared/monitoring/scrub.ts
+++ b/src/shared/monitoring/scrub.ts
@@ -4,11 +4,17 @@ import type { Breadcrumb, ErrorEvent } from '@sentry/react';
  * 개인정보·자격증명 스크럽
  *
  * Sentry는 요청 URL과 breadcrumb를 자동으로 수집하는데, 하우미는 카카오 인가코드를
- * 쿼리 파라미터로 보내고(`/oauth/kakao/callback?code=...`) 상품 검색어도 URL에 실린다.
+ * 쿼리 파라미터로 보낸다(`/oauth/kakao/callback?code=...`).
  * 헤더·쿠키만 지우는 것(기존 scrub)으로는 부족해서 URL 계열을 전부 이 모듈에서 걸러낸다.
  */
 
-/** 값이 노출되면 안 되는 쿼리 파라미터 키 (소문자로 비교) */
+/**
+ * 값이 노출되면 안 되는 쿼리 파라미터 키 (소문자로 비교)
+ *
+ * 상품 검색어(`keyword`, `q`)는 **의도적으로 넣지 않는다.** 가구 검색어는 개인정보가 아니고,
+ * "어떤 검색어에서 에러가 나는가"가 원인 파악에 직접 쓰인다. GA 이벤트로도 원문이
+ * breadcrumb에 실리므로 여기서 막으면 같은 값이 한쪽만 가려져 오해를 부른다.
+ */
 const SENSITIVE_QUERY_KEYS = new Set([
   'code', // 카카오 OAuth 인가코드
   'token',
@@ -18,8 +24,6 @@ const SENSITIVE_QUERY_KEYS = new Set([
   'refresh-token',
   'signuptoken',
   'id_token',
-  'keyword', // 상품 검색어 (사용자 입력)
-  'q',
   'email',
   'phone',
 ]);

--- a/src/store/imageFlow/buildGenerateRequest.test.ts
+++ b/src/store/imageFlow/buildGenerateRequest.test.ts
@@ -1,7 +1,18 @@
 import { describe, expect, it } from 'vitest';
 
-import { buildGenerateRequest, type FunnelData } from './buildGenerateRequest';
+import {
+  buildGenerateRequest,
+  GENERATE_INVALID_REASON,
+  type FunnelData,
+  type GenerateInvalidReason,
+} from './buildGenerateRequest';
 import { FLOW_CONFIG, type ImageFlow } from './flowConfig';
+
+/** invalid 결과에서 reason만 꺼낸다 (아니면 테스트가 실패해야 하므로 undefined 반환) */
+const reasonOf = (
+  plan: ReturnType<typeof buildGenerateRequest>
+): GenerateInvalidReason | undefined =>
+  plan.kind === 'invalid' ? plan.reason : undefined;
 
 const validFloorPlan = {
   floorPlanId: 1,
@@ -200,6 +211,115 @@ describe('buildGenerateRequest - invalid 케이스', () => {
       phase: 'funnel',
     } as unknown as ImageFlow;
     expect(buildGenerateRequest(flow, fullFunnelData).kind).toBe('invalid');
+  });
+});
+
+// invalid는 전부 같은 값이라 "생성 버튼을 눌렀는데 홈으로 튕겼다"의 원인을 알 수 없었다.
+// reason이 원인별로 갈리는지 확인한다 — Sentry에서 이 값으로 이슈를 나눈다.
+describe('buildGenerateRequest - invalid reason', () => {
+  const fullFunnelFlow: ImageFlow = {
+    route: 'GENERATE_BUTTON',
+    phase: 'postFunnel',
+  };
+
+  it('flow가 null이면 noFlow, route는 null', () => {
+    const plan = buildGenerateRequest(null, fullFunnelData);
+
+    expect(reasonOf(plan)).toBe(GENERATE_INVALID_REASON.NO_FLOW);
+    if (plan.kind === 'invalid') expect(plan.route).toBeNull();
+  });
+
+  it('도면 손상은 invalidFloorPlan', () => {
+    expect(
+      reasonOf(
+        buildGenerateRequest(fullFunnelFlow, {
+          ...fullFunnelData,
+          floorPlan: null,
+        })
+      )
+    ).toBe(GENERATE_INVALID_REASON.INVALID_FLOOR_PLAN);
+  });
+
+  // 풀퍼널은 어느 스텝의 입력이 사라졌는지 구분돼야 원인 추적이 된다
+  it('풀퍼널 입력은 무드보드·활동·가구를 따로 구분한다', () => {
+    expect(
+      reasonOf(
+        buildGenerateRequest(fullFunnelFlow, {
+          ...fullFunnelData,
+          moodBoardIds: null,
+        })
+      )
+    ).toBe(GENERATE_INVALID_REASON.INVALID_MOOD_BOARD_IDS);
+
+    expect(
+      reasonOf(
+        buildGenerateRequest(fullFunnelFlow, {
+          ...fullFunnelData,
+          activityInfo: { furnitureIds: [1] },
+        })
+      )
+    ).toBe(GENERATE_INVALID_REASON.INVALID_ACTIVITY);
+
+    expect(
+      reasonOf(
+        buildGenerateRequest(fullFunnelFlow, {
+          ...fullFunnelData,
+          activityInfo: { activity: 'REST' },
+        })
+      )
+    ).toBe(GENERATE_INVALID_REASON.INVALID_FURNITURE_IDS);
+  });
+
+  it('배너·스타일·상품 경로도 각각 구분된다', () => {
+    const bannerFlow = {
+      route: 'HOME_BANNER',
+      phase: 'postFunnel',
+      bannerId: 1.5,
+      answerId: 2,
+    } as unknown as ImageFlow;
+    expect(reasonOf(buildGenerateRequest(bannerFlow, shortFunnelData))).toBe(
+      GENERATE_INVALID_REASON.INVALID_BANNER_REF
+    );
+
+    const styleFlow = {
+      route: 'STYLE_RESTYLE',
+      phase: 'postFunnel',
+      styleId: null,
+    } as unknown as ImageFlow;
+    expect(reasonOf(buildGenerateRequest(styleFlow, shortFunnelData))).toBe(
+      GENERATE_INVALID_REASON.INVALID_STYLE_REF
+    );
+
+    const productFlow: ImageFlow = {
+      route: 'PRODUCT_SELECTION',
+      phase: 'postFunnel',
+      isRegenerate: false,
+      productIds: [],
+      productsToBeRestored: null,
+    };
+    expect(reasonOf(buildGenerateRequest(productFlow, shortFunnelData))).toBe(
+      GENERATE_INVALID_REASON.INVALID_PRODUCT_IDS
+    );
+  });
+
+  it('알 수 없는 route는 unknownRoute', () => {
+    const flow = {
+      route: 'UNKNOWN_ROUTE',
+      phase: 'funnel',
+    } as unknown as ImageFlow;
+
+    expect(reasonOf(buildGenerateRequest(flow, fullFunnelData))).toBe(
+      GENERATE_INVALID_REASON.UNKNOWN_ROUTE
+    );
+  });
+
+  it('route가 있으면 invalid에도 함께 담는다', () => {
+    const plan = buildGenerateRequest(fullFunnelFlow, {
+      ...fullFunnelData,
+      floorPlan: null,
+    });
+
+    if (plan.kind === 'invalid') expect(plan.route).toBe('GENERATE_BUTTON');
   });
 });
 

--- a/src/store/imageFlow/buildGenerateRequest.ts
+++ b/src/store/imageFlow/buildGenerateRequest.ts
@@ -14,13 +14,49 @@ export interface FunnelData {
   activityInfo: { activity?: string; furnitureIds?: number[] } | null;
 }
 
+/**
+ * 생성 요청을 만들지 못한 이유
+ *
+ * 이 값이 없으면 "생성 버튼을 눌렀는데 홈으로 튕겼다"의 원인을 알 수 없다.
+ * 서버 입장에서는 요청이 오지 않았으므로 서버 로그에도 흔적이 없다.
+ * LoadingPage가 이 값을 Sentry fingerprint로 써서 원인별로 이슈를 나눈다.
+ */
+export const GENERATE_INVALID_REASON = {
+  /** 진입 경로 정보가 사라짐 (sessionStorage 유실) */
+  NO_FLOW: 'noFlow',
+  /** 도면 값이 손상됨 — 모든 경로에 필수 */
+  INVALID_FLOOR_PLAN: 'invalidFloorPlan',
+  /** 풀퍼널 — 무드보드 선택값이 손상됨 */
+  INVALID_MOOD_BOARD_IDS: 'invalidMoodBoardIds',
+  /** 풀퍼널 — 주요활동 선택값이 손상됨 */
+  INVALID_ACTIVITY: 'invalidActivity',
+  /** 풀퍼널 — 가구 선택값이 손상됨 */
+  INVALID_FURNITURE_IDS: 'invalidFurnitureIds',
+  /** 배너 경로 — bannerId/answerId가 손상됨 */
+  INVALID_BANNER_REF: 'invalidBannerRef',
+  /** 스타일 경로 — styleId가 손상됨 */
+  INVALID_STYLE_REF: 'invalidStyleRef',
+  /** 상품 경로 — productIds가 손상됐거나 개수가 1~6 범위를 벗어남 */
+  INVALID_PRODUCT_IDS: 'invalidProductIds',
+  /** 알 수 없는 route가 복원됨 (컴파일 타임엔 도달 불가) */
+  UNKNOWN_ROUTE: 'unknownRoute',
+} as const;
+
+export type GenerateInvalidReason =
+  (typeof GENERATE_INVALID_REASON)[keyof typeof GENERATE_INVALID_REASON];
+
 // 어떤 이미지 생성 API를 어떤 payload로 부를지 담은 결과 (실제 mutate 연결은 훅에서 함)
 export type GenerateRequestPlan =
   | { kind: 'fullFunnel'; payload: GenerateImageV4Request }
   | { kind: 'banner'; payload: BannerGenerateImageRequest }
   | { kind: 'otherStyle'; payload: OtherStyleGenerateImageRequest }
   | { kind: 'product'; payload: ProductGenerateImageRequest }
-  | { kind: 'invalid' };
+  | {
+      kind: 'invalid';
+      reason: GenerateInvalidReason;
+      /** 어느 진입 경로에서 실패했는지. flow 자체가 없으면 null */
+      route: ImageFlow['route'] | null;
+    };
 
 const isFloorPlanValid = (
   floorPlan: unknown
@@ -50,24 +86,41 @@ export const buildGenerateRequest = (
   flow: ImageFlow | null,
   funnel: FunnelData
 ): GenerateRequestPlan => {
-  if (!flow) return { kind: 'invalid' };
+  if (!flow) {
+    return {
+      kind: 'invalid',
+      reason: GENERATE_INVALID_REASON.NO_FLOW,
+      route: null,
+    };
+  }
 
   const { floorPlan, moodBoardIds, activityInfo } = funnel;
+  // 이 아래로는 route가 확정돼 있으므로 invalid에 매번 같이 담는다
+  const invalid = (reason: GenerateInvalidReason): GenerateRequestPlan => ({
+    kind: 'invalid',
+    reason,
+    route: flow.route,
+  });
 
   // 도면(floorPlan)은 모든 생성 요청에 반드시 필요
-  if (!isFloorPlanValid(floorPlan)) return { kind: 'invalid' };
+  if (!isFloorPlanValid(floorPlan)) {
+    return invalid(GENERATE_INVALID_REASON.INVALID_FLOOR_PLAN);
+  }
 
   switch (flow.route) {
     case 'GENERATE_BUTTON':
     case 'FLOOR_PLAN': {
       const activity = activityInfo?.activity;
       const furnitureIds = activityInfo?.furnitureIds;
-      if (
-        !isIntegerArray(moodBoardIds) ||
-        typeof activity !== 'string' ||
-        !isIntegerArray(furnitureIds)
-      ) {
-        return { kind: 'invalid' };
+      // 세 값을 따로 판별한다 — 어느 스텝의 입력이 사라졌는지 알아야 원인 추적이 된다
+      if (!isIntegerArray(moodBoardIds)) {
+        return invalid(GENERATE_INVALID_REASON.INVALID_MOOD_BOARD_IDS);
+      }
+      if (typeof activity !== 'string') {
+        return invalid(GENERATE_INVALID_REASON.INVALID_ACTIVITY);
+      }
+      if (!isIntegerArray(furnitureIds)) {
+        return invalid(GENERATE_INVALID_REASON.INVALID_FURNITURE_IDS);
       }
       return {
         kind: 'fullFunnel',
@@ -86,7 +139,7 @@ export const buildGenerateRequest = (
         !Number.isInteger(flow.bannerId) ||
         !Number.isInteger(flow.answerId)
       ) {
-        return { kind: 'invalid' };
+        return invalid(GENERATE_INVALID_REASON.INVALID_BANNER_REF);
       }
       return {
         kind: 'banner',
@@ -100,7 +153,9 @@ export const buildGenerateRequest = (
       };
     }
     case 'STYLE_RESTYLE': {
-      if (!Number.isInteger(flow.styleId)) return { kind: 'invalid' };
+      if (!Number.isInteger(flow.styleId)) {
+        return invalid(GENERATE_INVALID_REASON.INVALID_STYLE_REF);
+      }
       return {
         kind: 'otherStyle',
         payload: {
@@ -118,7 +173,7 @@ export const buildGenerateRequest = (
         flow.productIds.length < 1 ||
         flow.productIds.length > 6
       ) {
-        return { kind: 'invalid' };
+        return invalid(GENERATE_INVALID_REASON.INVALID_PRODUCT_IDS);
       }
       return {
         kind: 'product',
@@ -132,6 +187,6 @@ export const buildGenerateRequest = (
     }
     default:
       // sessionStorage 손상 등으로 알 수 없는 route가 복원된 경우 방어 (컴파일 타임엔 도달 불가)
-      return { kind: 'invalid' };
+      return invalid(GENERATE_INVALID_REASON.UNKNOWN_ROUTE);
   }
 };

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -8,6 +8,8 @@ interface ImportMetaEnv {
   readonly VITE_SENTRY_DSN?: string;
   readonly VITE_SENTRY_ENVIRONMENT?: string;
   readonly VITE_SENTRY_RELEASE?: string;
+  /** 'true'면 로컬(DEV)에서도 Sentry로 실제 전송한다 (기본은 dry-run) */
+  readonly VITE_SENTRY_FORCE_ENABLE?: string;
   readonly VITE_CLARITY_PROJECT_ID?: string;
   readonly VITE_CURATION_OUTBOUND_UTM_QUERY?: string;
   readonly VITE_CURATION_DETECTION_MODE?: 'server' | 'client';


### PR DESCRIPTION
close #636

출시 후 Sentry를 운영하며 로깅 관련 코드를 확인해보니 **앱이 성공적으로 복구한 에러는 Sentry로 보내지 않고 있었습니다.**

- `handleGlobalError`가 모든 query/mutation 에러의 종착지인데 `SESSION_EXPIRED`만 처리하고 나머지를 버리고 있었음
- TanStack Query가 catch한 에러는 처리되지 않은 예외가 아니라 `ErrorBoundary`에도 `window.onerror`에도 걸리지 않음
- 우회 경로(`throwOnError`, `useSuspenseQuery`, route `loader`)도 전부 0건이라 빠져나갈 구멍 X

=> 주요 API에서 에러가 발생했을 때 Sentry에 잡히도록, 그리고 실행 환경·사용자 행동 맥락·서버에 도달하지 못한 실패와 같이 서버에서 재구성할 수 없는 로그를 프론트단에서 잡을 수 있도록 수정했습니다.

이 PR에서는 기존 Sentry 문제를 해결할 수 있도록, 서버에서 재구성할 수 없는 로그를 프론트에서 잡을 수 있도록 다섯 가지를 처리합니다 — **노이즈 차단**, **개인정보 제거**, **전역 API 에러 수집**, **사용자 행동 맥락 부착**, **이미지 생성 정지·요청 실패 감지**. 커밋 5개로 나눠져 있고 순서대로 읽으면 됩니다.

---

## 문제 상황

### 1. 앱이 잡은 API 에러가 Sentry로 가지 않습니다 (근본 원인)

`globalErrorHandler.ts`의 `handleGlobalError`가 이렇게 되어 있었습니다.

```ts
export const handleGlobalError = (error: unknown) => {
  if (import.meta.env.DEV) console.error('[QueryClient Error]', error);
  if (isSessionExpiredError(error)) handleSessionExpired();
};
```

프로덕션에서는 `SESSION_EXPIRED`가 아닌 모든 실패가 아무 흔적 없이 사라집니다. 서버가 500을 주든 요청이 타임아웃되든 와이파이가 끊기든 동일합니다.

앱 전체에서 `Sentry.captureException` 호출은 `RouteErrorFallback.tsx` 한 곳뿐이었고, 그건 라우트 단위 에러(청크 로드 실패)만 잡습니다.

### 2. 인스타그램 인앱브라우저 노이즈가 신호를 덮고 있습니다

`HOUME-CLIENT-F` 이슈가 367건입니다. 스택이 `/landing:1:1142 (sendDataToNative)`인데 `sendDataToNative`는 레포에 없는 함수입니다. 인스타그램이 페이지에 끼워 넣은 스크립트입니다.

②는 ①의 결과는 아니지만, ①을 고치면 악화됩니다. 진짜 에러를 보내기 시작해도 367건 속에 묻힙니다.

### 3. 카카오 인가코드가 Sentry로 나갈 수 있습니다

`useKakaoLoginMutation.ts:38`이 `query: { code, env }`로 요청합니다. 주소에 인가코드가 실리고 Sentry는 `request.url`과 xhr breadcrumb을 자동 수집합니다. 기존 스크럽은 `Authorization` 헤더와 쿠키만 지웠습니다.

③도 ①을 고치면 악화됩니다. 전송 이벤트가 늘면 인가코드가 실린 이벤트도 같이 늘어납니다.

<details>
<summary><b>4. 이미지 생성이 100%에서 멈추면 빠져나올 수 없습니다</b></summary>

`ProgressBar.tsx`가 100%에 도달하면 `doneRef`로 완료를 한 번만 처리합니다.

```
ProgressBar: progress 100 도달 → doneRef.current = true → onComplete 호출
LoadingPage: if (!navigationData || !isApiCompleted) return;   ← 조용히 빠져나감
```

`doneRef`가 이미 서 있어서 `onComplete`는 다시 호출되지 않습니다. 사용자는 100%를 보며 무한 대기합니다.

나가려면 이탈 팝업을 통과해야 하는데, `exit`이 `abandonFlow()`를 실행해 퍼널 입력을 전부 삭제합니다. 크레딧은 이미 소모된 상태입니다.

`isApiCompleted`가 오지 않는 경우에는 90%에서 멈춥니다. 타임아웃이 없습니다.

**실제로 발생했으나 재현되지 않았습니다.** 아무 이벤트도 만들어지지 않아 기록될 것이 없었기 때문입니다.

</details>

<details>
<summary><b>5. 생성 요청이 안 나가고 홈으로 튕기는 원인을 구분할 수 없습니다</b></summary>

`buildGenerateRequest.ts`가 `{ kind: 'invalid' }`를 반환하는 지점이 7곳인데 전부 같은 값이었습니다.

사용자는 퍼널 3스텝을 다 밟고 CTA를 눌렀는데, 에러 화면도 없이 홈으로 이동합니다. 서버 입장에서는 요청이 온 적이 없어 서버 로그에도 흔적이 없습니다.

</details>

---

## 해결 방법

### 관심사별 소유자

| 관심사 | 소유 파일 | 하는 일 |
| --- | --- | --- |
| 노이즈 판별 | `monitoring/noiseFilter.ts` | 메시지 7종·주소 5종 차단, 끼워 넣은 스크립트 표시 |
| 개인정보 제거 | `monitoring/scrub.ts` | URL·breadcrumb에서 인가코드·토큰 제거 |
| 볼륨 제어 | `monitoring/sampling.ts` | 샘플링, 한 번 페이지를 연 동안 최대 20건 |
| 에러 분류 | `monitoring/classifyApiError.ts` | 실패를 7종으로 판별 |
| 전송 정책 | `monitoring/apiReportPolicy.ts` | 종류별 전송 여부와 fingerprint |
| 전송 실행 | `monitoring/report.ts` | Sentry 호출, 개인정보 타입 제약 |
| 배선 | `apis/config/globalErrorHandler.ts` | 캡처 지점 1곳으로 고정 |
| 정지 감지 | `loading/hooks/useGenerateStallWatchdog.ts` | 시간 기준 판정 + 홈 복구 |
| 원인 판별 | `store/imageFlow/buildGenerateRequest.ts` | invalid 9종 구분 (순수 함수) |
| 행동 맥락 | `analytics/track.ts` | GA 이벤트를 breadcrumb으로 |
| 화면 맥락 | `hooks/useSentrySync.ts` | 화면·진입경로 태그 |

### 캡처 지점을 한 곳으로 고정하고, 정책은 훅이 선언합니다

각 페이지에서 Sentry를 부르면 같은 에러가 두 번 가거나 새 API를 만들 때 빠뜨립니다. 그래서 `handleGlobalError` 한 곳에서만 보내고, 예외가 필요한 요청은 TanStack Query의 `meta`로 선언합니다.

```ts
// 앱 부팅 시 미리 불러오는 4개 — 실패해도 사용자 영향이 없어 보내지 않음
meta: { sentry: { scope: MONITORING_SCOPE.API, capture: 'never' } }

// 이미지 생성 mutation 4개 — 실패 시 도메인 식별
meta: { sentry: { scope: MONITORING_SCOPE.IMAGE_GENERATE } }
```

`LoadingPage`에는 Sentry 호출이 한 줄도 없습니다.

### 무엇을 보내고 무엇을 버리는지

| 실패 종류 | 전송 | 근거 |
| --- | --- | --- |
| 5xx | 20% | 서버에서 이미 수집 중이라 표본만 필요 |
| 타임아웃 | 전량 | 서버에 요청이 닿지 않아 서버 로그에 없음 |
| 네트워크 끊김 | 조회 10%, 저장·전송 100% | 저장 실패는 사용자 행동이 사라진 것 |
| 4xx | allowlist만 | 크레딧 초과·중복 요청은 정상 흐름 |
| 세션 만료·요청 취소 | 미전송 | 정상 동작 |

전송하지 않기로 한 실패도 breadcrumb으로는 남깁니다. 추가 사용량 없이 "직전에 어떤 API가 어떻게 실패했는지"가 다음 이벤트에 붙습니다.

### 이미 있는 GA 계측을 재사용합니다

Sentry 기본 breadcrumb은 쓸모가 없었습니다. `navigation`은 원시 경로만 담아 퍼널 스텝(`?image-generation-funnel.step=`)을 구분 못 하고, `ui.click`은 vanilla-extract가 만든 `_1ugrehr0` 같은 클래스명이라 어떤 버튼인지 알 수 없습니다.

`track.ts`의 `trackEvent` 한 곳에 breadcrumb을 추가했습니다. `roomTypeAnalytics.ts` 41개를 비롯해 퍼널 CTA가 전부 계측돼 있어서, 새로 심을 것 없이 사용자 행동 기록이 생깁니다.

GA가 꺼졌거나 Firebase 초기화가 실패한 환경에서도 쌓이도록 early return보다 위에 뒀습니다. 관측이 가장 필요한 순간이 그때입니다.

### 개인정보는 타입으로 막습니다

`report.ts`의 컨텍스트 파라미터가 문자열·숫자·불린만 받습니다.

```ts
export type ReportContext = Record<string, string | number | boolean | null | undefined>;
```

응답 바디나 폼 값을 통째로 넣는 실수가 컴파일 단계에서 거부됩니다. `mutation.variables`(회원가입 닉네임·생년월일·인증 토큰)는 첨부하지 않고, `queryKey`는 앞 2개 세그먼트만 씁니다.

상품 검색어는 **의도적으로 가리지 않습니다.** 가구 검색어는 개인정보가 아니고 어떤 검색어에서 실패했는지가 원인 파악에 직접 쓰입니다.

---

## 리뷰 포인트

### 먼저 볼 것

- `src/shared/apis/config/globalErrorHandler.ts` — 유일한 캡처 지점입니다. 분류 → breadcrumb → 정책 판단 → 전송 순서
- `src/shared/monitoring/apiReportPolicy.ts` — 위 정책 표가 코드로 있는 곳. 샘플링 비율 판단을 봐주세요
- `src/shared/config/sentry.ts` — 노이즈 차단·스크럽·dry-run이 연결되는 곳

### 로직이 변경돼 확인이 필요한 곳

- `src/store/imageFlow/buildGenerateRequest.ts` — `invalid` 타입에 `reason`·`route`를 추가했습니다. 풀퍼널 검사를 무드보드·활동·가구 3개로 나눴는데 판정 결과 자체는 동일합니다
- `src/pages/generate/v2/pages/loading/LoadingPage.tsx` — 정지 시 홈으로 복구하는 동작이 새로 생겼습니다. 판정 시간은 진행바 예상 소요의 3배(81초)입니다
- `src/shared/hooks/useSentrySync.ts` — `useLayoutEffect`를 씁니다. `useEffect`면 첫 렌더 이벤트에 태그가 안 붙습니다(아래 검증 참고)
- `src/shared/monitoring/scrub.ts` — `keyword`·`q`를 민감 키에서 뺐습니다

### 가볍게 봐도 되는 것

- `monitoring/scope.ts`, `monitoring/queryMeta.ts` — 상수와 타입 선언
- `useGenerate*ImageMutation.ts` 4개 — `meta` 한 줄씩
- 테스트 파일 6개
- `analytics/params/types.ts` — 주석 한 줄

---

## 검증

**실행한 명령**

```bash
pnpm exec tsc -b          # 통과
pnpm exec eslint .        # 에러 0 (경고 11개는 기존 파일)
pnpm exec vitest run --project unit
pnpm build                # 통과
```

**추가한 테스트 94개**

- `monitoring/` 57개 — 판별 순서 7단계, 전송 정책, 스크럽, 노이즈 필터, 샘플링
- `buildGenerateRequest.test.ts` 26개 — `invalid` 9종 원인이 각각 구분되는지
- `globalErrorHandler.test.ts` 11개 — 5xx는 보내고 404는 안 보내는지, queryKey에서 검색어가 안 새는지

`scrub.test.ts`는 보안 회귀 테스트로 유지합니다. `?code=SECRET_AUTH_CODE`를 넣고 결과에 그 값이 없는지 확인합니다.

**로컬 dry-run 실측**

`beforeSend`에서 전송 대신 콘솔에 출력하는 모드를 넣어 확인했습니다. 여기서 **태그 누락 버그를 배포 전에 잡았습니다.**

React가 자식의 `useEffect`를 부모보다 먼저 실행해서, `RootLayout`이 태그를 붙이기 전에 `useGenerateImageRequest`의 `invalid`가 전송되고 있었습니다. 맥락이 가장 필요한 이벤트가 맥락 없이 나가는 상태였습니다. `useLayoutEffect`로 바꿔 해결했고 마지막 커밋에 있습니다.

수정 후 실측 결과입니다.

```
message:  "image generate request invalid"
contexts.houme: { reason: 'invalidFloorPlan', route: 'GENERATE_BUTTON' }
fingerprint:    ['generate-invalid', 'invalidFloorPlan']
tags:     screen_name: "loadImg", login_status: "logged_in",
          ab_variant: "B", image_entry_route: "top_nav", scope: "imageGenerate"
```

**검증의 한계**

- **GA breadcrumb이 실제로 붙는지 확인하지 못했습니다.** 로컬은 GA 전송이 꺼져 있고, `invalid`는 새로고침 후에 발생하는데 새로고침하면 breadcrumb이 초기화됩니다. 배포 후 확인해야 합니다
- 정지 감지가 실제 정지 상황에서 발동하는지 확인하지 못했습니다. 재현되지 않는 버그라 인위적 재현이 어렵습니다
- 노이즈 367건이 실제로 멈추는지는 배포 후 확인 항목입니다
- 기존 테스트 4개(`usePostSignupMutation` 3, `useKakaoLoginMutation` 1)가 실패합니다. 이 PR 이전부터 실패하던 것으로, `git stash`로 확인했습니다

---

## 이번 PR에서 안 한 것

- **`Sentry.setUser` 보류** — `useClaritySync.ts:15`에 "개인 식별은 하지 않는다(개인정보처리방침과 정합)"가 이미 적혀 있습니다. 방침에 내부 식별자 저장이 가능한지 확인 후 결정합니다. 그때까지 이슈별 영향 유저 수는 0으로 표시됩니다
- **`release: houme-client@0.0.0`** — `package.json` 버전이 `0.0.0`이라 배포별 회귀 추적이 안 됩니다
- **정지 시 알림 문구** — 기존 생성 실패 토스트를 재사용했습니다. 크레딧이 소모된 상태를 알릴지는 기획 확인이 필요합니다
- **샘플링 값** — 5xx 20%, 네트워크 조회 10%, 401·403 10%. 근거가 약하고 배포 후 실제 유입량을 보고 조정할 예정입니다
- **`useExitBlocker`의 `Invalid blocker state transition`** — Sentry가 이미 잡은 실버그지만 로깅과 무관해 별도로 처리합니다
- **다음 작업** — 클라이언트 저장소 손상 계측(`localStorage` 접근 실패로 앱이 흰 화면이 되는 지점), 폴백 UI 노출 계측(`InlineError` 12곳)
