### PR TITLE
[style] 비교 결과 스켈레톤 인터랙션 및 드롭다운 동작 수정

### DIFF
--- a/src/pages/home/components/compare/dropdown/SortDropdown.css.ts
+++ b/src/pages/home/components/compare/dropdown/SortDropdown.css.ts
@@ -16,6 +16,15 @@ export const pressable = style({
   ...pressInteraction(0.97, '&:not(:disabled):active'),
 });
 
+export const backdrop = style({
+  position: 'fixed',
+  zIndex: zIndex.backdrop,
+  inset: 0,
+  border: 0,
+  background: 'transparent',
+  padding: 0,
+});
+
 export const menu = style({
   boxSizing: 'border-box',
   position: 'absolute',

--- a/src/pages/home/components/compare/dropdown/SortDropdown.tsx
+++ b/src/pages/home/components/compare/dropdown/SortDropdown.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useId, useRef, useState } from 'react';
+import { useEffect, useId, useState } from 'react';
 
 import TextButton from '@components/btnText/TextButton';
 
@@ -21,36 +21,25 @@ const CompareSortDropdown = ({
   onChange,
 }: CompareSortDropdownProps) => {
   const [isOpen, setIsOpen] = useState(false);
-  const dropdownRef = useRef<HTMLDivElement>(null);
   const menuId = useId();
   const isDisabled = disabled || !onChange;
 
   useEffect(() => {
     if (!isOpen) return;
 
-    const closeOnOutsidePointerDown = (event: PointerEvent) => {
-      if (
-        event.target instanceof Node &&
-        !dropdownRef.current?.contains(event.target)
-      ) {
-        setIsOpen(false);
-      }
-    };
     const closeOnEscape = (event: KeyboardEvent) => {
       if (event.key === 'Escape') setIsOpen(false);
     };
 
-    document.addEventListener('pointerdown', closeOnOutsidePointerDown);
     document.addEventListener('keydown', closeOnEscape);
 
     return () => {
-      document.removeEventListener('pointerdown', closeOnOutsidePointerDown);
       document.removeEventListener('keydown', closeOnEscape);
     };
   }, [isOpen]);
 
   return (
-    <div ref={dropdownRef} className={styles.container}>
+    <div className={styles.container}>
       <TextButton
         className={styles.pressable}
         color="secondary"
@@ -66,34 +55,43 @@ const CompareSortDropdown = ({
       </TextButton>
 
       {isOpen ? (
-        <div
-          id={menuId}
-          className={styles.menu}
-          role="menu"
-          aria-label="상품 정렬"
-        >
-          {COMPARE_SORT_OPTIONS.map((option) => {
-            const isSelected = value === option;
+        <>
+          <button
+            type="button"
+            className={styles.backdrop}
+            aria-label="정렬 메뉴 닫기"
+            tabIndex={-1}
+            onClick={() => setIsOpen(false)}
+          />
+          <div
+            id={menuId}
+            className={styles.menu}
+            role="menu"
+            aria-label="상품 정렬"
+          >
+            {COMPARE_SORT_OPTIONS.map((option) => {
+              const isSelected = value === option;
 
-            return (
-              <div className={styles.item} key={option}>
-                <TextButton
-                  className={styles.pressable}
-                  color={isSelected ? 'primary' : 'secondary'}
-                  size="s"
-                  role="menuitemradio"
-                  aria-checked={isSelected}
-                  onClick={() => {
-                    onChange?.(option);
-                    setIsOpen(false);
-                  }}
-                >
-                  {option}
-                </TextButton>
-              </div>
-            );
-          })}
-        </div>
+              return (
+                <div className={styles.item} key={option}>
+                  <TextButton
+                    className={styles.pressable}
+                    color={isSelected ? 'primary' : 'secondary'}
+                    size="s"
+                    role="menuitemradio"
+                    aria-checked={isSelected}
+                    onClick={() => {
+                      onChange?.(option);
+                      setIsOpen(false);
+                    }}
+                  >
+                    {option}
+                  </TextButton>
+                </div>
+              );
+            })}
+          </div>
+        </>
       ) : null}
     </div>
   );

--- a/src/pages/home/components/compare/result/CompareResultSkeleton.css.ts
+++ b/src/pages/home/components/compare/result/CompareResultSkeleton.css.ts
@@ -4,6 +4,7 @@ import { colorVars } from '@styles/tokens/color.css';
 import { fontVars } from '@styles/tokens/font.css';
 import {
   interactionDurationValues,
+  interactionEasingValues,
   interactionVars,
 } from '@styles/tokens/interaction/tokens.css';
 import { unitVars } from '@styles/tokens/unit.css';
@@ -23,7 +24,7 @@ const opacityFadeBackInEndMs =
 const scaleAnimation = keyframes({
   '0%': {
     transform: 'scale(0.9)',
-    animationTimingFunction: interactionVars.interaction.easing['bezier.back'],
+    animationTimingFunction: interactionEasingValues['bezier.back'],
   },
   [toKeyframePercent(interactionDurationValues.slow)]: {
     transform: 'scale(1)',
@@ -37,18 +38,18 @@ const scaleAnimation = keyframes({
 const opacityAnimation = keyframes({
   '0%': {
     opacity: 0,
-    animationTimingFunction: interactionVars.interaction.easing['bezier.inout'],
+    animationTimingFunction: interactionEasingValues['bezier.inout'],
   },
   [toKeyframePercent(opacityFadeInEndMs)]: {
     opacity: 1,
   },
   [toKeyframePercent(opacityHoldEndMs)]: {
     opacity: 1,
-    animationTimingFunction: interactionVars.interaction.easing['bezier.inout'],
+    animationTimingFunction: interactionEasingValues['bezier.inout'],
   },
   [toKeyframePercent(opacityFadeOutEndMs)]: {
     opacity: 0,
-    animationTimingFunction: interactionVars.interaction.easing['bezier.inout'],
+    animationTimingFunction: interactionEasingValues['bezier.inout'],
   },
   [toKeyframePercent(opacityFadeBackInEndMs)]: {
     opacity: 1,

--- a/src/pages/home/components/compare/result/CompareResultSkeleton.css.ts
+++ b/src/pages/home/components/compare/result/CompareResultSkeleton.css.ts
@@ -23,7 +23,7 @@ const opacityFadeBackInEndMs =
 const scaleAnimation = keyframes({
   '0%': {
     transform: 'scale(0.9)',
-    animationTimingFunction: interactionVars.interaction.easing['bezier.inout'],
+    animationTimingFunction: interactionVars.interaction.easing['bezier.back'],
   },
   [toKeyframePercent(interactionDurationValues.slowest)]: {
     transform: 'scale(1)',

--- a/src/pages/home/components/compare/result/CompareResultSkeleton.css.ts
+++ b/src/pages/home/components/compare/result/CompareResultSkeleton.css.ts
@@ -25,7 +25,7 @@ const scaleAnimation = keyframes({
     transform: 'scale(0.9)',
     animationTimingFunction: interactionVars.interaction.easing['bezier.back'],
   },
-  [toKeyframePercent(interactionDurationValues.slowest)]: {
+  [toKeyframePercent(interactionDurationValues.slow)]: {
     transform: 'scale(1)',
   },
   '100%': {

--- a/src/shared/styles/tokens/interaction/tokens.css.ts
+++ b/src/shared/styles/tokens/interaction/tokens.css.ts
@@ -21,6 +21,13 @@ export const interactionDurationValues = {
   slowest: 1200,
 } as const;
 
+/** @keyframes 등 CSS 변수 참조를 사용할 수 없는 곳을 위한 easing 원본값 */
+export const interactionEasingValues = {
+  'bezier.out': 'cubic-bezier(0, 0.56, 0.33, 1)',
+  'bezier.inout': 'cubic-bezier(0.59, 0.14, 0.38, 1)',
+  'bezier.back': 'cubic-bezier(0.25, 1.45, 0.65, 1.03)',
+} as const;
+
 export const interactionVars = createGlobalTheme(':root', {
   interaction: {
     duration: {
@@ -32,11 +39,7 @@ export const interactionVars = createGlobalTheme(':root', {
       slower: `${interactionDurationValues.slower}ms`,
       slowest: `${interactionDurationValues.slowest}ms`,
     },
-    easing: {
-      'bezier.out': 'cubic-bezier(0, 0.56, 0.33, 1)',
-      'bezier.inout': 'cubic-bezier(0.59, 0.14, 0.38, 1)',
-      'bezier.back': 'cubic-bezier(0.25, 1.45, 0.65, 1.03)',
-    },
+    easing: interactionEasingValues,
     trigger: {
       tap: 'tap',
       whilePressing: 'whilePressing',


### PR DESCRIPTION
## 📌 Summary

- close #676
> 비교 결과 스켈레톤 인터랙션과 드롭다운 바깥 영역 클릭 동작을 수정했습니다.

## 📄 Tasks

- 결과 스켈레톤 인터랙션 수정
  - keyframes 내부에서 CSS 변수 형태의 easing 토큰을 참조해 구간별 easing이 의도대로 적용되지 않는 문제를 수정했습니다.
  - keyframes에서 사용할 easing 원본값을 별도로 제공하도록 easing 인터랙션 토큰을 수정했습니다.
  - 디자인파트와 상의한 결과 scale의 애니메이션 중 `bezier.out → bezier.back`,`slowest → slow(duration)`로 수정했습니다. 

- 드롭다운 바깥 영역 클릭 동작 수정
  - 드롭다운이 닫히는 클릭과 카드 외부 링크 이동이 동시에 실행되는 문제를 수정했습니다.
  - 드롭다운이 열렸을 때 투명한 backdrop이 첫 클릭을 받아 드롭다운만 닫도록 변경했습니다.
   → 드롭다운이 완전히 닫힌 이후부터 카드 클릭과 외부 링크 이동이 동작합니다.

## 🔍 To Reviewer

- 기존 `interactionVars`의 API와 값은 유지되어 다른 컴포넌트의 인터랙션에는 영향을 주지 않습니다.

## 📸 Screenshot


https://github.com/user-attachments/assets/c6216cf1-d5dc-4b09-bc99-adc96a5374ac

https://github.com/user-attachments/assets/a518edfe-8dff-45b9-bbcd-ee9b0598c590


