### PR TITLE
[feat] OutputLink 컴포넌트 구현

### DIFF
--- a/src/pages/home/components/priceComparison/linkOutput/OutputLink.css.ts
+++ b/src/pages/home/components/priceComparison/linkOutput/OutputLink.css.ts
@@ -1,0 +1,148 @@
+import { style } from '@vanilla-extract/css';
+
+import { colorVars } from '@styles/tokens/color.css';
+import { fontVars } from '@styles/tokens/font.css';
+import { unitVars } from '@styles/tokens/unit.css';
+
+export const container = style({
+  boxSizing: 'border-box',
+  display: 'flex',
+  flexDirection: 'column',
+  justifyContent: 'center',
+  border: `1px solid ${colorVars.color.border.secondary}`,
+  borderRadius: unitVars.unit.radius['600'],
+  backgroundColor: colorVars.color.bg.primary,
+  width: '33.6rem',
+  overflow: 'hidden',
+});
+
+export const contentButton = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: unitVars.unit.gapPadding['300'],
+  border: 0,
+  backgroundColor: 'transparent',
+  padding: `${unitVars.unit.gapPadding['400']}`,
+  textAlign: 'left',
+});
+
+export const titleRow = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: unitVars.unit.gapPadding['100'],
+  width: '100%',
+});
+
+export const title = style({
+  ...fontVars.font.title_sb_16,
+  margin: 0,
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+  color: colorVars.color.text.primary,
+});
+
+export const productCard = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: unitVars.unit.gapPadding['200'],
+  width: '100%',
+});
+
+export const imgSection = style({
+  boxSizing: 'border-box',
+  position: 'relative',
+  flexShrink: 0,
+  border: `1px solid ${colorVars.color.border.tertiary}`,
+  borderRadius: unitVars.unit.radius['300'],
+  background: 'transparent',
+  width: '8rem',
+  height: '8rem',
+  overflow: 'hidden',
+});
+
+export const cardImage = style({
+  display: 'block',
+  objectFit: 'cover',
+  objectPosition: 'center',
+  width: '100%',
+  height: '100%',
+});
+
+export const infoSection = style({
+  display: 'flex',
+  flex: 1,
+  flexDirection: 'column',
+  gap: unitVars.unit.gapPadding['100'],
+  padding: `${unitVars.unit.gapPadding['000']} ${unitVars.unit.gapPadding['100']}`,
+  minWidth: 0,
+});
+
+export const brandText = style({
+  ...fontVars.font.caption_r_12,
+  width: '100%',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  lineHeight: '1.1rem',
+  whiteSpace: 'nowrap',
+  color: colorVars.color.text.tertiary,
+});
+
+export const productText = style({
+  ...fontVars.font.body_r_14,
+  width: '100%',
+  height: '2rem',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+  color: colorVars.color.text.primary,
+});
+
+export const priceRow = style({
+  ...fontVars.font.title_sb_16,
+  display: 'flex',
+  alignItems: 'center',
+  gap: unitVars.unit.gapPadding['050'],
+  width: '100%',
+  maxWidth: '18rem',
+  overflow: 'hidden',
+});
+
+export const discountRateText = style({
+  flexShrink: 0,
+  whiteSpace: 'nowrap',
+  color: colorVars.color.text.brand,
+});
+
+export const discountPriceText = style({
+  minWidth: 0,
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+  color: colorVars.color.text.primary,
+});
+
+export const searchButton = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  border: 0,
+  borderTop: `1px solid ${colorVars.color.border.secondary}`,
+  backgroundColor: colorVars.color.fill.whitish,
+  padding: unitVars.unit.gapPadding['400'],
+  width: '100%',
+});
+
+export const searchButtonContent = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: unitVars.unit.gapPadding['100'],
+});
+
+export const searchButtonText = style({
+  ...fontVars.font.body_r_14,
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+  color: colorVars.color.text.secondary,
+});

