### PR TITLE
[chore] Label 및 Assignee 자동화 

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # CODEOWNERS 파일
 # 이 파일은 GitHub에서 자동으로 코드 리뷰어를 지정하는 데 사용됩니다.
-@jstar000 @earl9rey @soyyyyy
+* @jstar000 @earl9rey @soyyyyy

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,50 @@
+version: 1
+labels:
+  - label: '⚙️ Setting'
+    title: '(?i)^\[?(chore|setting|config)\]?([(:\s]|$)'
+  - label: '⚙️ Setting'
+    branch: '(?i)^(chore|setting|config)/'
+
+  - label: '🌐 Deploy'
+    title: '(?i)^\[?(deploy|release)\]?([(:\s]|$)'
+  - label: '🌐 Deploy'
+    branch: '(?i)^(deploy|release)/'
+
+  - label: '🎨 Style'
+    title: '(?i)^\[?(style|format|prettier)\]?([(:\s]|$)'
+  - label: '🎨 Style'
+    branch: '(?i)^(style|format|prettier)/'
+
+  - label: '💫 Feature'
+    title: '(?i)^\[?(feat|feature)\]?([(:\s]|$)'
+  - label: '💫 Feature'
+    branch: '(?i)^(feat|feature)/'
+
+  - label: '📄 Docs'
+    title: '(?i)^\[?docs?\]?([(:\s]|$)'
+  - label: '📄 Docs'
+    branch: '(?i)^docs?/'
+
+  - label: '🔧 Fix'
+    title: '(?i)^\[?(fix|hotfix|bugfix)\]?([(:\s]|$)'
+  - label: '🔧 Fix'
+    branch: '(?i)^(fix|hotfix|bugfix)/'
+
+  - label: '🛠️ Refactor'
+    title: '(?i)^\[?refactor\]?([(:\s]|$)'
+  - label: '🛠️ Refactor'
+    branch: '(?i)^refactor/'
+
+  - label: '🧪 Test'
+    title: '(?i)^\[?tests?\]?([(:\s]|$)'
+  - label: '🧪 Test'
+    branch: '(?i)^tests?/'
+
+  - label: '🤙 성하'
+    authors: ['earl9rey']
+
+  - label: '🤙 소이'
+    authors: ['soyyyyy']
+
+  - label: '🤙 지성'
+    authors: ['jstar000']

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -1,0 +1,45 @@
+name: Auto Assign
+
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review]
+  issues:
+    types: [opened, reopened]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number }}
+  cancel-in-progress: true
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  assign-author:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Assign issue or PR to author
+        uses: actions/github-script@v9
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const item = context.payload.pull_request ?? context.payload.issue
+            const author = item.user.login
+            const itemNumber = item.number
+
+            try {
+              await github.rest.issues.checkUserCanBeAssigned({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                assignee: author,
+              })
+
+              await github.rest.issues.addAssignees({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: itemNumber,
+                assignees: [author],
+              })
+            } catch (error) {
+              core.warning(`Failed to add assignee: ${error.message}`)
+            }

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -18,7 +18,10 @@ on:
     types:
       - opened
       - reopened
-      - edited
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number }}
+  cancel-in-progress: true
 
 jobs:
   labeler:

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -1,0 +1,37 @@
+name: Issue and Pull Request Labeler
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+on:
+  pull_request:
+    branches:
+      - '**'
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+  issues:
+    types:
+      - opened
+      - reopened
+      - edited
+
+jobs:
+  labeler:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - uses: srvaroa/labeler@v1.13.0
+        with:
+          config_path: .github/labeler.yml
+          fail_on_error: true
+          use_local_config: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## 📌 Summary

- close #650 

> Issue, PR 작성시 Label, Assignee 등록을 자동화했습니다.
> codeowners 문법을 수정해서 리뷰어 자동으로 달리도록 수정했습니다. 


## 📄 Tasks

### 도입 배경
38기에서 자동화 스터디를 하면서 여러가지 자동화를 알게 되었는데 실제 사용해보니 편하더라구요! 곧 Phase-C가 시작하면 각자 작업양이 늘어날테니 이런 부분에서라도 신경쓸 걸 줄여보고자 가져오게 되었습니다. 

### 작업 내용
- [x] 이슈 및 PR 작성자 자동 어사이니 설정
- [x] 이슈 및 PR 라벨 자동 지정 설정
- [x] 프로젝트에서 사용하는 기존 라벨과 labeler 규칙 연결
- [x] 작성자별 라벨 자동 지정
- [x] CODEOWNERS 전체 경로 패턴 수정
- [x] YAML 문법 및 자동화 설정 검증

#### 1. Assignee 동작 조건
- 이슈 또는 PR을 작성한 사용자를 해당 이슈/PR의 어사이니로 자동 지정합니다.

| 대상 | 실행 시점 |
| --- | --- |
| PR | 생성, 재오픈, Draft에서 Ready for review로 전환 |
| Issue | 생성, 재오픈 |

#### 2. Label 동작 조건 
- PR은 제목 또는 브랜치명을 기준으로 라벨을 지정하며, Issue는 제목을 기준으로 라벨을 지정합니다.
- 추가로 chore는 setting에 포함되므로 PR 제목이 `[chore] 자동화 설정` 또는 `chore: 자동화 설정`이거나 브랜치명이 `chore/...`이면 기존 `⚙️ Setting` 라벨이 지정됩니다.

| 대상 | 실행 시점 |
| --- | --- |
| PR | 생성, 재오픈, 커밋 추가, Ready for review 전환 |
| Issue | 생성, 재오픈, 제목 수정 |



## 🔍 To Reviewer
- codeowners와 자동화는 이 PR이 머지된 후에 확실하게 확인할 수 있습니다. (이 PR에서는 동작 확인)


## 📸 Screenshot

- UI 변경사항 없음.
