### PR TITLE
[chore] push 전 CI 검사 및 빌드 결과 코멘트 방식 변경

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -90,12 +90,34 @@ jobs:
           script: |
             const prNumber = context.payload.pull_request.number;
             const message = `${{ steps.status.outputs.message }}`;
-            await github.rest.issues.createComment({
+            const marker = '<!-- build-status-comment -->';
+            const body = `${marker}\n### 빌드 결과\n${message}`;
+            const comments = await github.paginate(github.rest.issues.listComments, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: prNumber,
-              body: `### 빌드 결과\n${message}`
             });
+            const buildComment = comments.reverse().find(
+              (comment) =>
+                comment.user?.type === 'Bot' &&
+                (comment.body?.includes(marker) || comment.body?.startsWith('### 빌드 결과'))
+            );
+
+            if (buildComment) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: buildComment.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body,
+              });
+            }
 
       - name: Fail job if build failed
         if: steps.build.outcome == 'failure'

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,8 @@
+echo "🐕 Husky pre-push CI 검사 실행"
+
+pnpm lint:ci
+pnpm format:check
+pnpm knip:ci
+pnpm build
+
+echo "🎉 CI 검사 완료!"

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -3,6 +3,5 @@ echo "🐕 Husky pre-push CI 검사 실행"
 pnpm lint:ci
 pnpm format:check
 pnpm knip:ci
-pnpm build
 
 echo "🎉 CI 검사 완료!"


### PR DESCRIPTION
## 📌 Summary

- close #672

1. 5차 리팩터링에서 CI 검사가 강화되었고, 3가지를 통과해야 한다고 했습니다. 따라서 PR 푸시 전에 로컬에서 CI 전체 검사를 수행하도록 했습니다. 
2. 빌드 결과가 푸시마다 새 댓글로 쌓이지 않도록 개선했습니다.

## 📄 Tasks

- Husky `pre-push` 훅에서 `lint:ci`, `format:check`, `knip:ci`를 순차 실행하도록 추가
- PR 빌드 결과 댓글에서 기존 댓글이 있으면 `updateComment`로 갱신

## 🔍 To Reviewer

- 커밋 전에는 기존 `lint-staged`로 staged 파일만 검사하고, 푸시 전에는 CI와 동일한 전체 검사를 수행합니다.
- 빌드 결과 댓글 조회 시 최신 봇 댓글을 선택하며, 처음 실행할 때만 댓글을 생성합니다.
- 로컬 검증: `pnpm lint:ci`, `pnpm format:check`, `pnpm knip:ci` 통과

## 📸 Screenshot

- UI 변경사항 없음