--- a/src/pages/home/components/priceComparison/linkOutput/OutputLink.css.ts
+++ b/src/pages/home/components/priceComparison/linkOutput/OutputLink.css.ts
@@ -20,10 +20,15 @@ export const contentButton = style({
   display: 'flex',
   flexDirection: 'column',
   gap: unitVars.unit.gapPadding['300'],
-  border: 0,
-  backgroundColor: 'transparent',
   padding: `${unitVars.unit.gapPadding['400']}`,
   textAlign: 'left',
+  selectors: {
+    '&:focus-visible': {
+      outline: `2px solid ${colorVars.color.text.brand}`,
+      outlineOffset: '-2px',
+      borderRadius: unitVars.unit.radius['300'],
+    },
+  },
 });
 
 export const titleRow = style({
@@ -126,11 +131,16 @@ export const searchButton = style({
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
-  border: 0,
   borderTop: `1px solid ${colorVars.color.border.secondary}`,
   backgroundColor: colorVars.color.fill.whitish,
   padding: unitVars.unit.gapPadding['400'],
   width: '100%',
+  selectors: {
+    '&:focus-visible': {
+      outline: `2px solid ${colorVars.color.text.brand}`,
+      outlineOffset: '-2px',
+    },
+  },
 });
 
 export const searchButtonContent = style({

--- a/src/pages/home/components/priceComparison/linkOutput/OutputLink.tsx
+++ b/src/pages/home/components/priceComparison/linkOutput/OutputLink.tsx
@@ -1,0 +1,91 @@
+import type { PriceInfo, ProductInfo } from '@shared/types/productCard';
+
+import emptyImage from '@assets/images/ImgEmpty.png';
+
+import Icon from '@components/icon/Icon';
+import OptimizedImage from '@components/image/OptimizedImage';
+
+import { getPriceTexts } from '@utils/productCardUtils';
+
+import * as styles from './OutputLink.css';
+
+interface OutputLinkProps {
+  product: ProductInfo;
+  price?: PriceInfo;
+  onProductClick?: () => void;
+  onSearchNewLink?: () => void;
+}
+
+const OutputLink = ({
+  product,
+  price,
+  onProductClick,
+  onSearchNewLink,
+}: OutputLinkProps) => {
+  const { discountPriceText, discountRateText } = getPriceTexts(
+    price?.original,
+    price?.discount,
+    price?.discountRate
+  );
+
+  return (
+    <section className={styles.container} aria-label="검색한 상품">
+      <button
+        type="button"
+        className={styles.contentButton}
+        onClick={onProductClick}
+      >
+        <div className={styles.titleRow}>
+          <Icon name="Link" size="24" decorative />
+          <h2 className={styles.title}>검색한 상품</h2>
+        </div>
+
+        <div className={styles.productCard}>
+          <section className={styles.imgSection}>
+            <OptimizedImage
+              src={product.imageUrl || emptyImage}
+              fallbackSrc={emptyImage}
+              placeholder="skeleton"
+              className={styles.cardImage}
+              alt="카드 이미지"
+            />
+          </section>
+
+          <section className={styles.infoSection}>
+            {product.brand ? (
+              <p className={styles.brandText}>{product.brand}</p>
+            ) : null}
+            <p className={styles.productText}>{product.title}</p>
+            {(discountPriceText || discountRateText) && (
+              <div className={styles.priceRow}>
+                {discountRateText ? (
+                  <span className={styles.discountRateText}>
+                    {discountRateText}
+                  </span>
+                ) : null}
+                {discountPriceText ? (
+                  <span className={styles.discountPriceText}>
+                    {discountPriceText}
+                  </span>
+                ) : null}
+              </div>
+            )}
+          </section>
+        </div>
+      </button>
+
+      <button
+        type="button"
+        className={styles.searchButton}
+        onClick={onSearchNewLink}
+      >
+        <span className={styles.searchButtonContent}>
+          <Icon name="Search" size="16" decorative />
+          <span className={styles.searchButtonText}>새로운 링크 검색하기</span>
+        </span>
+      </button>
+    </section>
+  );
+};
+
+export default OutputLink;

--- a/src/pages/home/components/priceComparison/linkOutput/OutputLink.tsx
+++ b/src/pages/home/components/priceComparison/linkOutput/OutputLink.tsx
@@ -22,11 +22,9 @@ const OutputLink = ({
   onProductClick,
   onSearchNewLink,
 }: OutputLinkProps) => {
-  const { discountPriceText, discountRateText } = getPriceTexts(
-    price?.original,
-    price?.discount,
-    price?.discountRate
-  );
+  const { originalPriceText, discountPriceText, discountRateText } =
+    getPriceTexts(price?.original, price?.discount, price?.discountRate);
+  const priceText = discountPriceText ?? originalPriceText;
 
   return (
     <section className={styles.container} aria-label="검색한 상품">
@@ -35,43 +33,41 @@ const OutputLink = ({
         className={styles.contentButton}
         onClick={onProductClick}
       >
-        <div className={styles.titleRow}>
+        <span className={styles.titleRow}>
           <Icon name="Link" size="24" decorative />
-          <h2 className={styles.title}>검색한 상품</h2>
-        </div>
+          <span className={styles.title}>검색한 상품</span>
+        </span>
 
-        <div className={styles.productCard}>
-          <section className={styles.imgSection}>
+        <span className={styles.productCard}>
+          <span className={styles.imgSection}>
             <OptimizedImage
               src={product.imageUrl || emptyImage}
               fallbackSrc={emptyImage}
               placeholder="skeleton"
               className={styles.cardImage}
-              alt="카드 이미지"
+              alt=""
             />
-          </section>
+          </span>
 
-          <section className={styles.infoSection}>
+          <span className={styles.infoSection}>
             {product.brand ? (
-              <p className={styles.brandText}>{product.brand}</p>
+              <span className={styles.brandText}>{product.brand}</span>
             ) : null}
-            <p className={styles.productText}>{product.title}</p>
-            {(discountPriceText || discountRateText) && (
-              <div className={styles.priceRow}>
+            <span className={styles.productText}>{product.title}</span>
+            {(priceText || discountRateText) && (
+              <span className={styles.priceRow}>
                 {discountRateText ? (
                   <span className={styles.discountRateText}>
                     {discountRateText}
                   </span>
                 ) : null}
-                {discountPriceText ? (
-                  <span className={styles.discountPriceText}>
-                    {discountPriceText}
-                  </span>
+                {priceText ? (
+                  <span className={styles.discountPriceText}>{priceText}</span>
                 ) : null}
-              </div>
+              </span>
             )}
-          </section>
-        </div>
+          </span>
+        </span>
       </button>
 
       <button

--- a/src/shared/components/productCard/ProductCard.tsx
+++ b/src/shared/components/productCard/ProductCard.tsx
@@ -37,6 +37,7 @@ interface ProductCardProps {
   disabled?: boolean;
   onCardClick?: (area?: CardClickArea) => void;
   enableWholeCardLink?: boolean;
+  benefitAmount?: number;
   shoppingAction?: {
     label?: string;
     onClick: () => void;
@@ -55,6 +56,7 @@ const ProductCard = ({
   disabled = false,
   onCardClick,
   enableWholeCardLink = false,
+  benefitAmount,
   shoppingAction,
   onShoppingViewDetailClick,
 }: ProductCardProps) => {
@@ -70,21 +72,11 @@ const ProductCard = ({
   const { visibleColors, extraColorCount } = getColorChips(product.colorHexes);
   const { originalPriceText, discountPriceText, discountRateText } =
     getPriceTexts(price?.original, price?.discount, price?.discountRate);
-  const originalPrice = price?.original;
-  const discountPrice = price?.discount;
-  const priceDiff =
-    typeof originalPrice === 'number' &&
-    Number.isFinite(originalPrice) &&
-    originalPrice >= 0 &&
-    typeof discountPrice === 'number' &&
-    Number.isFinite(discountPrice) &&
-    discountPrice >= 0
-      ? originalPrice - discountPrice
-      : null;
-  const benefitAmount =
-    priceDiff !== null && priceDiff > 0 && Number.isFinite(priceDiff)
-      ? priceDiff
-      : null;
+  const shouldShowBenefitBadge =
+    isDefault &&
+    typeof benefitAmount === 'number' &&
+    Number.isFinite(benefitAmount) &&
+    benefitAmount > 0;
 
   const handleCardNavigate = () =>
     openProductLink(linkHref, undefined, LOGIN_ENTRY_ROUTE.PRODUCT_CARD_SITE);
@@ -239,9 +231,7 @@ const ProductCard = ({
             </div>
           )}
 
-          {isDefault && benefitAmount !== null && (
-            <BenefitBadge amount={benefitAmount} />
-          )}
+          {shouldShowBenefitBadge && <BenefitBadge amount={benefitAmount} />}
         </div>
 
         {/* 저장(하트) 정보 */}


### PR DESCRIPTION
## 📌 Summary

- close #660

1. `OutputLink` 컴포넌트 추가
2. ProductCard의 BenefitBadge 노출 조건 수정
3. BenefitBadge 계산 책임을 ProductCard 내부에서 제거

## 📄 Tasks

### 1. `OutputLink` 컴포넌트
- `OutputLink` 컴포넌트 구현
  - 가격 비교 페이지에서만 사용하는 컴포넌트임으로 고려해 다음 위치에 구현`src/pages/home/components/priceComparison/linkOutput`
  - 상단 영역 클릭: `onProductClick`
  - 하단 CTA 클릭: `onSearchNewLink`

- `OutputLink` 내부 상품 카드 구현
  - 기존 `ListProductCard`와 유사하지만 요구사항이 달라 사용하지 않고 `OutputLink` 파일 내에 직접 구현
    - 컬러칩 대신 브랜드명 표시
    - 우측 하단 링크/찜 아이콘 미노출
    - 가격 폰트 크기 및 레이아웃 상이

- 브랜드명 line-height 보정
  - Figma에서 브랜드명 텍스트 프레임 높이가 실제 토큰 line-height보다 작게 잡혀 있기 때문에 `brandText`에 `line-height: 1.1rem` 적용

**OutputLink 사용 예시**

```tsx
<OutputLink
  product={{
    title: '상품명은 최대 한 줄까지',
    brand: '브랜드명',
    imageUrl: productImageUrl,
  }}
  price={{
    original: 100000,
    discount: 79000,
    discountRate: 21,
  }}
  onProductClick={handleProductClick}
  onSearchNewLink={handleSearchNewLink}
/>
```

### 2. ProductCard의 BenefitBadge 노출 조건

- ProductCard BenefitBadge 노출 조건 수정
  - [이전 PR(#661)](https://github.com/TEAM-HOUME/HOUME-CLIENT/pull/661)에서 구현한 ProductCard의 BenefitBadge 노출 조건 확인 결과, BenefitBadge는 모든 ProductCard에 항상 노출되는 요소가 아님
  - 특정 화면(상품비교)에서만 필요한 값이므로 `benefitAmount` optional prop으로 변경

- BenefitBadge 계산 로직 제거
  - BenefitBadge는 사용자가 입력한 원본 상품 URL의 스크래핑 가격과 비교 대상 상품 가격의 차이를 나타냄 → 즉, 할인율/할인가와 BenefitBadge는 무관하기 때문에 관련 계산 로직 제거
  - 자세한 계산 로직은 API 연동 시 상품비교 페이지에서 처리 예정
  - 관련 상세 맥락은 디스코드 스레드 참고 부탁드립니다.

**BenefitBadge가 있는 ProductCard 사용 예시**

```tsx
<ProductCard
  product={product}
  price={price}
  save={save}
  benefitAmount={197370}
/>
```

## 🔍 To Reviewer
- `BenefitBadge` 노출 조건 관련해 기/디에 문의한 내용은 디코 스레드 참고부탁드립니다!



## 📸 Screenshot
<img width="349" height="211" alt="image" src="https://github.com/user-attachments/assets/0ce8fcda-0be9-4d79-baab-21c67da3ace4" />

